### PR TITLE
feat: agent preamble, post-outline approval, URL updates

### DIFF
--- a/.claude/rules/control-channel.md
+++ b/.claude/rules/control-channel.md
@@ -1,0 +1,97 @@
+---
+applies_to: "src/untether/runners/claude.py,src/untether/telegram/commands/claude_control.py"
+---
+
+# Control Channel Rules
+
+## PTY lifecycle
+
+ClaudeRunner uses `pty.openpty()` for stdin (not `subprocess.PIPE`):
+1. `master_fd, slave_fd = pty.openpty()`
+2. `tty.setraw(master_fd)` for raw byte passthrough
+3. Slave FD passed to subprocess as stdin
+4. Master FD wrapped in `anyio.AsyncFile` for async writes
+5. **Always close master FD in `finally`** — FD leaks break subsequent runs
+
+## Session registries
+
+```python
+_SESSION_STDIN: dict[str, anyio.abc.ByteSendStream]   # session_id -> stdin
+_REQUEST_TO_SESSION: dict[str, str]                    # request_id -> session_id
+_DISCUSS_COOLDOWN: dict[str, tuple[float, int]]        # session_id -> (timestamp, deny_count)
+_DISCUSS_APPROVED: set[str]                            # sessions with post-outline approval
+_PENDING_ASK_REQUESTS: dict[str, str]                  # request_id -> question text
+```
+
+- Register on first `system.init` event (when session_id is known)
+- Clean up all registries in the `finally` block of `run_impl` (including cooldown and approval state)
+- All control responses go through `write_control_response(session_id, request_id, approved, deny_message)`
+
+## Auto-approve
+
+Non-interactive tools are auto-approved without showing buttons:
+- List maintained in `_AUTO_APPROVE_TOOLS` set
+- `ControlInitializeRequest`: always auto-approved immediately
+- Tool requests: check `tool_name in _AUTO_APPROVE_TOOLS`
+- `ExitPlanMode`: NEVER auto-approved — always show Telegram buttons
+- `AskUserQuestion`: NEVER auto-approved — shown in Telegram for user to reply with text
+
+## AskUserQuestion flow
+
+When Claude calls `AskUserQuestion`:
+1. Control request intercepted → registered in `_PENDING_ASK_REQUESTS[request_id]`
+2. Question extracted from `input.question` or `input.questions[0].question`
+3. Progress message shows `❓ <question text>` with Approve/Deny buttons
+4. User replies with text → `telegram/loop.py` intercepts via `get_pending_ask_request()`
+5. `answer_ask_question()` sends deny response with user's text as `denial_message`
+6. Claude reads the denial message as the answer and continues
+
+## Diff preview
+
+`_format_diff_preview(tool_name, tool_input)` generates compact diffs for approval messages:
+- Only for tools going through `ControlRequest` (not auto-approved)
+- Edit: `- old` / `+ new` lines (max 4 each, 60 char truncation)
+- Write: `+ content` (max 8 lines)
+- Bash: `$ command` (max 200 chars)
+
+## Progressive cooldown
+
+After "Pause & Outline Plan" click:
+- Base cooldown: 30 seconds
+- Escalation: `min(30 * deny_count, 120)` seconds
+- Auto-deny rapid `ExitPlanMode` retries within cooldown window
+- Deny count preserved across expiry (keeps escalating)
+- Resets to 0 on explicit Approve or Deny
+- Cooldown and approval state cleaned up on session end
+
+## Post-outline approval
+
+After cooldown auto-deny, synthetic Approve/Deny buttons appear in Telegram:
+- User clicks "Approve Plan" → session added to `_DISCUSS_APPROVED`, cooldown cleared
+- User clicks "Deny" → cooldown cleared, no auto-approve flag set
+- Next `ExitPlanMode` checks `_DISCUSS_APPROVED` → auto-approves if present
+- Synthetic callback_data prefix: `da:` (fits 64-byte Telegram limit)
+- Handled in `claude_control.py` before the normal approve/deny flow
+
+## Control request/response format
+
+Request (from Claude on stdout):
+```json
+{"type":"control_request","request_id":"req_1","tool_name":"Bash","tool_input":{...}}
+```
+
+Response (to Claude on stdin):
+```json
+{"type":"control_response","request_id":"req_1","approved":true}
+```
+
+Denial with message:
+```json
+{"type":"control_response","request_id":"req_1","approved":false,"denial_message":"..."}
+```
+
+## After changes
+
+```bash
+uv run pytest tests/test_claude_control.py tests/test_ask_user_question.py tests/test_diff_preview.py -x
+```

--- a/.claude/rules/runner-development.md
+++ b/.claude/rules/runner-development.md
@@ -1,0 +1,50 @@
+---
+applies_to: "src/untether/runners/**,src/untether/runner.py"
+---
+
+# Runner Development Rules
+
+## 3-event contract
+
+Every run MUST emit exactly this sequence:
+1. `StartedEvent` — once, when session ID is known
+2. `ActionEvent(s)` — zero or more, phase: started/updated/completed
+3. `CompletedEvent` — exactly once, always the final event
+
+After emitting `CompletedEvent`, drop all subsequent JSONL lines.
+
+## Event creation
+
+Use `EventFactory` (from `src/untether/events.py`) for all event construction:
+```python
+factory = EventFactory(engine=self.engine)
+factory.started(token, title="myengine")
+factory.action_started(action_id=..., kind=..., title=...)
+factory.action_completed(action_id=..., kind=..., title=..., ok=True)
+factory.completed_ok(answer=..., resume=token, usage=...)
+```
+
+Do NOT construct `StartedEvent`, `ActionEvent`, `CompletedEvent` dataclasses directly.
+
+## Session locking
+
+- `SessionLockMixin` provides `lock_for(token) -> anyio.Semaphore`
+- Keys: `"engine:session_id"` in a `WeakValueDictionary` (auto-cleanup)
+- Resume runs: acquire lock before spawning subprocess
+- New runs: acquire lock when session ID first appears, before yielding `StartedEvent`
+
+## Adding a new engine
+
+1. Create `src/untether/runners/myengine.py` extending `JsonlSubprocessRunner`
+2. Create `src/untether/schemas/myengine.py` with msgspec structs
+3. Override: `command()`, `build_args()`, `translate()`, `new_state()`
+4. Export `BACKEND = EngineBackend(id="myengine", build_runner=..., cli_cmd="myengine")`
+5. Register in `pyproject.toml` entry points: `myengine = "untether.runners.myengine:BACKEND"`
+6. Add reference docs in `docs/reference/runners/myengine/`
+7. Add tests mirroring `tests/test_codex_runner.py` patterns
+
+## After changes
+
+```bash
+uv run pytest tests/test_*_runner.py tests/test_claude_control.py -x
+```

--- a/.claude/rules/telegram-transport.md
+++ b/.claude/rules/telegram-transport.md
@@ -1,0 +1,52 @@
+---
+applies_to: "src/untether/telegram/**"
+---
+
+# Telegram Transport Rules
+
+## Outbox model
+
+ALL Telegram writes (send, edit, delete) MUST go through `TelegramOutbox`. Never call Bot API methods directly from command handlers or bridge code.
+
+- Sends: `transport.send(channel_id, message, options)`
+- Edits: `transport.edit(ref, message)`
+- Deletes: `transport.delete(ref)`
+
+The outbox handles coalescing, priority scheduling, and rate limiting automatically.
+
+## Callback data
+
+- Max 64 bytes (Telegram enforced)
+- Format: `prefix:action:id` (e.g. `ctrl:approve:req_123`)
+- Must call `answerCallbackQuery` promptly to clear the button spinner
+
+## Early callback answering
+
+For time-sensitive callbacks (approval buttons), use early answering:
+- Set `answer_early = True` on the callback backend
+- Provide `early_answer_toast()` returning the toast text ("Approved", "Denied", etc.)
+- Dispatch calls `answerCallbackQuery` before processing the action
+
+## Ephemeral messages
+
+Messages that should auto-delete when a run finishes:
+- Register via `register_ephemeral_message(channel_id, anchor_msg_id, ref)` in `runner_bridge.py`
+- `ProgressEdits.delete_ephemeral()` cleans them up on run completion
+
+## Rate limiting
+
+- Per-chat pacing: private 1.0 msg/s, groups 20/60 msg/s
+- On 429: `RetryAfter` raised, op requeued unless superseded
+- Non-429 errors: logged and dropped
+
+## Message limits
+
+- Telegram message limit: 4096 chars after entity parsing
+- Untether trims to ~3500 chars by default
+- Split mode (`message_overflow = "split"`) sends multiple messages
+
+## Inline keyboards
+
+- `RenderedMessage.extra["reply_markup"]["inline_keyboard"]` for buttons
+- Approval buttons: detect transitions via keyboard length changes
+- Push notification: sent separately (`notify=True`) when approval buttons appear

--- a/.claude/rules/testing-conventions.md
+++ b/.claude/rules/testing-conventions.md
@@ -1,0 +1,68 @@
+---
+applies_to: "tests/**"
+---
+
+# Testing Conventions
+
+## Framework
+
+- pytest + anyio for async tests
+- structlog for log capture in tests
+- msgspec for JSONL fixture generation
+
+## Patterns
+
+### Stub subprocess runners
+
+Use fake CLI scripts that emit known JSONL to test event translation:
+```python
+# Create a temporary script that outputs known events
+fake_cli = tmp_path / "fake_claude"
+fake_cli.write_text('#!/bin/bash\necho \'{"type":"system","subtype":"init",...}\'')
+fake_cli.chmod(0o755)
+```
+
+### Mock transport
+
+Use the `Transport` protocol for test doubles — don't instantiate `TelegramClient`:
+```python
+@dataclass
+class FakeTransport:
+    sent: list = field(default_factory=list)
+    async def send(self, channel_id, message, options=None): ...
+    async def edit(self, ref, message, wait=True): ...
+    async def delete(self, ref): ...
+```
+
+### Event ordering assertions
+
+Always verify the 3-event contract:
+```python
+events = [evt async for evt in runner.run(prompt, resume)]
+assert isinstance(events[0], StartedEvent)
+assert isinstance(events[-1], CompletedEvent)
+assert all(isinstance(e, ActionEvent) for e in events[1:-1])
+```
+
+## Coverage
+
+- Threshold: 80% (enforced by pytest config in `pyproject.toml`)
+- Run all: `uv run pytest`
+- Run specific: `uv run pytest tests/test_claude_control.py -x`
+
+## Key test files
+
+| File | Covers |
+|------|--------|
+| `test_claude_control.py` | Control channel, session registries, auto-approve, cooldown |
+| `test_callback_dispatch.py` | Callback parsing, dispatch, early answering |
+| `test_exec_bridge.py` | Ephemeral cleanup, approval notifications |
+| `test_ask_user_question.py` | AskUserQuestion handling, question extraction, answer routing |
+| `test_diff_preview.py` | Edit/Write/Bash diff preview formatting and truncation |
+| `test_cost_tracker.py` | Per-run/daily cost tracking, budget alerts, daily reset |
+| `test_export_command.py` | Session export (markdown/JSON), event recording, trimming |
+| `test_browse_command.py` | File browser, path registry, inline keyboards, project root |
+| `test_codex_runner.py` | Codex event translation, session locking |
+| `test_opencode_runner.py` | OpenCode event translation |
+| `test_pi_runner.py` | Pi event translation, session ID promotion |
+| `test_settings.py` | Config validation, engine config parsing |

--- a/.claude/skills/claude-stream-json/SKILL.md
+++ b/.claude/skills/claude-stream-json/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: claude-stream-json
+description: >
+  Claude Code CLI stream-json protocol as consumed by Untether.
+  Covers JSONL event types, content blocks, control channel protocol,
+  permission modes, auto-approve, progressive cooldown, and ExitPlanMode handling.
+  This is the CONSUMER side — Untether spawns Claude Code as a subprocess.
+triggers:
+  - working on Claude runner code
+  - modifying control channel handling
+  - changing permission request logic
+  - working on auto-approve or cooldown
+  - debugging Claude Code event streams
+  - modifying ExitPlanMode or plan mode handling
+---
+
+# Claude Code stream-json Protocol (Consumer)
+
+Untether spawns Claude Code CLI as a subprocess and consumes its JSONL output. This skill covers the protocol from Untether's perspective.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `src/untether/runners/claude.py` | `ClaudeRunner` — subprocess management, PTY, control channel, event translation |
+| `src/untether/schemas/claude.py` | msgspec structs for Claude JSONL events |
+| `src/untether/runners/tool_actions.py` | `tool_kind_and_title()` — tool name to ActionKind mapping |
+| `docs/reference/runners/claude/runner.md` | Full runner specification |
+| `docs/reference/runners/claude/stream-json-cheatsheet.md` | JSONL event shapes with examples |
+| `docs/reference/runners/claude/untether-events.md` | Claude JSONL to Untether event mapping |
+
+## CLI invocation
+
+### Non-interactive mode (`-p`)
+
+```bash
+claude -p --output-format stream-json --input-format stream-json --verbose -- <prompt>
+```
+
+- `-p` / `--print`: non-interactive, prompt as positional arg after `--`
+- `--verbose`: required for full stream-json output
+- `--input-format stream-json`: enables JSON input on stdin
+- Prompt passed after `--` to protect prompts starting with `-`
+
+### Interactive permission mode
+
+```bash
+claude --output-format stream-json --input-format stream-json --verbose \
+  --permission-mode plan --permission-prompt-tool stdio
+```
+
+- **No `-p` flag** — prompt sent via stdin as JSON user message
+- `--permission-prompt-tool stdio`: enables bidirectional control channel
+- `--permission-mode plan|tool`: determines what needs approval
+
+### Common flags
+
+- `--resume <session_id>`: resume a previous session
+- `--model <name>`: model override (sonnet, opus, haiku)
+- `--allowedTools "<rules>"`: auto-approve specific tools
+
+## JSONL event types
+
+One JSON object per line on stdout. Required field: `type`.
+
+### `system` (init)
+
+```json
+{"type":"system","subtype":"init","session_id":"...","cwd":"/repo","model":"sonnet",
+ "permissionMode":"auto","tools":["Bash","Read","Write"],"mcp_servers":[...]}
+```
+
+- Emitted once at stream start
+- `session_id`: opaque string (do NOT assume UUID format)
+- Untether emits `StartedEvent` here
+
+### `assistant` / `user` messages
+
+```json
+{"type":"assistant","session_id":"...","message":{"id":"msg_1","role":"assistant",
+ "content":[...],"usage":{...}}}
+```
+
+Content blocks in `message.content[]`:
+
+| Block type | Fields | Untether mapping |
+|-----------|--------|-----------------|
+| `text` | `text` | Stored as fallback answer; no action emitted |
+| `tool_use` | `id`, `name`, `input` | `ActionEvent(phase="started")` |
+| `tool_result` | `tool_use_id`, `content`, `is_error` | `ActionEvent(phase="completed")` |
+| `thinking` | `thinking` | Optional note action or ignored |
+
+### `result`
+
+```json
+{"type":"result","subtype":"success","session_id":"...","is_error":false,
+ "result":"Done.","total_cost_usd":0.01,"usage":{...},
+ "duration_ms":12345,"duration_api_ms":12000,"num_turns":2}
+```
+
+- `is_error`: authoritative error indicator
+- `result`: final answer string
+- Untether emits exactly one `CompletedEvent` here
+- Lines after `result` are dropped
+
+Fields NOT in Untether's `StreamResultMessage` schema (silently ignored by msgspec):
+- `error`, `permission_denials`, `modelUsage`
+
+## Tool name to ActionKind mapping
+
+| Tool name | ActionKind | Title source |
+|-----------|-----------|-------------|
+| `Bash` | `command` | `input.command` |
+| `Edit`, `Write`, `MultiEdit`, `NotebookEdit` | `file_change` | `input.file_path` or `input.path` |
+| `Read` | `tool` | `Read <path>` |
+| `Glob`, `Grep` | `tool` | pattern from input |
+| `WebSearch` | `web_search` | `input.query` |
+| `WebFetch` | `web_search` | URL from input |
+| `TodoWrite`, `TodoRead` | `note` | "update todos" |
+| `AskUserQuestion` | `note` | "ask user" |
+| `Task`, `Agent` | `tool` | tool name |
+| `KillShell` | `command` | tool name |
+| (other) | `tool` | tool name |
+
+Mapping implemented in `src/untether/runners/tool_actions.py`.
+
+## Control channel protocol
+
+When using `--permission-prompt-tool stdio`, Claude Code sends control requests as JSONL on stdout and expects responses on stdin.
+
+### Control request (stdout)
+
+```json
+{"type":"assistant","session_id":"...","message":{"content":[
+  {"type":"tool_use","id":"toolu_ctrl_1","name":"PermissionPromptTool",
+   "input":{"type":"control_request","request_id":"req_1",
+            "tool_name":"Bash","tool_input":{"command":"rm -rf /"}}}
+]}}
+```
+
+### Control response (stdin)
+
+```json
+{"type":"control_response","request_id":"req_1","approved":true}
+```
+
+Or with denial:
+```json
+{"type":"control_response","request_id":"req_1","approved":false,
+ "denial_message":"Not allowed — explain your plan first."}
+```
+
+### ControlInitializeRequest
+
+Sent at session start; auto-approved immediately (no user prompt):
+```json
+{"type":"control_response","request_id":"req_init","approved":true}
+```
+
+## PTY for stdin
+
+ClaudeRunner uses `pty.openpty()` instead of `subprocess.PIPE` for stdin:
+- Prevents deadlock when keeping stdin open for control responses
+- Master FD held by the runner; slave FD passed to subprocess
+- `tty.setraw(master_fd)` for raw byte passthrough
+- Stdin refs captured locally at spawn time (not on `self`)
+
+## Session registries (concurrent sessions)
+
+```python
+_SESSION_STDIN: dict[str, anyio.abc.ByteSendStream]   # session_id -> stdin pipe
+_REQUEST_TO_SESSION: dict[str, str]                    # request_id -> session_id
+```
+
+- Registered in `_iter_jsonl_events` when session_id is first seen
+- Control responses routed via `_REQUEST_TO_SESSION` lookup
+- Cleaned up when run completes
+
+## Auto-approve logic
+
+Non-interactive tools are auto-approved without user prompt:
+
+```python
+AUTO_APPROVE_TOOLS = {"Grep", "Glob", "Read", "LS", "Bash", "BashOutput",
+                      "TodoWrite", "TodoRead", "WebSearch", "WebFetch", ...}
+```
+
+- `ControlInitializeRequest`: always auto-approved
+- Tool requests where `tool_name in AUTO_APPROVE_TOOLS`: auto-approved silently
+- `ExitPlanMode`: always shown to user as inline buttons
+
+## ExitPlanMode handling
+
+When Claude requests `ExitPlanMode`:
+1. Inline keyboard shown: **Approve** / **Deny** / **Pause & Outline Plan**
+2. "Pause & Outline Plan" sends a deny with a detailed message asking Claude to write a step-by-step plan
+3. Progressive cooldown on rapid retries: 30s, 60s, 90s, 120s (capped)
+
+### Progressive cooldown
+
+```python
+# In ClaudeRunner
+_discuss_deny_count: int = 0          # escalates per click
+_discuss_last_at: float = 0.0         # timestamp of last discuss/auto-deny
+_DISCUSS_BASE_COOLDOWN_S = 30         # base cooldown
+_DISCUSS_MAX_COOLDOWN_S = 120         # cap
+```
+
+- After "Pause & Outline Plan", auto-deny rapid ExitPlanMode retries within cooldown window
+- Cooldown: `min(base * count, max)` seconds
+- Deny count preserved across expiry (keeps escalating)
+- Resets on explicit Approve or Deny
+
+## Early callback answering
+
+Telegram buttons show a spinner until `answerCallbackQuery`. The Claude control callback handler sets `answer_early = True` to clear the spinner immediately with a toast ("Approved", "Denied", "Outlining plan...").
+
+## `write_control_response` helper
+
+```python
+async def write_control_response(
+    session_id: str,
+    request_id: str,
+    approved: bool,
+    deny_message: str | None = None,
+) -> None:
+```
+
+Looks up stdin in `_SESSION_STDIN[session_id]`, writes JSON response, handles cleanup.
+
+## Config keys (`[claude]` section in untether.toml)
+
+```toml
+[claude]
+model = "sonnet"
+allowed_tools = ["Bash", "Read", "Edit", "Write"]
+dangerously_skip_permissions = false
+use_api_billing = false
+permission_mode = "plan"  # set via /planmode command or ChatPrefsStore
+```
+
+- `use_api_billing = false` (default): strips `ANTHROPIC_API_KEY` from subprocess env
+- `permission_mode`: overridable per-chat via `/planmode` command

--- a/.claude/skills/codex-opencode-pi/SKILL.md
+++ b/.claude/skills/codex-opencode-pi/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: codex-opencode-pi
+description: >
+  Codex CLI, OpenCode CLI, and Pi CLI runner protocols for Untether.
+  Covers JSONL event types, event translation, resume mechanisms,
+  and key differences between engines. All three are non-interactive
+  (no control channel).
+triggers:
+  - working on Codex runner code
+  - working on OpenCode runner code
+  - working on Pi runner code
+  - adding support for a new engine
+  - comparing engine event models
+  - debugging non-Claude runner streams
+---
+
+# Codex, OpenCode, and Pi Runner Protocols
+
+These three engines are **non-interactive only** — no control channel, no permission prompts. They extend `JsonlSubprocessRunner` directly (unlike ClaudeRunner which overrides `run_impl`).
+
+## Quick comparison
+
+| Aspect | Codex | OpenCode | Pi |
+|--------|-------|----------|-----|
+| **CLI** | `codex exec --json` | `opencode run --format json` | `pi --print --mode json` |
+| **Event model** | Turn-based (items in turns) | Step-based (tools in steps) | Agent-based (messages + tools) |
+| **Resume line** | `` `codex resume <thread_id>` `` | `` `opencode --session ses_XXX` `` | `` `pi --session <token>` `` |
+| **Resume token** | thread_id (UUID) | ses_XXXX (26+ chars) | UUID short (8 chars) or path |
+| **Final answer** | `agent_message` item | Accumulated `text` events | `message_end` assistant content |
+| **Error signal** | `turn.failed` | `error` event / missing `step_finish` | `stopReason` in `message_end` |
+
+---
+
+## Codex
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `src/untether/runners/codex.py` | `CodexRunner` implementation |
+| `src/untether/schemas/codex.py` | msgspec structs for Codex events |
+| `docs/reference/runners/codex/exec-json-cheatsheet.md` | JSONL event shapes |
+| `docs/reference/runners/codex/untether-events.md` | Event mapping spec |
+
+### CLI invocation
+
+```bash
+codex exec --json --skip-git-repo-check --color=never \
+  [--model MODEL] [--session THREAD_ID -] [-]
+```
+
+- Prompt on stdin (trailing `-` means read stdin)
+- Resume: `--session <thread_id> -`
+- `--skip-git-repo-check --color=never` for clean output
+
+### JSONL events
+
+| Event | Untether mapping |
+|-------|-----------------|
+| `thread.started` | `StartedEvent(resume=thread_id)` |
+| `item.started` | `ActionEvent(phase="started")` |
+| `item.updated` | `ActionEvent(phase="updated")` |
+| `item.completed` | `ActionEvent(phase="completed")` |
+| `turn.completed` | `CompletedEvent(ok=True, answer=final_answer)` |
+| `turn.failed` | `CompletedEvent(ok=False, error=message)` |
+| `error` (transient) | Progress note (reconnect handling) |
+
+### Item types
+
+| Item type | ActionKind | Notes |
+|-----------|-----------|-------|
+| `command_execution` | `command` | ok = (status=="completed" && exit_code==0) |
+| `mcp_tool_call` | `tool` | Title: `server.tool` |
+| `file_change` | `file_change` | `detail.changes = [{path, kind}]` |
+| `web_search` | `web_search` | Title: query |
+| `todo_list` | `note` | `detail.done`, `detail.total` |
+| `reasoning` | `note` | Reasoning text |
+| `agent_message` | (not emitted) | Stored as final answer candidate |
+| `error` (item) | `warning` | Non-fatal error |
+
+### Final answer selection
+
+Multiple `agent_message` items may appear. Selection:
+1. Prefer item with `phase == "final_answer"`
+2. Fall back to last unnamed `agent_message`
+3. Used in `CompletedEvent.answer`
+
+### Config keys
+
+```toml
+[codex]
+profile = "Codex"        # Codex profile name
+extra_args = []           # additional CLI flags
+```
+
+---
+
+## OpenCode
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `src/untether/runners/opencode.py` | `OpenCodeRunner` implementation |
+| `src/untether/schemas/opencode.py` | msgspec structs for OpenCode events |
+| `docs/reference/runners/opencode/runner.md` | Runner spec |
+| `docs/reference/runners/opencode/stream-json-cheatsheet.md` | JSONL event shapes |
+| `docs/reference/runners/opencode/untether-events.md` | Event mapping spec |
+
+### CLI invocation
+
+```bash
+opencode run --format json [--session SESSION_ID] [--model MODEL] -- <prompt>
+```
+
+- Prompt as positional arg after `--`
+- Resume: `--session ses_XXX`
+- Session IDs: `ses_` prefix + 20+ chars
+
+### JSONL events
+
+| Event | Untether mapping |
+|-------|-----------------|
+| `step_start` (first, with `sessionID`) | `StartedEvent(resume=sessionID)` |
+| `tool_use` (status="completed") | `ActionEvent(phase="completed", ok=exit==0)` |
+| `tool_use` (status="error") | `ActionEvent(phase="completed", ok=False)` |
+| `text` | Accumulated as final answer (no action) |
+| `step_finish` (reason="stop") | `CompletedEvent(ok=True, answer=text)` |
+| `error` | `CompletedEvent(ok=False, error=message)` |
+
+### Tool mapping
+
+| Tool | ActionKind |
+|------|-----------|
+| `bash`, `shell` | `command` |
+| `edit`, `write`, `multiedit` | `file_change` |
+| `read`, `glob`, `grep` | `tool` |
+| `websearch`, `web_search`, `webfetch`, `web_fetch` | `web_search` |
+| `todowrite`, `todoread` | `note` |
+| `task` | `tool` |
+| (other) | `tool` |
+
+### Not yet implemented
+
+Usage accumulation: OpenCode's `step_finish` may include token/cost data but the runner does not currently extract it. `CompletedEvent.usage` is not populated.
+
+### Config keys
+
+```toml
+[opencode]
+model = "claude-sonnet-4-5-20250929"
+```
+
+---
+
+## Pi
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `src/untether/runners/pi.py` | `PiRunner` implementation |
+| `src/untether/schemas/pi.py` | msgspec structs for Pi events |
+| `docs/reference/runners/pi/runner.md` | Runner spec |
+| `docs/reference/runners/pi/stream-json-cheatsheet.md` | JSONL event shapes |
+| `docs/reference/runners/pi/untether-events.md` | Event mapping spec |
+
+### CLI invocation
+
+```bash
+pi --print --mode json [--session SESSION_PATH] \
+  [--provider PROVIDER] [--model MODEL] <prompt>
+```
+
+- Prompt as positional arg (prefixed with space if starts with `-`)
+- Resume: `--session <token>` (short ID or full path)
+- Minimum version: 0.45.1
+- Environment: `NO_COLOR=1`, `CI=1` (set by runner)
+
+### JSONL events
+
+| Event | Untether mapping |
+|-------|-----------------|
+| `session` | Session ID extraction, possible ID promotion |
+| `agent_start` | `StartedEvent(resume=session_token)` |
+| `tool_execution_start` | `ActionEvent(phase="started")` |
+| `tool_execution_end` | `ActionEvent(phase="completed", ok=!isError)` |
+| `message_end` (assistant) | Final answer + usage stored |
+| `agent_end` | `CompletedEvent(ok=..., answer=last_text)` |
+
+### Session ID promotion
+
+Pi has a unique resume mechanism:
+1. For new runs, Untether generates a session `.jsonl` file path
+2. If a `session` header arrives with a UUID, the resume token is promoted to the 8-char short ID
+3. `allow_id_promotion` flag ensures this only happens once
+4. This gives a user-friendly resume token instead of a long path
+
+Session path format: `~/.pi/agent/sessions/--<sanitized-cwd>--/<date>-<uuid>.jsonl`
+
+### Tool mapping
+
+| Tool | ActionKind | Title source |
+|------|-----------|-------------|
+| `bash` | `command` | `args.command` |
+| `edit`, `write` | `file_change` | `args.path` |
+| `read`, `grep`, `find`, `ls` | `tool` | `tool: <path>` or `tool: <pattern>` |
+| (other) | `tool` | tool name |
+
+### Error detection
+
+- `stopReason` in `message_end`: `"error"` or `"aborted"` -> `ok=False`
+- No `agent_end` received -> `CompletedEvent(ok=False, error="stream ended...")`
+
+### Config keys
+
+```toml
+[pi]
+provider = "anthropic"   # or "openai", "google", etc.
+model = "claude-sonnet-4-5-20250929"
+extra_args = []
+```
+
+---
+
+## Adding a new engine
+
+To add a new engine runner:
+
+1. Create `src/untether/runners/myengine.py`
+2. Define schemas in `src/untether/schemas/myengine.py`
+3. Implement `MyEngineRunner(JsonlSubprocessRunner)` with required template methods
+4. Export `BACKEND = EngineBackend(id="myengine", build_runner=..., cli_cmd="myengine")`
+5. Register in `pyproject.toml` entry points:
+   ```toml
+   myengine = "untether.runners.myengine:BACKEND"
+   ```
+6. Add reference docs in `docs/reference/runners/myengine/`
+7. Add tests mirroring existing `tests/test_*_runner.py` patterns

--- a/.claude/skills/jsonl-subprocess-runner/SKILL.md
+++ b/.claude/skills/jsonl-subprocess-runner/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: jsonl-subprocess-runner
+description: >
+  JSONL subprocess management patterns for Untether engine runners.
+  Covers JsonlSubprocessRunner base class, template methods, event translation,
+  session locking, resume tokens, process lifecycle, PTY usage, and concurrent
+  session registries.
+triggers:
+  - working on runner code
+  - adding a new engine backend
+  - modifying event translation logic
+  - changing subprocess management
+  - working on session locking or resume tokens
+  - debugging runner event streams
+---
+
+# JSONL Subprocess Runner Framework
+
+All Untether engine runners (Claude, Codex, OpenCode, Pi) extend `JsonlSubprocessRunner`, which manages subprocess lifecycle, JSONL parsing, session locking, and error handling.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `src/untether/runner.py` | `JsonlSubprocessRunner` base class, `Runner` protocol, `SessionLockMixin`, `ResumeTokenMixin` |
+| `src/untether/model.py` | `StartedEvent`, `ActionEvent`, `CompletedEvent`, `ResumeToken`, `Action`, `ActionKind` |
+| `src/untether/events.py` | `EventFactory` — consistent event creation per engine |
+| `src/untether/backends.py` | `EngineBackend` dataclass, `EngineConfig` |
+| `src/untether/progress.py` | `ProgressTracker` — aggregates actions for UI rendering |
+| `src/untether/runner_bridge.py` | `ProgressEdits`, `handle_message` — connects runners to transport |
+| `src/untether/runners/` | Engine-specific runner implementations |
+
+## Class hierarchy
+
+```
+Runner (Protocol)
+  BaseRunner (SessionLockMixin)
+    JsonlSubprocessRunner
+      CodexRunner
+      OpenCodeRunner
+      PiRunner
+      ClaudeRunner (overrides run_impl for PTY support)
+```
+
+## Template methods to override
+
+When creating a new runner, override these methods on `JsonlSubprocessRunner`:
+
+```python
+class MyRunner(JsonlSubprocessRunner):
+    engine: EngineId = "myengine"
+
+    def command(self) -> str:
+        """CLI binary name (e.g. 'codex', 'opencode', 'pi')."""
+
+    def build_args(self, prompt, resume, *, state) -> list[str]:
+        """Build CLI arguments. Called once per run."""
+
+    def translate(self, data, *, state, resume, found_session) -> list[UntetherEvent]:
+        """Translate a decoded JSON dict to Untether events. Core logic."""
+
+    def new_state(self, prompt, resume) -> Any:
+        """Create per-run state (e.g. EventFactory, accumulators)."""
+
+    # Optional overrides:
+    def stdin_payload(self, prompt, resume, *, state) -> bytes | None:
+        """Data to send on stdin. Default: prompt.encode()."""
+
+    def env(self, *, state) -> dict[str, str] | None:
+        """Extra environment variables for the subprocess."""
+
+    def decode_jsonl(self, *, line: bytes) -> Any | None:
+        """Custom JSON decoder. Default: json.loads."""
+```
+
+## Event model (3 events)
+
+Every run emits exactly this sequence:
+
+```
+StartedEvent       — emitted once when session ID is known
+ActionEvent(s)     — zero or more, with phase: started → completed
+CompletedEvent     — emitted exactly once, always last
+```
+
+### StartedEvent
+```python
+StartedEvent(engine="codex", resume=ResumeToken(engine="codex", value="thread_123"))
+```
+
+### ActionEvent
+```python
+ActionEvent(
+    engine="codex",
+    action=Action(id="item_5", kind="command", title="ls -la", detail={...}),
+    phase="started",  # or "completed"
+    ok=True,          # only on completed phase
+)
+```
+
+### CompletedEvent
+```python
+CompletedEvent(engine="codex", ok=True, answer="Done.", resume=token, usage={...})
+```
+
+## ActionKind values
+
+| Kind | When |
+|------|------|
+| `command` | Shell execution (Bash, shell) |
+| `tool` | Generic tool call (Read, Grep, Glob, MCP tools) |
+| `file_change` | File edits (Edit, Write, MultiEdit, NotebookEdit) |
+| `web_search` | Web search/fetch (WebSearch, WebFetch) |
+| `note` | Commentary, reasoning, todos (TodoWrite, AskUserQuestion) |
+| `warning` | Non-fatal errors, permission denials |
+| `turn` | Turn markers (metadata-only, ignored by ProgressTracker) |
+| `telemetry` | Usage/cost data (metadata-only) |
+| `subagent` | Subagent/Task invocations |
+
+## Session locking
+
+```python
+class SessionLockMixin:
+    session_locks: WeakValueDictionary[str, anyio.Semaphore]
+
+    def lock_for(self, token: ResumeToken) -> anyio.Semaphore:
+        # Key: "engine:session_id"
+        # WeakValueDictionary auto-cleans when semaphore has no references
+```
+
+Locking rules:
+- **Resume runs**: acquire lock immediately before spawning subprocess
+- **New runs**: don't know session_id until `StartedEvent`; acquire lock when first `system.init` / `thread.started` / `step_start` arrives, before yielding the event
+- Lock held until run completes (released in `finally`)
+- Serialises concurrent runs on the same session
+
+## Process lifecycle (`run_impl`)
+
+```
+1. new_state(prompt, resume)           → create per-run state
+2. build_args(prompt, resume, state)   → construct CLI command
+3. stdin_payload(prompt, resume, state) → optional stdin data
+4. manage_subprocess(cmd, ...)         → spawn with PIPE for stdin/stdout/stderr
+5. _send_payload(proc, payload)        → send stdin, close stdin
+6. drain_stderr(proc.stderr)           → log stderr concurrently (task group)
+7. _iter_jsonl_events(proc.stdout)     → parse JSONL, call translate()
+8. proc.wait()                         → wait for exit code
+9. stream_end_events() or              → emit CompletedEvent if not already emitted
+   process_error_events()
+```
+
+## JSONL stream state
+
+```python
+@dataclass
+class JsonlStreamState:
+    expected_session: ResumeToken | None    # from resume arg
+    found_session: ResumeToken | None       # from stream
+    did_emit_completed: bool                # guard: exactly one CompletedEvent
+    ignored_after_completed: bool           # drop lines after CompletedEvent
+    jsonl_seq: int                          # line counter for logging
+```
+
+Key invariants:
+- **Exactly one CompletedEvent per run** — after emitting, all subsequent lines are dropped
+- **Session verification** — if expected_session is set and stream yields a different session_id, raise RuntimeError
+- **Duplicate StartedEvent suppression** — only the first StartedEvent is yielded
+
+## Error handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Invalid JSON line | `invalid_json_events()` → warning ActionEvent, continue |
+| Decode error (msgspec) | `decode_error_events()` → warning ActionEvent, continue |
+| Translation error | `translate_error_events()` → warning ActionEvent, continue |
+| Non-zero exit code | `process_error_events()` → CompletedEvent(ok=False) |
+| Stream ends without result | `stream_end_events()` → CompletedEvent(ok=False) |
+
+## Resume token mixin
+
+```python
+class ResumeTokenMixin:
+    engine: EngineId
+    resume_re: re.Pattern[str]  # engine-specific regex
+
+    def extract_resume(text) -> ResumeToken | None  # parse last match
+    def format_resume(token) -> str                  # canonical resume line
+    def is_resume_line(line) -> bool                 # for stripping from prompts
+```
+
+Resume line formats per engine:
+- Claude: `` `claude --resume <session_id>` ``
+- Codex: `` `codex resume <thread_id>` ``
+- OpenCode: `` `opencode --session <ses_XXX>` ``
+- Pi: `` `pi --session <token>` ``
+
+## Engine backend registration
+
+Each runner module exports a `BACKEND`:
+
+```python
+# src/untether/runners/myengine.py
+BACKEND = EngineBackend(
+    id="myengine",
+    build_runner=_build_runner,
+    cli_cmd="myengine",
+    install_cmd="pip install myengine",
+)
+```
+
+Registered in `pyproject.toml`:
+```toml
+[project.entry-points."untether.engine_backends"]
+codex = "untether.runners.codex:BACKEND"
+claude = "untether.runners.claude:BACKEND"
+opencode = "untether.runners.opencode:BACKEND"
+pi = "untether.runners.pi:BACKEND"
+```
+
+Discovery: `importlib.metadata.entry_points(group="untether.engine_backends")`
+
+## EventFactory
+
+Helper for consistent event creation:
+
+```python
+factory = EventFactory(engine="codex")
+factory.started(token, title="Codex")
+factory.action_started(action_id="item_1", kind="command", title="ls")
+factory.action_completed(action_id="item_1", kind="command", title="ls", ok=True)
+factory.completed_ok(answer="Done.", resume=token, usage={...})
+factory.completed_error(error="timeout", resume=token)
+```
+
+## ClaudeRunner PTY exception
+
+`ClaudeRunner` overrides `run_impl` entirely because it uses a PTY for the bidirectional control channel instead of standard PIPE stdin. It manages:
+- `pty.openpty()` for stdin (prevents deadlock with persistent stdin)
+- Session registries (`_SESSION_STDIN`, `_REQUEST_TO_SESSION`) for concurrent sessions
+- Control request/response draining after every JSONL line
+
+See `.claude/skills/claude-stream-json/SKILL.md` for Claude-specific details.

--- a/.claude/skills/telegram-bot-api/SKILL.md
+++ b/.claude/skills/telegram-bot-api/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: telegram-bot-api
+description: >
+  Raw Telegram Bot API patterns used by Untether. Covers httpx async HTTP client,
+  inline keyboards, callback queries, long polling, rate limiting, outbox model,
+  forum topics, voice transcription, and media group coalescing.
+  NOT aiogram, python-telegram-bot, or grammY — Untether uses raw HTTP.
+triggers:
+  - working on Telegram transport code
+  - modifying inline keyboards or callback queries
+  - changing rate limiting or outbox behaviour
+  - adding new Bot API methods
+  - working on voice transcription
+  - modifying forum topic handling
+  - working on media group coalescing
+---
+
+# Telegram Bot API (Raw HTTP)
+
+Untether uses a **custom Telegram Bot API client** built on `httpx` (async) and `msgspec` (JSON). There is no Telegram SDK dependency.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `src/untether/telegram/client.py` | `TelegramClient` — all Bot API calls |
+| `src/untether/telegram/outbox.py` | `TelegramOutbox` — queued send/edit/delete with rate limiting |
+| `src/untether/telegram/bridge.py` | `TelegramPresenter` — renders progress, inline keyboards, answers |
+| `src/untether/telegram/loop.py` | Long polling loop (`getUpdates`), callback dispatch |
+| `src/untether/telegram/commands/` | Command and callback handlers |
+| `docs/reference/transports/telegram.md` | Full transport reference |
+
+## Bot API call pattern
+
+All calls go through `TelegramClient`, which wraps `httpx.AsyncClient`:
+
+```python
+# Typical Bot API call (inside TelegramClient)
+resp = await self._http.post(
+    f"{self._base_url}/bot{self._token}/{method}",
+    json=params,
+)
+data = msgspec.json.decode(resp.content, type=TelegramResponse)
+```
+
+- Base URL: `https://api.telegram.org`
+- Auth: bot token in the URL path (`/bot<token>/`)
+- All responses decoded with `msgspec.json.decode` into typed structs
+- Error handling: check `ok` field, raise on HTTP or Telegram errors
+
+## Inline keyboards and callback queries
+
+Permission requests and plan mode buttons use Telegram inline keyboards:
+
+```python
+# reply_markup structure in RenderedMessage.extra
+{
+    "reply_markup": {
+        "inline_keyboard": [
+            [{"text": "Approve", "callback_data": "ctrl:approve:<request_id>"}],
+            [{"text": "Deny", "callback_data": "ctrl:deny:<request_id>"}],
+            [{"text": "Pause & Outline Plan", "callback_data": "ctrl:discuss:<request_id>"}],
+        ]
+    }
+}
+```
+
+- Callback data format: `<prefix>:<action>:<id>` (max 64 bytes)
+- Must call `answerCallbackQuery` promptly to clear the spinner
+- Early answering: set `answer_early = True` on the backend to clear the spinner immediately with a toast
+
+## Long polling (`getUpdates`)
+
+```python
+# In telegram/loop.py
+updates = await client.get_updates(offset=last_offset + 1, timeout=30)
+for update in updates:
+    last_offset = update.update_id
+    await handle_update(update)
+```
+
+- Bypasses the outbox (direct API call)
+- Retries on `RetryAfter` by sleeping for the provided delay
+- No webhooks — Untether is designed for single-instance long polling
+
+## Outbox model
+
+All writes (send, edit, delete) go through `TelegramOutbox`:
+
+- **Single worker** processes one op at a time
+- **Keyed deduplication**: one pending op per key; new ops overwrite payload but preserve `queued_at`
+- **Priority scheduling**: `(priority, queued_at)` ordering
+  - send=0 (highest), delete=1, edit=2 (lowest)
+- **Coalescing**: rapid edits to the same message naturally coalesce (only latest payload runs)
+
+Key formats (include `chat_id` to avoid cross-chat collisions):
+- `("edit", chat_id, message_id)` for edits
+- `("delete", chat_id, message_id)` for deletes
+- `("send", chat_id, replace_message_id)` when replacing a progress message
+- Unique key for normal sends
+
+## Rate limiting
+
+- Per-chat pacing: `private_chat_rps` (default 1.0 msg/s), `group_chat_rps` (default 20/60 msg/s)
+- Global `next_at` timestamp — worker waits until `max(next_at, retry_at)`
+- On 429: `RetryAfter` raised using `parameters.retry_after`; op requeued if no newer op superseded it
+- Non-429 errors: logged and dropped (no retry)
+
+## Replace progress messages
+
+`send_message(replace_message_id=...)`:
+1. Drops any pending edit for the progress message
+2. Enqueues the send at highest priority
+3. On success, enqueues a delete for the old progress message
+
+## Voice transcription
+
+```toml
+[transports.telegram]
+voice_transcription = true
+voice_transcription_model = "gpt-4o-mini-transcribe"
+```
+
+1. Download voice payload from Telegram (`getFile` + HTTP fetch)
+2. Transcribe with OpenAI-compatible API (or local Whisper server)
+3. Route transcript through same command/directive pipeline as typed text
+
+## Forum topics
+
+Topics bind Telegram forum threads to a project/branch:
+- Scope modes: `auto`, `main`, `projects`, `all`
+- `/topic <project> @branch` creates and binds a topic
+- Resume tokens persist per topic
+- Bot needs **Manage Topics** permission
+
+## Media group coalescing
+
+Multiple documents sent as an album share a `media_group_id`:
+- `MediaGroupBuffer` collects messages with the same `media_group_id`
+- After `media_group_debounce_s` seconds of quiet, buffer flushes
+- Processed as a single batch via `handle_media_group`
+
+## Forwarded message coalescing
+
+Comment + forwarded messages arrive as separate updates:
+- Wait `forward_coalesce_s` seconds for additional forwards
+- Forwards appended to the prompt; don't start their own runs
+- Forwarded messages alone don't start runs
+
+## Message overflow
+
+- Default: trim to ~3500 chars (Telegram limit is 4096 after entity parsing)
+- Split mode: multiple messages with "continued (N/M)" headers
+- Configure via `message_overflow = "trim" | "split"`
+
+## Approval push notifications
+
+`edit_message_text` doesn't trigger phone push notifications. Untether sends a separate `notify=True` message ("Action required -- approval needed") when approval buttons appear. The `_approval_notified` flag resets when buttons disappear.
+
+## Ephemeral message cleanup
+
+Approval-related messages auto-delete:
+- "Action required" notification — deleted when user clicks a button
+- "Approved/Denied" feedback — deleted when the run finishes
+- Tracked via `_approval_notify_ref` (in `ProgressEdits`) and `_EPHEMERAL_MSGS` (in `runner_bridge.py`)

--- a/.claude/skills/untether-architecture/SKILL.md
+++ b/.claude/skills/untether-architecture/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: untether-architecture
+description: >
+  Untether overall architecture, event model, data flow, config system,
+  engine backend registration, progress tracking, approval notifications,
+  ephemeral cleanup, and key abstractions. Use when working on core
+  infrastructure or understanding how the pieces fit together.
+triggers:
+  - working on core untether infrastructure
+  - understanding the data flow from runner to Telegram
+  - modifying the config system
+  - working on progress tracking or rendering
+  - adding new commands or callbacks
+  - modifying the bridge layer
+  - understanding engine registration
+---
+
+# Untether Architecture
+
+Telegram bridge for agent CLIs (Claude Code, Codex, OpenCode, Pi). Control coding agents from anywhere.
+
+## Data flow
+
+```
+Telegram Bot API
+    |
+    v
+TelegramClient (httpx, long polling)
+    |
+    v
+telegram/loop.py (parse updates, dispatch commands/callbacks)
+    |
+    v
+handle_message() in runner_bridge.py
+    |
+    v
+Runner.run(prompt, resume) -> AsyncIterator[UntetherEvent]
+    |                              |
+    v                              v
+ProgressEdits <-- on_event() -- StartedEvent / ActionEvent / CompletedEvent
+    |
+    v
+TelegramPresenter.render_progress() / render_final()
+    |
+    v
+TelegramOutbox (coalesced edits, rate-limited sends)
+    |
+    v
+Telegram Bot API
+```
+
+## Core abstractions
+
+### Runner (Protocol)
+
+```python
+class Runner(Protocol):
+    engine: str
+    def run(self, prompt: str, resume: ResumeToken | None) -> AsyncIterator[UntetherEvent]
+    def is_resume_line(self, line: str) -> bool
+    def format_resume(self, token: ResumeToken) -> str
+    def extract_resume(self, text: str | None) -> ResumeToken | None
+```
+
+### UntetherEvent (discriminated union)
+
+```python
+type UntetherEvent = StartedEvent | ActionEvent | CompletedEvent
+```
+
+Every run emits: `StartedEvent` (once) -> `ActionEvent`s (zero+) -> `CompletedEvent` (once, always last).
+
+### RunnerBridge (`runner_bridge.py`)
+
+Connects runners to the transport layer:
+
+1. `handle_message()` — entry point for incoming Telegram messages
+2. Creates `ProgressTracker` and `ProgressEdits`
+3. Spawns runner in a task group with cancel support
+4. Manages progress message lifecycle (create -> edit -> replace with final)
+5. Handles errors, cancellation, ephemeral cleanup
+
+### ProgressTracker (`progress.py`)
+
+Aggregates events into renderable state:
+
+```python
+tracker = ProgressTracker(engine="claude")
+tracker.note_event(evt)           # returns True if state changed
+state = tracker.snapshot(
+    resume_formatter=runner.format_resume,
+    context_line="myproject@main",
+)
+```
+
+Snapshot includes: resume line, action list, action count, context line.
+
+### ProgressEdits
+
+Live-updates the Telegram progress message:
+- Signal-based: only renders when new events arrive
+- Detects approval button transitions for push notifications
+- Manages `_approval_notified` flag and `_approval_notify_ref`
+- `delete_ephemeral()` cleans up notification messages on run completion
+
+### TelegramPresenter (`telegram/bridge.py`)
+
+Renders progress and final messages:
+- `render_progress(state, elapsed_s, label)` -> `RenderedMessage`
+- `render_final(state, elapsed_s, status, answer)` -> `RenderedMessage`
+- Inline keyboard buttons in `extra["reply_markup"]`
+
+### RenderedMessage
+
+```python
+@dataclass
+class RenderedMessage:
+    text: str
+    extra: dict[str, Any]  # reply_markup, parse_mode, followups, etc.
+```
+
+## Config system
+
+### untether.toml
+
+```toml
+# ~/.untether/untether.toml
+default_engine = "claude"
+default_project = "untether"
+
+[transports.telegram]
+bot_token = "..."
+chat_id = -1001234567890
+voice_transcription = true
+session_mode = "chat"
+topics.enabled = true
+
+[claude]
+model = "sonnet"
+permission_mode = "plan"
+
+[codex]
+profile = "Codex"
+
+[projects.untether]
+path = "/home/nathan/untether"
+```
+
+### Settings hierarchy
+
+```python
+UntetherSettings (pydantic-settings, TOML source)
+  ├── TransportsSettings
+  │     └── TelegramTransportSettings
+  │           ├── TelegramTopicsSettings
+  │           └── TelegramFilesSettings
+  ├── PluginsSettings
+  ├── ProjectSettings (per project)
+  └── engine_config(engine_id) -> dict  # [claude], [codex], etc.
+```
+
+- Config loaded from `~/.untether/untether.toml`
+- Engine configs in `[engine_id]` sections (flat) or `[engines.engine_id]` (nested)
+- Environment overrides: `UNTETHER__` prefix with `__` nesting
+
+### ChatPrefsStore
+
+Per-chat persistent preferences (engine, model, reasoning, permission_mode):
+
+```python
+class EngineOverrides:
+    engine: str | None
+    model: str | None
+    reasoning: str | None
+    permission_mode: str | None
+```
+
+- Stored in `telegram_chat_prefs_state.json`
+- Set via `/agent`, `/model`, `/reasoning`, `/planmode` commands
+- Applied at run time to override global config
+
+## Engine backend registration
+
+### Entry points (`pyproject.toml`)
+
+```toml
+[project.entry-points."untether.engine_backends"]
+codex = "untether.runners.codex:BACKEND"
+claude = "untether.runners.claude:BACKEND"
+opencode = "untether.runners.opencode:BACKEND"
+pi = "untether.runners.pi:BACKEND"
+```
+
+### EngineBackend
+
+```python
+@dataclass(frozen=True, slots=True)
+class EngineBackend:
+    id: str
+    build_runner: Callable[[EngineConfig, Path], Runner]
+    cli_cmd: str | None = None
+    install_cmd: str | None = None
+```
+
+Discovery: `importlib.metadata.entry_points(group="untether.engine_backends")`
+
+## Command system
+
+### Command handlers (`telegram/commands/`)
+
+| File | Commands |
+|------|----------|
+| `dispatch.py` | Callback dispatch, early answering, ephemeral registration |
+| `claude_control.py` | Approve/Deny/Discuss handlers, cooldown wiring |
+| `planmode.py` | `/planmode` toggle |
+| `usage.py` | `/usage` — Claude Code API usage |
+| `model.py` | `/model` override |
+| `reasoning.py` | `/reasoning` override |
+| `trigger.py` | `/trigger` — mentions-only mode |
+| `agent.py` | `/agent` — engine selection |
+
+### CommandResult
+
+```python
+@dataclass
+class CommandResult:
+    text: str
+    parse_mode: str | None = None  # "HTML" for bold formatting
+```
+
+Commands return `CommandResult`; dispatch sends it as a Telegram message.
+
+### Callback dispatch
+
+Callback data format: `<prefix>:<action>:<id>` (max 64 bytes).
+- `ctrl:approve:<request_id>` — approve control request
+- `ctrl:deny:<request_id>` — deny control request
+- `ctrl:discuss:<request_id>` — pause & outline plan
+
+## Running tasks
+
+```python
+RunningTasks = dict[MessageRef, RunningTask]
+
+@dataclass
+class RunningTask:
+    resume: ResumeToken | None
+    resume_ready: anyio.Event
+    cancel_requested: anyio.Event
+    done: anyio.Event
+    context: RunContext | None
+```
+
+- Keyed by progress message ref
+- `/cancel` sets `cancel_requested` event
+- `done` event signals run completion for cleanup
+
+## Project system
+
+Projects bind a directory + optional branch to a Telegram context:
+
+```toml
+[projects.untether]
+path = "/home/nathan/untether"
+default_engine = "claude"
+chat_id = -1001234567890   # optional per-project chat
+```
+
+- `/topic <project> @branch` creates bound topics
+- `/ctx set <project>` binds a chat context
+- Project alias used as directive prefix: `/untether fix the bug`
+
+## Key conventions
+
+- Python 3.12+, anyio for async, msgspec for JSONL parsing, structlog for logging
+- pydantic + pydantic-settings for config validation
+- Ruff for linting, pytest with coverage for tests
+- Runner backends registered via entry points
+- All Telegram writes go through the outbox
+- Exactly one CompletedEvent per run (enforced by JsonlStreamState)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # changelog
 
+## v0.24.0 (2026-02-27)
+
+### changes
+
+- agent context preamble — configurable `[preamble]` injects Telegram context into every runner prompt, informing agents they're on Telegram and requesting structured end-of-task summaries; engine-agnostic (Claude, Codex, OpenCode, Pi) [#21](https://github.com/littlebearapps/untether/issues/21)
+- post-outline Approve/Deny buttons — after "Pause & Outline Plan", Claude writes the outline then Approve/Deny buttons appear automatically in Telegram; no need to type "approved" [#22](https://github.com/littlebearapps/untether/issues/22)
+
+### fixes
+
+- improved discuss denial message for resumed sessions — explicitly tells Claude to rewrite the outline even if one exists in prior context [#23](https://github.com/littlebearapps/untether/issues/23)
+- discuss cooldown state cleaned up on session end — prevents stale cooldown leaking into resumed runs [#23](https://github.com/littlebearapps/untether/issues/23)
+
+### docs
+
+- update plan-mode how-to with post-outline approval flow
+- update control-channel rule with new registries and discuss-approval mechanism
+- update CLAUDE.md feature list with preamble and discuss buttons
+- update site URL to `https://littlebearapps.com/tools/untether/`
+
 ## v0.23.5 (2026-02-27)
 
 ### changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ Untether adds interactive permission control, plan mode support, and several UX 
 ## Features (vs upstream takopi)
 
 - **Interactive permission control** — bidirectional Telegram buttons for tool approval, plan mode, and clarifying questions
-- **Pause & Outline Plan** — third button on plan approval to request a written plan before proceeding, with progressive cooldown
+- **Pause & Outline Plan** — third button on plan approval; after Claude writes the outline, Approve/Deny buttons appear automatically (no need to type "approved")
+- **Agent context preamble** — configurable prompt preamble tells agents they're on Telegram and requests structured end-of-task summaries; `[preamble]` config section
 - **`/planmode`** — toggle permission mode per chat (on/off/auto)
 - **Early callback answering** — clears button spinners immediately instead of waiting for processing
 - **Approval push notifications** — separate notify message when approval buttons appear
@@ -45,7 +46,7 @@ Telegram <-> TelegramPresenter <-> RunnerBridge <-> Runner (claude/codex/opencod
 | File | Purpose |
 |------|---------|
 | `runners/claude.py` | Claude Code runner, interactive features |
-| `runner_bridge.py` | Connects runners to Telegram presenter |
+| `runner_bridge.py` | Connects runners to Telegram presenter, injects agent preamble |
 | `cost_tracker.py` | Per-run/daily cost tracking and budget alerts |
 | `commands/claude_control.py` | Approve/Deny/Discuss callback handler |
 | `commands/dispatch.py` | Callback dispatch and command routing |
@@ -113,12 +114,12 @@ Rules in `.claude/rules/` auto-load when editing matching files:
 | `runner-development.md` | `runners/**`, `runner.py` | EventFactory usage, session locking, entry point registration |
 | `telegram-transport.md` | `telegram/**` | Outbox-only writes, 64-byte callback data, ephemeral cleanup |
 | `control-channel.md` | `runners/claude.py`, `claude_control.py` | PTY lifecycle, session registries, cooldown mechanics |
-| `testing-conventions.md` | `tests/**` | pytest+anyio, stub patterns, 81% coverage threshold |
+| `testing-conventions.md` | `tests/**` | pytest+anyio, stub patterns, 80% coverage threshold |
 | `release-discipline.md` | `CHANGELOG.md`, `pyproject.toml` | GitHub issue linking, changelog format, semantic versioning |
 
 ## Tests
 
-888 tests, 80% coverage threshold. Key test files:
+896 tests, 80% coverage threshold. Key test files:
 
 - `test_claude_control.py` — 56 tests: control requests, response routing, registry lifecycle, auto-approve/auto-deny, tool auto-approve, custom deny messages, discuss action, early toast, progressive cooldown, auto permission mode
 - `test_callback_dispatch.py` — 28 tests: callback parsing, dispatch toast/ephemeral behaviour, early answering
@@ -131,6 +132,7 @@ Rules in `.claude/rules/` auto-load when editing matching files:
 - `test_meta_line.py` — 26 tests: model name shortening, meta line formatting, ProgressTracker meta storage/snapshot, footer ordering (context/meta/resume)
 - `test_runner_utils.py` — error formatting helpers, drain_stderr capture, enriched error messages
 - `test_shutdown.py` — 4 tests: shutdown state transitions, idempotency, reset
+- `test_preamble.py` — 5 tests: default preamble injection, disabled preamble, custom text override, empty text disables, settings defaults
 - `test_restart_command.py` — 3 tests: command triggers shutdown, idempotent response, command id
 
 ## Development

--- a/docs/how-to/plan-mode.md
+++ b/docs/how-to/plan-mode.md
@@ -49,6 +49,8 @@ Tapping "Pause & Outline Plan" tells Claude to stop and write a comprehensive pl
 
 This is useful when you want to review the approach before Claude starts making changes.
 
+After Claude writes the outline, **Approve Plan / Deny** buttons appear automatically in Telegram. Tap "Approve Plan" to let Claude proceed, or "Deny" to stop and provide feedback. You no longer need to type "approved" — the buttons handle it.
+
 ## Progressive cooldown
 
 After you tap "Pause & Outline Plan", a cooldown window prevents Claude from immediately retrying ExitPlanMode:
@@ -60,9 +62,9 @@ After you tap "Pause & Outline Plan", a cooldown window prevents Claude from imm
 | 3rd | 90 seconds |
 | 4th+ | 120 seconds (maximum) |
 
-During the cooldown, any ExitPlanMode attempt is automatically denied with an escalating message asking Claude to write a more detailed plan. The cooldown resets when you explicitly Approve or Deny a request.
+During the cooldown, any ExitPlanMode attempt is automatically denied, but **Approve Plan / Deny buttons** are shown in Telegram so you can approve the plan as soon as you've read it. The cooldown resets when you explicitly Approve or Deny.
 
-This prevents the agent from bulldozing through when you've asked it to slow down and explain its approach.
+This prevents the agent from bulldozing through when you've asked it to slow down and explain its approach, while still giving you a one-tap way to approve once you're satisfied.
 
 ## Related
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -158,6 +158,25 @@ Controls what appears in the message footer after a run completes.
 
 When `show_subscription_usage` is enabled, a compact line like `⚡ 5h: 45% (2h 15m) | 7d: 30% (4d 3h)` appears after every Claude run. Threshold-based warnings (≥70%) appear regardless of this setting.
 
+## `preamble`
+
+Controls the context preamble injected at the start of every agent prompt.
+
+=== "toml"
+
+    ```toml
+    [preamble]
+    enabled = true
+    text = "Custom preamble text..."
+    ```
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `enabled` | bool | `true` | Inject preamble into prompts. |
+| `text` | string\|null | `null` | Custom preamble text. `null` uses the built-in default. |
+
+The default preamble tells agents they're running via Telegram, lists key constraints (only assistant text is visible), and requests a structured end-of-task summary.
+
 ## `cost_budget`
 
 === "toml"

--- a/docs/tutorials/install.md
+++ b/docs/tutorials/install.md
@@ -30,7 +30,7 @@ Verify it's installed:
 untether --version
 ```
 
-You should see something like `0.23.4`.
+You should see something like `0.24.0`.
 
 ## 3. Install agent CLIs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.23.5"
+version = "0.24.0"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, and Pi to Telegram with interactive permissions, voice notes, and live progress."
 readme = "README.md"
@@ -43,10 +43,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/littlebearapps/untether"
+Homepage = "https://littlebearapps.com/tools/untether/"
 Repository = "https://github.com/littlebearapps/untether.git"
 Issues = "https://github.com/littlebearapps/untether/issues"
-Documentation = "https://github.com/littlebearapps/untether/tree/master/docs"
+Documentation = "https://littlebearapps.com/tools/untether/"
 Changelog = "https://github.com/littlebearapps/untether/blob/master/CHANGELOG.md"
 Upstream = "https://github.com/banteg/takopi"
 

--- a/src/untether/cli/__init__.py
+++ b/src/untether/cli/__init__.py
@@ -159,7 +159,7 @@ def create_app() -> typer.Typer:
     app = typer.Typer(
         add_completion=False,
         invoke_without_command=True,
-        help="Telegram bridge for coding agents. Docs: https://github.com/littlebearapps/untether",
+        help="Telegram bridge for coding agents. Docs: https://littlebearapps.com/tools/untether/",
     )
     config_app = typer.Typer(help="Read and modify untether config.")
     config_app.command(name="path")(config_path_cmd)

--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -134,6 +134,13 @@ class FooterSettings(BaseModel):
     show_subscription_usage: bool = False
 
 
+class PreambleSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    enabled: bool = True
+    text: str | None = None
+
+
 class UntetherSettings(BaseSettings):
     model_config = SettingsConfigDict(
         extra="allow",
@@ -153,6 +160,7 @@ class UntetherSettings(BaseSettings):
     plugins: PluginsSettings = Field(default_factory=PluginsSettings)
     cost_budget: CostBudgetSettings = Field(default_factory=CostBudgetSettings)
     footer: FooterSettings = Field(default_factory=FooterSettings)
+    preamble: PreambleSettings = Field(default_factory=PreambleSettings)
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -235,7 +235,7 @@ async def test_handle_message_strips_resume_line_from_prompt() -> None:
 
     assert runner.calls
     prompt, passed_resume = runner.calls[0]
-    assert prompt == "do this\nand that"
+    assert prompt.endswith("do this\nand that")
     assert passed_resume == resume
 
 

--- a/tests/test_preamble.py
+++ b/tests/test_preamble.py
@@ -1,0 +1,50 @@
+"""Tests for prompt preamble injection."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from untether.runner_bridge import _DEFAULT_PREAMBLE, _apply_preamble
+from untether.settings import PreambleSettings
+
+
+def test_default_preamble_prepended() -> None:
+    """Default preamble is prepended when settings use defaults."""
+    result = _apply_preamble("fix the bug")
+    assert result.startswith("[Untether]")
+    assert result.endswith("fix the bug")
+    assert "\n\n---\n\n" in result
+    assert _DEFAULT_PREAMBLE in result
+
+
+def test_preamble_disabled() -> None:
+    """Prompt is returned unchanged when preamble is disabled."""
+    cfg = PreambleSettings(enabled=False)
+    with patch("untether.runner_bridge._load_preamble_settings", return_value=cfg):
+        result = _apply_preamble("fix the bug")
+    assert result == "fix the bug"
+
+
+def test_custom_preamble_text() -> None:
+    """Custom preamble text overrides the default."""
+    cfg = PreambleSettings(text="Custom context for this agent.")
+    with patch("untether.runner_bridge._load_preamble_settings", return_value=cfg):
+        result = _apply_preamble("fix the bug")
+    assert result.startswith("Custom context for this agent.")
+    assert result.endswith("fix the bug")
+    assert _DEFAULT_PREAMBLE not in result
+
+
+def test_preamble_empty_text() -> None:
+    """Empty text string effectively disables the preamble."""
+    cfg = PreambleSettings(text="")
+    with patch("untether.runner_bridge._load_preamble_settings", return_value=cfg):
+        result = _apply_preamble("fix the bug")
+    assert result == "fix the bug"
+
+
+def test_preamble_settings_defaults() -> None:
+    """PreambleSettings defaults to enabled with no custom text."""
+    cfg = PreambleSettings()
+    assert cfg.enabled is True
+    assert cfg.text is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -277,3 +277,45 @@ def test_footer_rejects_extra_keys(tmp_path: Path) -> None:
     }
     with pytest.raises(ConfigError, match="bogus_key"):
         validate_settings_data(data, config_path=config_path)
+
+
+# ---------------------------------------------------------------------------
+# PreambleSettings tests
+# ---------------------------------------------------------------------------
+
+
+def test_preamble_defaults() -> None:
+    from untether.settings import PreambleSettings
+
+    preamble = PreambleSettings()
+    assert preamble.enabled is True
+    assert preamble.text is None
+
+
+def test_preamble_from_toml(tmp_path: Path) -> None:
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        'transport = "telegram"\n\n'
+        "[transports.telegram]\n"
+        'bot_token = "token"\n'
+        "chat_id = 123\n\n"
+        "[preamble]\n"
+        "enabled = false\n"
+        'text = "Custom preamble"\n',
+        encoding="utf-8",
+    )
+
+    settings, _ = load_settings(config_path)
+    assert settings.preamble.enabled is False
+    assert settings.preamble.text == "Custom preamble"
+
+
+def test_preamble_rejects_extra_keys(tmp_path: Path) -> None:
+    config_path = tmp_path / "untether.toml"
+    data = {
+        "transport": "telegram",
+        "transports": {"telegram": {"bot_token": "token", "chat_id": 123}},
+        "preamble": {"enabled": True, "bogus_key": True},
+    }
+    with pytest.raises(ConfigError, match="bogus_key"):
+        validate_settings_data(data, config_path=config_path)

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -939,7 +939,7 @@ async def test_run_main_loop_allows_allowed_sender() -> None:
     await run_main_loop(cfg, poller)
 
     assert runner.calls
-    assert runner.calls[0][0] == "hello"
+    assert runner.calls[0][0].endswith("hello")
 
 
 def test_cancel_command_accepts_extra_text() -> None:
@@ -1755,7 +1755,7 @@ async def test_run_main_loop_ignores_duplicate_update_id() -> None:
     await run_main_loop(cfg, poller)
 
     assert len(runner.calls) == 1
-    assert runner.calls[0][0] == "first"
+    assert runner.calls[0][0].endswith("first")
 
 
 @pytest.mark.anyio
@@ -2089,7 +2089,7 @@ async def test_run_main_loop_prompt_upload_uses_caption_directives(
     assert saved_path.read_bytes() == payload
     assert runner.calls
     prompt_text, _ = runner.calls[0]
-    assert prompt_text.startswith("do thing")
+    assert "do thing" in prompt_text
     assert "/other" not in prompt_text
     assert "[uploaded file: incoming/hello.txt]" in prompt_text
 
@@ -2164,7 +2164,7 @@ async def test_run_main_loop_voice_transcript_preserves_directive(
 
     assert not claude_runner.calls
     assert len(codex_runner.calls) == 1
-    assert codex_runner.calls[0][0].startswith("(voice transcribed) do thing")
+    assert "(voice transcribed) do thing" in codex_runner.calls[0][0]
 
 
 @pytest.mark.anyio
@@ -2244,7 +2244,7 @@ async def test_run_main_loop_debounces_forwarded_messages_preserves_directives()
     assert not claude_runner.calls
     assert len(codex_runner.calls) == 1
     prompt_text, _ = codex_runner.calls[0]
-    assert prompt_text == "summarize these\n\na\n\nb\n\nc"
+    assert prompt_text.endswith("summarize these\n\na\n\nb\n\nc")
 
 
 @pytest.mark.anyio
@@ -2368,7 +2368,7 @@ async def test_run_main_loop_forwarded_document_still_uploads(
     assert saved_path.read_bytes() == payload
     assert runner.calls
     prompt_text, _ = runner.calls[0]
-    assert prompt_text.startswith("do thing")
+    assert "do thing" in prompt_text
     assert "[uploaded file: incoming/hello.txt]" in prompt_text
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.23.5"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -2,7 +2,7 @@
 site_name = "untether"
 site_description = "Run coding agents on your computer, control them via Telegram. Send tasks from anywhere, stream progress live, pick up where you left off at the terminal."
 site_author = "Little Bear Apps"
-site_url = "https://github.com/littlebearapps/untether"
+site_url = "https://littlebearapps.com/tools/untether/"
 repo_url = "https://github.com/littlebearapps/untether"
 repo_name = "littlebearapps/untether"
 edit_uri = "edit/master/docs/"


### PR DESCRIPTION
## Summary

- **Agent context preamble** — configurable `[preamble]` config injects Telegram context and structured summary template into all engine prompts via `runner_bridge.py`. Works for Claude, Codex, OpenCode, and Pi. Includes `PreambleSettings` model with `enabled` and `text` fields.
- **Post-outline approval buttons** — after "Pause & Outline Plan" auto-deny, synthetic Approve/Deny buttons now appear in Telegram automatically, eliminating the need to type "approved". Uses `da:` callback prefix to fit 64-byte Telegram limit.
- **Resumed session fix** — cooldown and approval state (`_DISCUSS_COOLDOWN`, `_DISCUSS_APPROVED`) cleaned up on session end to prevent stale state leaking into resumed runs.
- **URL updates** — Homepage and Documentation URLs updated to `https://littlebearapps.com/tools/untether/` in pyproject.toml, CLI help text, and GitHub repo metadata.
- **Project-scoped rules & skills** — added `.claude/rules/` (4 rules) and `.claude/skills/` (5 skills) for development context.

Closes #21, closes #22, closes #23

## Test plan

- [x] 896 tests pass locally (80.61% coverage)
- [x] `ruff format` + `ruff check` clean
- [x] `uv lock --check` passes
- [x] Service restarted and verified via `journalctl` — preamble injection confirmed in logs
- [x] GitHub repo homepage set via `gh repo edit`
- [ ] CI pipeline passes (format, ruff, ty, pytest, build, lockfile, pip-audit, bandit, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)