### PR TITLE
feat: restructure startup message for v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # changelog
 
+## v0.23.1 (2026-02-26)
+
+### changes
+
+- restructure startup message: one field per line, always show all status fields
+  - list project names instead of count
+  - always show mode, topics, triggers, resume lines, voice, and files status
+  - add voice and files enabled/disabled status
+- update PyPI description and keywords to reflect current feature set
+
 ## v0.23.0 (2026-02-26)
 
 ### changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.23.0"
-keywords = ["telegram", "claude-code", "codex", "opencode", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
-description = "Telegram bridge for Claude Code, Codex, and other agent CLIs. Fork of takopi with interactive permission control."
+version = "0.23.1"
+keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
+description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, and Pi to Telegram with interactive permissions, voice notes, and live progress."
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/tests/test_telegram_backend.py
+++ b/tests/test_telegram_backend.py
@@ -52,7 +52,7 @@ def test_build_startup_message_includes_missing_engines(tmp_path: Path) -> None:
 
     assert "untether" in message and "is ready" in message
     assert "engines: `codex (not installed: pi)`" in message
-    assert "projects: `0`" in message
+    assert "projects: `none`" in message
 
 
 def test_build_startup_message_surfaces_unavailable_engine_reasons(
@@ -140,7 +140,7 @@ def test_startup_message_uses_dog_emoji(tmp_path: Path) -> None:
 
 
 def test_startup_message_minimal_when_healthy(tmp_path: Path) -> None:
-    """When everything is healthy, only show primary info and working dir."""
+    """When everything is healthy, show all status fields."""
     runtime = _build_healthy_runtime()
     message = telegram_backend._build_startup_message(
         runtime,
@@ -150,11 +150,15 @@ def test_startup_message_minimal_when_healthy(tmp_path: Path) -> None:
         show_resume_line=True,
         topics=TelegramTopicsSettings(),
     )
-    assert "mode:" not in message
-    assert "topics:" not in message
-    assert "triggers:" not in message
-    assert "engines:" not in message
-    assert "resume lines:" not in message
+    assert "default: `claude`" in message
+    assert "engines: `claude`" in message
+    assert "projects: `none`" in message
+    assert "mode: `stateless`" in message
+    assert "topics: `disabled`" in message
+    assert "triggers: `disabled`" in message
+    assert "resume lines: `shown`" in message
+    assert "voice: `disabled`" in message
+    assert "files: `disabled`" in message
     assert "working in:" in message
 
 
@@ -169,6 +173,23 @@ def test_startup_message_shows_mode_chat(tmp_path: Path) -> None:
         topics=TelegramTopicsSettings(),
     )
     assert "mode: `chat`" in message
+
+
+def test_startup_message_voice_and_files_enabled(tmp_path: Path) -> None:
+    runtime = _build_healthy_runtime()
+    message = telegram_backend._build_startup_message(
+        runtime,
+        startup_pwd=str(tmp_path),
+        chat_id=123,
+        session_mode="stateless",
+        show_resume_line=False,
+        topics=TelegramTopicsSettings(),
+        voice_transcription=True,
+        files_enabled=True,
+    )
+    assert "voice: `enabled`" in message
+    assert "files: `enabled`" in message
+    assert "resume lines: `hidden`" in message
 
 
 def test_startup_message_project_count(tmp_path: Path) -> None:
@@ -206,7 +227,7 @@ def test_startup_message_project_count(tmp_path: Path) -> None:
         show_resume_line=True,
         topics=TelegramTopicsSettings(),
     )
-    assert "projects: `2`" in message
+    assert "projects: `proj-a, proj-b`" in message
 
 
 def test_telegram_backend_build_and_run_wires_config(

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Restructure startup message: one field per line, always show all status fields
- List project names instead of just a count
- Add voice and files enabled/disabled status
- Always show mode, topics, triggers, and resume lines (even when disabled)
- Update PyPI description and keywords to reflect current feature set

## Test plan

- [x] All 862 tests pass locally
- [x] Ruff lint and format clean
- [ ] CI passes (format, ruff, ty, pytest on 3.12/3.13/3.14, build, lockfile, pip-audit, bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)