### PR TITLE
feat: v0.25.0 — verbose mode, outline visibility, Pi compaction

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Check if this command is restarting the Untether service:\n\nCommand: {{tool_input.command}}\n\nIf it contains 'systemctl --user restart untether' or 'systemctl --user start untether', respond with:\nREMINDER: Before restarting, verify:\n1. Tests pass: `uv run pytest --ignore=tests/test_cli_helpers.py`\n2. Lint clean: `uv run ruff check src/`\n3. Any config changes in untether.toml are intentional\n\nOtherwise respond: PASS"
+            "prompt": "Check if this command interacts with Untether systemd services:\n\nCommand: {{tool_input.command}}\n\nRules:\n1. If it contains 'systemctl' with 'untether-dev' (e.g. restart/start/stop untether-dev): this is the DEV service, which is correct for testing local changes. Respond with:\nDEV SERVICE: Before restarting untether-dev, verify:\n1. Tests pass: `uv run pytest`\n2. Lint clean: `uv run ruff check src/`\n\n2. If it contains 'systemctl' with just 'untether' (NOT 'untether-dev') and 'restart' or 'start' (e.g. 'restart untether', 'start untether'): this is the PRODUCTION service. Respond with:\nBLOCKED: Do NOT restart production (untether.service). Production runs a frozen PyPI wheel — local code changes have no effect on it. Restarting production during development is always wrong.\n\nTo test local changes, use the dev service instead:\n  systemctl --user restart untether-dev\n\nProduction should only be restarted after `pipx upgrade untether` following a PyPI release.\n\n3. If it contains 'pipx upgrade untether' followed by 'systemctl' restart of production: this is the correct production upgrade path. Respond: PASS\n\n4. Otherwise respond: PASS"
           }
         ]
       },

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -1,0 +1,57 @@
+---
+applies_to: "src/untether/**"
+---
+
+# Dev/Production Workflow Rules
+
+## Two instances
+
+| | Production | Dev |
+|---|---|---|
+| **Service** | `untether.service` | `untether-dev.service` |
+| **Bot** | `@hetz_lba1_bot` | `@untether_dev_bot` |
+| **Source** | PyPI wheel (frozen) | Local editable (`/home/nathan/untether/src/`) |
+| **Config** | `~/.untether/untether.toml` | `~/.untether-dev/untether.toml` |
+
+## Rules
+
+### NEVER restart production to test local changes
+
+`systemctl --user restart untether` does NOT pick up local code changes — production runs a PyPI wheel. Restarting it during development is always wrong and risks disrupting live chat routes.
+
+The ONLY time to restart production is after `pipx upgrade untether` following a PyPI release.
+
+### ALWAYS use the dev service for testing
+
+```bash
+systemctl --user restart untether-dev
+journalctl --user -u untether-dev -f
+```
+
+Test changes via `@untether_dev_bot` in Telegram. The dev service runs the local editable source and picks up code changes on restart.
+
+### Production upgrade path
+
+```bash
+# Only after code is merged and released to PyPI:
+pipx upgrade untether
+systemctl --user restart untether
+```
+
+### Testing before merge
+
+1. Edit code in `src/`
+2. `uv run pytest && uv run ruff check src/`
+3. `systemctl --user restart untether-dev`
+4. Test via `@untether_dev_bot`
+5. When satisfied: commit, push, release
+
+## After changes
+
+```bash
+# Restart dev to pick up changes
+systemctl --user restart untether-dev
+
+# Never this (production restart for testing):
+# systemctl --user restart untether  ← WRONG during development
+```

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,10 @@ __pycache__/
 mutants/
 .worktrees/
 research/
+test-projects/
 _site/
 docs/reference/changelog.md
+.envrc
+.claude/settings.json
+.claude/plans/
+launch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # changelog
 
+## v0.25.0 (2026-02-28)
+
+### changes
+
+- `/verbose` command and `[progress]` config — per-chat verbose toggle shows tool details (file paths, commands, patterns) in progress messages; global verbosity and max_actions settings [#25](https://github.com/littlebearapps/untether/issues/25)
+- Pi context compaction events — render `AutoCompactionStart`/`AutoCompactionEnd` as progress actions with token counts [#26](https://github.com/littlebearapps/untether/issues/26)
+- `UNTETHER_CONFIG_PATH` env var — override config file location for multi-instance setups [#27](https://github.com/littlebearapps/untether/issues/27)
+- ExceptionGroup unwrapping, transport resilience, and debug logging improvements [#30](https://github.com/littlebearapps/untether/issues/30)
+
+### fixes
+
+- outline not visible in Pause & Outline Plan flow — outline was scrolled off by max_actions truncation and lost in final message [#28](https://github.com/littlebearapps/untether/issues/28)
+- footer double-spacing — sulguk trailing `\n\n` caused blank lines between footer items (context/meta/resume) [#29](https://github.com/littlebearapps/untether/issues/29)
+
+### docs
+
+- add dev instance quickref (`docs/reference/dev-instance.md`) documenting production vs dev separation
+- add dev workflow rule (`.claude/rules/dev-workflow.md`) preventing accidental production restarts
+- update CLAUDE.md and README with verbose mode, Pi compaction, and config path features
+
+### tests
+
+- add test suites for verbose command, verbose progress formatting, config path env var, cooldown bypass, and Pi compaction (44 new tests)
+
 ## v0.24.0 (2026-02-27)
 
 ### changes

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ That's it. Your agent runs on your machine, streams progress to Telegram, and yo
 | `/file put/get` | Transfer files |
 | `/topic` | Create or bind forum topics |
 | `/restart` | Gracefully restart Untether (drains active runs first) |
+| `/verbose` | Toggle verbose progress mode (show tool details) |
 
 Prefix any message with `/<engine>` to pick an engine for that task, or `/<project>` to target a repo:
 

--- a/docs/reference/commands-and-directives.md
+++ b/docs/reference/commands-and-directives.md
@@ -51,6 +51,7 @@ This line is parsed from replies and takes precedence over new directives.
 | `/browse` | Browse project files with inline keyboard navigation. |
 | `/ping` | Health check — replies with uptime. |
 | `/restart` | Gracefully drain active runs and restart Untether. |
+| `/verbose` | Toggle verbose progress mode (on/off/clear). Shows tool details in progress messages. |
 | `/new` | Clear stored sessions for the current scope (topic/chat). |
 
 Notes:

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -177,6 +177,25 @@ Controls the context preamble injected at the start of every agent prompt.
 
 The default preamble tells agents they're running via Telegram, lists key constraints (only assistant text is visible), and requests a structured end-of-task summary.
 
+## `progress`
+
+Controls progress message rendering during agent runs.
+
+=== "toml"
+
+    ```toml
+    [progress]
+    verbosity = "verbose"
+    max_actions = 8
+    ```
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `verbosity` | `"compact"` \| `"verbose"` | `"compact"` | `compact` shows status + title only. `verbose` adds tool detail lines (file paths, commands, patterns). |
+| `max_actions` | int (0–50) | `5` | Maximum action lines shown in the progress message. |
+
+Per-chat override: `/verbose on` and `/verbose off` override the config default for the current chat without editing the TOML file. `/verbose clear` removes the override.
+
 ## `cost_budget`
 
 === "toml"

--- a/docs/reference/dev-instance.md
+++ b/docs/reference/dev-instance.md
@@ -1,0 +1,100 @@
+# Dev Instance
+
+Untether runs two isolated instances on lba-1: **production** (PyPI release) and **dev** (local editable source). They use separate Telegram bots, separate configs, and separate state — zero crosstalk.
+
+## How it works
+
+| | Production | Dev |
+|---|---|---|
+| **Systemd service** | `untether.service` | `untether-dev.service` |
+| **Binary** | `~/.local/bin/untether` (pipx, PyPI wheel) | `/home/nathan/untether/.venv/bin/untether` (editable) |
+| **Config** | `~/.untether/untether.toml` | `~/.untether-dev/untether.toml` |
+| **State files** | `~/.untether/*.json` | `~/.untether-dev/*.json` |
+| **Lock file** | `~/.untether/untether.toml.lock` | `~/.untether-dev/untether.toml.lock` |
+| **Telegram bot** | `@hetz_lba1_bot` | `@untether_dev_bot` |
+| **Source** | Frozen PyPI release | Whatever's in `/home/nathan/untether/src/` |
+
+The `UNTETHER_CONFIG_PATH` env var (set in the dev systemd unit) is what directs the dev instance to its own config directory. State and lock files derive their paths from the config file location automatically.
+
+## Why no separate repo or branch?
+
+The dev instance doesn't need its own branch or repo. The separation is at the **runtime** level, not the source level:
+
+- **Production** runs a frozen PyPI wheel — changing local source has zero effect on it
+- **Dev** runs the local editable install — any code change takes effect on `systemctl --user restart untether-dev`
+- You develop on whatever branch you like (master, feature branches, etc.)
+- The `~/.untether-dev/` config directory is local infrastructure, not versioned in git
+
+## Quick reference
+
+```bash
+# --- Dev instance ---
+systemctl --user restart untether-dev     # Pick up code changes
+systemctl --user stop untether-dev
+journalctl --user -u untether-dev -f      # Tail dev logs
+
+# --- Production instance ---
+systemctl --user restart untether         # Restart (same PyPI version)
+journalctl --user -u untether -f          # Tail prod logs
+
+# --- Upgrade production after a PyPI release ---
+pipx upgrade untether
+systemctl --user restart untether
+
+# --- Check both ---
+systemctl --user status untether untether-dev
+
+# --- Versions ---
+/home/nathan/.local/bin/untether --version          # Production (PyPI)
+/home/nathan/untether/.venv/bin/untether --version   # Dev (local)
+```
+
+## Dev workflow
+
+1. Edit code in `/home/nathan/untether/src/`
+2. `systemctl --user restart untether-dev`
+3. Test via `@untether_dev_bot` in Telegram
+4. Run tests: `uv run pytest`
+5. When satisfied: commit, push, release to PyPI
+6. Upgrade production: `pipx upgrade untether && systemctl --user restart untether`
+
+## Config files
+
+**Dev config** (`~/.untether-dev/untether.toml`): Minimal config with the dev bot token and test chat routes. Edit directly — not version-controlled.
+
+**Dev systemd unit** (`~/.config/systemd/user/untether-dev.service`): Sets `UNTETHER_CONFIG_PATH` and points `ExecStart` at the local `.venv`. Run `systemctl --user daemon-reload` after editing.
+
+## Test project directories
+
+Four test workspaces live under `test-projects/` in the repo (gitignored, not version-controlled):
+
+| Directory | Engine | Dev config route |
+|-----------|--------|-----------------|
+| `test-projects/test-claude/` | Claude Code | `[projects.claude-test]` |
+| `test-projects/test-codex/` | Codex | `[projects.codex-test]` |
+| `test-projects/test-opencode/` | OpenCode | `[projects.opencode-test]` |
+| `test-projects/test-pi/` | Pi | `[projects.pi-test]` |
+
+Each has a `CLAUDE.md` and `.claude/settings.json`. They're throwaway workspaces — agents run here during dev testing so untether source isn't accidentally modified.
+
+### Telegram groups
+
+Each test project has a dedicated Telegram group (all in the `ut-dev` folder):
+
+| Group | Chat ID | Engine |
+|-------|---------|--------|
+| ut-dev: claude | `-5284581592` | Claude Code |
+| ut-dev: codex | `-4929463515` | Codex |
+| ut-dev: opencode | `-5200822877` | OpenCode |
+| ut-dev: pi | `-5156256333` | Pi |
+
+Main dev chat (private): `8351408485` (direct messages to `@untether_dev_bot`)
+
+### Adding more routes
+
+To add another test route:
+1. Create a Telegram group and add `@untether_dev_bot`
+2. Get the chat_id from dev logs: `journalctl --user -u untether-dev -f`
+3. Add a `[projects.name]` section to `~/.untether-dev/untether.toml`
+4. Create a workspace directory under `test-projects/`
+5. Restart dev: `systemctl --user restart untether-dev`

--- a/docs/reference/runners/pi/stream-json-cheatsheet.md
+++ b/docs/reference/runners/pi/stream-json-cheatsheet.md
@@ -66,6 +66,18 @@ required `type` field. These are `AgentSessionEvent` objects from
 {"type":"tool_execution_end","toolCallId":"tool_1","toolName":"bash","result":{"content":[{"type":"text","text":"ok"}],"details":{}},"isError":false}
 ```
 
+### `auto_compaction_start`
+
+```json
+{"type":"auto_compaction_start","reason":"context_limit"}
+```
+
+### `auto_compaction_end`
+
+```json
+{"type":"auto_compaction_end","result":{"newNumTokens":42000},"aborted":false}
+```
+
 ## Notes
 
 * `message_end` with `role = "assistant"` contains the final assistant text.

--- a/docs/reference/runners/pi/untether-events.md
+++ b/docs/reference/runners/pi/untether-events.md
@@ -110,7 +110,31 @@ Mapping:
   - `resume = ResumeToken(engine="pi", value=session_token)`.
   - `usage = last assistant usage`.
 
-### 4.5 Other events
+### 4.5 `auto_compaction_start` / `auto_compaction_end`
+
+When Pi compacts its context window to free tokens, it emits these events.
+
+`auto_compaction_start` example:
+```json
+{"type":"auto_compaction_start","reason":"context_limit"}
+```
+
+Mapping:
+- Emit `action` with `phase="started"`, `kind="note"`.
+- `action.title = "compacting context… (reason)"`.
+- Sequential action ids: `compaction_1`, `compaction_2`, etc.
+
+`auto_compaction_end` example:
+```json
+{"type":"auto_compaction_end","result":{"newNumTokens":42000},"aborted":false}
+```
+
+Mapping:
+- Emit `action` with `phase="completed"`.
+- `action.title = "context compacted (42,000 tokens)"` (formatted with commas).
+- If `aborted=true`, title is `"context compaction aborted"`.
+
+### 4.6 Other events
 
 Ignore unknown events. If a JSONL line is malformed, emit a warning action and
 continue (default `JsonlSubprocessRunner` behavior).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.24.0"
+version = "0.25.0"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, and Pi to Telegram with interactive permissions, voice notes, and live progress."
 readme = "README.md"
@@ -70,6 +70,7 @@ ping = "untether.telegram.commands.ping:BACKEND"
 export = "untether.telegram.commands.export:BACKEND"
 browse = "untether.telegram.commands.browse:BACKEND"
 restart = "untether.telegram.commands.restart:BACKEND"
+verbose = "untether.telegram.commands.verbose:BACKEND"
 
 [build-system]
 requires = ["uv_build>=0.9.18,<0.10.0"]

--- a/src/untether/config.py
+++ b/src/untether/config.py
@@ -58,6 +58,10 @@ def read_config(cfg_path: Path) -> dict:
 
 
 def load_or_init_config(path: str | Path | None = None) -> tuple[dict, Path]:
+    if path is None:
+        env_path = os.environ.get("UNTETHER_CONFIG_PATH")
+        if env_path:
+            path = env_path
     cfg_path = Path(path).expanduser() if path else HOME_CONFIG_PATH
     if cfg_path.exists() and not cfg_path.is_file():
         raise ConfigError(f"Config path {cfg_path} exists but is not a file.") from None

--- a/src/untether/telegram/commands/dispatch.py
+++ b/src/untether/telegram/commands/dispatch.py
@@ -117,6 +117,7 @@ async def _dispatch_command(
         )
         await executor.send(f"error:\n{exc}", reply_to=message_ref, notify=True)
         return
+    logger.debug("command.executed", command=command_id, chat_id=chat_id)
     if result is not None:
         reply_to = message_ref if result.reply_to is None else result.reply_to
         msg: RenderedMessage | str = result.text
@@ -218,6 +219,7 @@ async def _dispatch_callback(
             )
             await _answer_callback(str(exc)[:200])
             return
+        logger.debug("callback.executed", command=command_id, chat_id=chat_id)
         if result is not None:
             reply_to = message_ref if result.reply_to is None else result.reply_to
             cb_msg: RenderedMessage | str = result.text

--- a/src/untether/telegram/commands/executor.py
+++ b/src/untether/telegram/commands/executor.py
@@ -175,6 +175,12 @@ async def _run_engine(
         await reply(text="Untether is restarting — try again shortly.")
         return
 
+    logger.debug(
+        "handle.engine_start",
+        chat_id=chat_id,
+        engine=str(engine_override) if engine_override else None,
+        resume=resume_token.value if resume_token else None,
+    )
     try:
         try:
             entry = runtime.resolve_runner(

--- a/src/untether/telegram/commands/verbose.py
+++ b/src/untether/telegram/commands/verbose.py
@@ -1,0 +1,81 @@
+"""Command backend for toggling verbose progress mode via /verbose."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ...commands import CommandBackend, CommandContext, CommandResult
+from ...logging import get_logger
+
+logger = get_logger(__name__)
+
+Verbosity = Literal["compact", "verbose"]
+
+# Module-level override: when set, overrides config-level verbosity.
+# Keyed by chat_id for future multi-chat support; None = use config default.
+_VERBOSE_OVERRIDES: dict[int, Verbosity] = {}
+
+
+def get_verbosity_override(chat_id: int) -> Verbosity | None:
+    """Return the per-chat verbosity override, or None for config default."""
+    return _VERBOSE_OVERRIDES.get(chat_id)
+
+
+class VerboseCommand:
+    """Command backend for toggling verbose progress mode."""
+
+    id = "verbose"
+    description = "Toggle verbose progress mode on/off"
+
+    async def handle(self, ctx: CommandContext) -> CommandResult | None:
+        chat_id = ctx.message.channel_id
+        args = ctx.args_text.strip().lower()
+
+        if args in ("on", "verbose"):
+            _VERBOSE_OVERRIDES[chat_id] = "verbose"
+            logger.info("verbose.set", chat_id=chat_id, verbosity="verbose")
+            return CommandResult(
+                text="verbose mode <b>on</b> — progress messages will show tool details.",
+                notify=True,
+                parse_mode="HTML",
+            )
+
+        if args in ("off", "compact"):
+            _VERBOSE_OVERRIDES[chat_id] = "compact"
+            logger.info("verbose.set", chat_id=chat_id, verbosity="compact")
+            return CommandResult(
+                text="verbose mode <b>off</b> — compact progress (default).",
+                notify=True,
+                parse_mode="HTML",
+            )
+
+        if args in ("clear", "reset"):
+            _VERBOSE_OVERRIDES.pop(chat_id, None)
+            logger.info("verbose.cleared", chat_id=chat_id)
+            return CommandResult(
+                text="verbose override <b>cleared</b> (using config default).",
+                notify=True,
+                parse_mode="HTML",
+            )
+
+        # No args: toggle
+        current = _VERBOSE_OVERRIDES.get(chat_id)
+        if current == "verbose":
+            _VERBOSE_OVERRIDES[chat_id] = "compact"
+            logger.info("verbose.toggled", chat_id=chat_id, verbosity="compact")
+            return CommandResult(
+                text="verbose mode <b>off</b>.",
+                notify=True,
+                parse_mode="HTML",
+            )
+        else:
+            _VERBOSE_OVERRIDES[chat_id] = "verbose"
+            logger.info("verbose.toggled", chat_id=chat_id, verbosity="verbose")
+            return CommandResult(
+                text="verbose mode <b>on</b>.",
+                notify=True,
+                parse_mode="HTML",
+            )
+
+
+BACKEND: CommandBackend = VerboseCommand()

--- a/src/untether/telegram/render.py
+++ b/src/untether/telegram/render.py
@@ -77,6 +77,9 @@ def render_markdown(md: str) -> tuple[str, list[dict[str, Any]]]:
     rendered = transform_html(html)
 
     text = _BULLET_RE.sub(r"\1-", rendered.text)
+    # sulguk adds trailing \n\n after the last paragraph; strip it so
+    # post-render appends (cost footer, usage) don't get double-spaced.
+    text = text.rstrip("\n")
 
     entities = [dict(e) for e in rendered.entities]
     return text, entities

--- a/tests/test_config_path_env.py
+++ b/tests/test_config_path_env.py
@@ -1,0 +1,140 @@
+"""Tests for UNTETHER_CONFIG_PATH env var support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from untether.config import HOME_CONFIG_PATH, load_or_init_config
+from untether.settings import _resolve_config_path, load_settings
+
+
+ENV_VAR = "UNTETHER_CONFIG_PATH"
+
+
+class TestResolveConfigPath:
+    """Tests for settings._resolve_config_path()."""
+
+    def test_explicit_path_wins_over_env(self, tmp_path: Path, monkeypatch) -> None:
+        env_config = tmp_path / "env" / "untether.toml"
+        explicit = tmp_path / "explicit" / "untether.toml"
+        monkeypatch.setenv(ENV_VAR, str(env_config))
+
+        result = _resolve_config_path(str(explicit))
+
+        assert result == explicit
+
+    def test_env_var_used_when_no_explicit_path(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        env_config = tmp_path / "env" / "untether.toml"
+        monkeypatch.setenv(ENV_VAR, str(env_config))
+
+        result = _resolve_config_path(None)
+
+        assert result == env_config
+
+    def test_falls_back_to_home_config(self, monkeypatch) -> None:
+        monkeypatch.delenv(ENV_VAR, raising=False)
+
+        result = _resolve_config_path(None)
+
+        assert result == HOME_CONFIG_PATH
+
+    def test_env_var_tilde_expanded(self, monkeypatch) -> None:
+        monkeypatch.setenv(ENV_VAR, "~/.untether-dev/untether.toml")
+
+        result = _resolve_config_path(None)
+
+        assert result == Path.home() / ".untether-dev" / "untether.toml"
+
+
+class TestLoadOrInitConfigEnv:
+    """Tests for config.load_or_init_config() with env var."""
+
+    def test_env_var_used_when_no_path_arg(self, tmp_path: Path, monkeypatch) -> None:
+        env_config = tmp_path / "untether.toml"
+        env_config.write_text(
+            'transport = "telegram"\n\n'
+            "[transports.telegram]\n"
+            'bot_token = "tok"\n'
+            "chat_id = 1\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv(ENV_VAR, str(env_config))
+
+        data, cfg_path = load_or_init_config()
+
+        assert cfg_path == env_config
+        assert data["transport"] == "telegram"
+
+    def test_explicit_path_wins_over_env(self, tmp_path: Path, monkeypatch) -> None:
+        env_config = tmp_path / "env.toml"
+        explicit_config = tmp_path / "explicit.toml"
+        explicit_config.write_text(
+            'transport = "telegram"\n\n'
+            "[transports.telegram]\n"
+            'bot_token = "tok"\n'
+            "chat_id = 2\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv(ENV_VAR, str(env_config))
+
+        data, cfg_path = load_or_init_config(str(explicit_config))
+
+        assert cfg_path == explicit_config
+        assert data["transports"]["telegram"]["chat_id"] == 2
+
+    def test_env_var_missing_file_returns_empty(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        env_config = tmp_path / "nonexistent.toml"
+        monkeypatch.setenv(ENV_VAR, str(env_config))
+
+        data, cfg_path = load_or_init_config()
+
+        assert cfg_path == env_config
+        assert data == {}
+
+
+class TestLoadSettingsEnv:
+    """Tests for settings.load_settings() with env var."""
+
+    def test_env_var_loads_config(self, tmp_path: Path, monkeypatch) -> None:
+        env_config = tmp_path / "untether.toml"
+        env_config.write_text(
+            'transport = "telegram"\n\n'
+            "[transports.telegram]\n"
+            'bot_token = "devtoken"\n'
+            "chat_id = 999\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv(ENV_VAR, str(env_config))
+
+        settings, cfg_path = load_settings()
+
+        assert cfg_path == env_config
+        assert settings.transports.telegram.bot_token == "devtoken"
+        assert settings.transports.telegram.chat_id == 999
+
+
+class TestOnboardingResolveHomeConfig:
+    """Tests for onboarding._resolve_home_config()."""
+
+    def test_env_var_overrides_default(self, tmp_path: Path, monkeypatch) -> None:
+        from untether.telegram.onboarding import _resolve_home_config
+
+        env_config = tmp_path / "dev" / "untether.toml"
+        monkeypatch.setenv(ENV_VAR, str(env_config))
+
+        result = _resolve_home_config()
+
+        assert result == env_config
+
+    def test_falls_back_to_home_config(self, monkeypatch) -> None:
+        from untether.telegram.onboarding import _resolve_home_config
+
+        monkeypatch.delenv(ENV_VAR, raising=False)
+
+        result = _resolve_home_config()
+
+        assert result == HOME_CONFIG_PATH

--- a/tests/test_cooldown_bypass.py
+++ b/tests/test_cooldown_bypass.py
@@ -1,0 +1,340 @@
+"""Tests for the Pause & Outline Plan cooldown bypass mechanism.
+
+When the user clicks "Pause & Outline Plan", a cooldown is set.
+Subsequent ExitPlanMode calls are handled differently depending on
+whether Claude has written substantial outline text (>= 200 chars):
+
+- With outline: auto-deny with _OUTLINE_WAIT_MESSAGE + synthetic Approve/Deny buttons
+- Without outline: auto-deny with escalation message + synthetic Approve/Deny buttons
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from untether.model import ActionEvent, ResumeToken
+from untether.runners.claude import (
+    ClaudeStreamState,
+    _DISCUSS_APPROVED,
+    _DISCUSS_COOLDOWN,
+    _OUTLINE_PENDING,
+    _REQUEST_TO_INPUT,
+    _REQUEST_TO_SESSION,
+    _OUTLINE_MIN_CHARS,
+    _OUTLINE_WAIT_MESSAGE,
+    set_discuss_cooldown,
+    translate_claude_event,
+)
+from untether.schemas import claude as claude_schema
+
+
+@pytest.fixture(autouse=True)
+def _clear_registries():
+    """Clear global registries before each test."""
+    _DISCUSS_COOLDOWN.clear()
+    _DISCUSS_APPROVED.clear()
+    _OUTLINE_PENDING.clear()
+    _REQUEST_TO_SESSION.clear()
+    _REQUEST_TO_INPUT.clear()
+    yield
+    _DISCUSS_COOLDOWN.clear()
+    _DISCUSS_APPROVED.clear()
+    _OUTLINE_PENDING.clear()
+    _REQUEST_TO_SESSION.clear()
+    _REQUEST_TO_INPUT.clear()
+
+
+def _make_resume(session_id: str) -> ResumeToken:
+    return ResumeToken(engine="claude", value=session_id)
+
+
+def _make_state(session_id: str) -> ClaudeStreamState:
+    state = ClaudeStreamState()
+    state.factory._resume = _make_resume(session_id)
+    return state
+
+
+def _make_exit_plan_mode_request(
+    request_id: str = "req_1",
+) -> claude_schema.StreamControlRequest:
+    """Create a fake ExitPlanMode control request."""
+    return claude_schema.StreamControlRequest(
+        request_id=request_id,
+        request=claude_schema.ControlCanUseToolRequest(
+            tool_name="ExitPlanMode",
+            input={},
+        ),
+    )
+
+
+def _make_text_block(text: str) -> claude_schema.StreamAssistantMessage:
+    """Create a StreamAssistantMessage containing a text block."""
+    return claude_schema.StreamAssistantMessage(
+        message=claude_schema.StreamAssistantMessageBody(
+            role="assistant",
+            content=[claude_schema.StreamTextBlock(text=text)],
+            model="claude-sonnet-4-20250514",
+        )
+    )
+
+
+# --- Bypass path: outline written (text >= 200 chars) ---
+
+
+def test_bypass_auto_denies_with_wait_message():
+    """ExitPlanMode after outline text should auto-deny with _OUTLINE_WAIT_MESSAGE."""
+    state = _make_state("sess-1")
+    set_discuss_cooldown("sess-1")
+    state.last_assistant_text = "x" * 300
+    state.max_text_len_since_cooldown = 300
+
+    request_id = "req_exit_plan"
+    _REQUEST_TO_SESSION[request_id] = "sess-1"
+    _REQUEST_TO_INPUT[request_id] = {}
+
+    event = _make_exit_plan_mode_request(request_id)
+    translate_claude_event(event, title="claude", state=state, factory=state.factory)
+
+    # Bypass path now auto-denies (not fall-through to normal buttons)
+    assert len(state.auto_deny_queue) == 1
+    assert state.auto_deny_queue[0][0] == request_id
+    assert state.auto_deny_queue[0][1] == _OUTLINE_WAIT_MESSAGE
+    # Counter should be reset after bypass
+    assert state.max_text_len_since_cooldown == 0
+
+
+def test_bypass_produces_synthetic_approve_deny_buttons():
+    """Bypass path should return synthetic Approve/Deny buttons (no Pause button)."""
+    state = _make_state("sess-2")
+    set_discuss_cooldown("sess-2")
+    state.max_text_len_since_cooldown = 300
+
+    request_id = "req_exit_plan"
+    _REQUEST_TO_SESSION[request_id] = "sess-2"
+    _REQUEST_TO_INPUT[request_id] = {}
+
+    event = _make_exit_plan_mode_request(request_id)
+    events = translate_claude_event(
+        event, title="claude", state=state, factory=state.factory
+    )
+
+    # Should return a synthetic action with inline keyboard
+    action_events = [e for e in events if isinstance(e, ActionEvent)]
+    assert len(action_events) == 1
+    detail = action_events[0].action.detail
+    assert detail["request_type"] == "DiscussApproval"
+    buttons = detail["inline_keyboard"]["buttons"]
+    # Only 1 row with 2 buttons: Approve Plan, Deny
+    assert len(buttons) == 1
+    assert len(buttons[0]) == 2
+    assert buttons[0][0]["text"] == "Approve Plan"
+    assert buttons[0][1]["text"] == "Deny"
+    # Callback data uses da: prefix
+    assert buttons[0][0]["callback_data"].startswith("claude_control:approve:da:")
+    assert buttons[0][1]["callback_data"].startswith("claude_control:deny:da:")
+
+
+def test_bypass_clears_outline_pending():
+    """Bypass should clear _OUTLINE_PENDING for the session."""
+    state = _make_state("sess-3")
+    set_discuss_cooldown("sess-3")
+    assert "sess-3" in _OUTLINE_PENDING  # set by set_discuss_cooldown
+
+    state.max_text_len_since_cooldown = 300
+    request_id = "req_exit_plan"
+    _REQUEST_TO_SESSION[request_id] = "sess-3"
+    _REQUEST_TO_INPUT[request_id] = {}
+
+    event = _make_exit_plan_mode_request(request_id)
+    translate_claude_event(event, title="claude", state=state, factory=state.factory)
+
+    assert "sess-3" not in _OUTLINE_PENDING
+
+
+def test_bypass_survives_text_overwrite():
+    """Bypass works even if a short text block overwrites the long outline.
+
+    Claude may write a 500-char outline in message #1, then a short "Calling
+    ExitPlanMode" in message #2.  ``last_assistant_text`` gets overwritten, but
+    ``max_text_len_since_cooldown`` preserves the peak length.
+    """
+    state = _make_state("sess-overwrite")
+    set_discuss_cooldown("sess-overwrite")
+
+    # First text block: long outline (500 chars)
+    state.last_assistant_text = "x" * 500
+    state.max_text_len_since_cooldown = 500
+
+    # Second text block: short message that overwrites last_assistant_text
+    state.last_assistant_text = "Calling ExitPlanMode now."
+    if len("Calling ExitPlanMode now.") > state.max_text_len_since_cooldown:
+        state.max_text_len_since_cooldown = len("Calling ExitPlanMode now.")
+
+    assert state.max_text_len_since_cooldown == 500  # preserved peak
+    assert len(state.last_assistant_text) < 200  # current text is short
+
+    request_id = "req_exit_plan"
+    _REQUEST_TO_SESSION[request_id] = "sess-overwrite"
+    _REQUEST_TO_INPUT[request_id] = {}
+
+    event = _make_exit_plan_mode_request(request_id)
+    translate_claude_event(event, title="claude", state=state, factory=state.factory)
+
+    # Should still trigger bypass (max_text_len_since_cooldown=500 >= 200)
+    assert len(state.auto_deny_queue) == 1
+    assert state.auto_deny_queue[0][1] == _OUTLINE_WAIT_MESSAGE
+    assert state.max_text_len_since_cooldown == 0
+
+
+# --- No-bypass path: no outline written ---
+
+
+def test_auto_deny_without_outline():
+    """ExitPlanMode should be auto-denied when no substantial text was written."""
+    state = _make_state("sess-4")
+    set_discuss_cooldown("sess-4")
+    state.last_assistant_text = "ok"
+
+    request_id = "req_exit_plan"
+    _REQUEST_TO_SESSION[request_id] = "sess-4"
+    _REQUEST_TO_INPUT[request_id] = {}
+
+    event = _make_exit_plan_mode_request(request_id)
+    translate_claude_event(event, title="claude", state=state, factory=state.factory)
+
+    assert len(state.auto_deny_queue) == 1
+    assert state.auto_deny_queue[0][0] == request_id
+    # Should use escalation message, not wait message
+    assert state.auto_deny_queue[0][1] != _OUTLINE_WAIT_MESSAGE
+
+
+def test_auto_deny_no_text():
+    """ExitPlanMode should be auto-denied when no text at all."""
+    state = _make_state("sess-5")
+    set_discuss_cooldown("sess-5")
+    state.last_assistant_text = None
+
+    request_id = "req_exit_plan"
+    _REQUEST_TO_SESSION[request_id] = "sess-5"
+    _REQUEST_TO_INPUT[request_id] = {}
+
+    event = _make_exit_plan_mode_request(request_id)
+    translate_claude_event(event, title="claude", state=state, factory=state.factory)
+
+    assert len(state.auto_deny_queue) == 1
+
+
+# --- Outline text storage: text block stores on state ---
+
+
+def test_outline_text_stored_on_state_during_cooldown():
+    """StreamTextBlock stores outline text on state when pending and text >= 200 chars."""
+    state = _make_state("sess-note")
+    set_discuss_cooldown("sess-note")
+    assert "sess-note" in _OUTLINE_PENDING
+
+    outline = "A" * 250
+    text_event = _make_text_block(outline)
+    events = translate_claude_event(
+        text_event, title="claude", state=state, factory=state.factory
+    )
+
+    # No separate note action emitted — outline is stored on state for embedding
+    action_events = [e for e in events if isinstance(e, ActionEvent)]
+    assert len(action_events) == 0
+    assert state.outline_text == outline
+
+
+def test_outline_text_not_stored_without_pending():
+    """StreamTextBlock should NOT store outline text during normal operation."""
+    state = _make_state("sess-normal")
+    # No set_discuss_cooldown → _OUTLINE_PENDING is empty
+
+    text_event = _make_text_block("A" * 300)
+    translate_claude_event(
+        text_event, title="claude", state=state, factory=state.factory
+    )
+
+    assert state.outline_text is None
+
+
+def test_outline_text_not_stored_for_short_text():
+    """Short text (< 200 chars) should NOT be stored even when outline is pending."""
+    state = _make_state("sess-short")
+    set_discuss_cooldown("sess-short")
+
+    text_event = _make_text_block("Short text")
+    translate_claude_event(
+        text_event, title="claude", state=state, factory=state.factory
+    )
+
+    assert state.outline_text is None
+
+
+def test_outline_embedded_in_synthetic_action():
+    """Synthetic Approve/Deny action should include outline text in title."""
+    state = _make_state("sess-embed")
+    set_discuss_cooldown("sess-embed")
+
+    # Simulate outline capture
+    outline = "Step 1: Do X\nStep 2: Do Y\n" * 20  # ~520 chars
+    state.outline_text = outline
+    state.max_text_len_since_cooldown = len(outline)
+
+    request_id = "req_exit_plan"
+    _REQUEST_TO_SESSION[request_id] = "sess-embed"
+    _REQUEST_TO_INPUT[request_id] = {}
+
+    event = _make_exit_plan_mode_request(request_id)
+    events = translate_claude_event(
+        event, title="claude", state=state, factory=state.factory
+    )
+
+    action_events = [e for e in events if isinstance(e, ActionEvent)]
+    assert len(action_events) == 1
+    title = action_events[0].action.title
+    assert title.startswith("Plan outline:\n")
+    assert "Step 1: Do X" in title
+    # Outline text should be cleared after use
+    assert state.outline_text is None
+
+
+def test_outline_truncated_in_synthetic_action():
+    """Outline text longer than 1500 chars should be truncated in synthetic action."""
+    state = _make_state("sess-trunc")
+    set_discuss_cooldown("sess-trunc")
+
+    long_text = "B" * 2000
+    state.outline_text = long_text
+    state.max_text_len_since_cooldown = len(long_text)
+
+    request_id = "req_exit_plan"
+    _REQUEST_TO_SESSION[request_id] = "sess-trunc"
+    _REQUEST_TO_INPUT[request_id] = {}
+
+    event = _make_exit_plan_mode_request(request_id)
+    events = translate_claude_event(
+        event, title="claude", state=state, factory=state.factory
+    )
+
+    action_events = [e for e in events if isinstance(e, ActionEvent)]
+    assert len(action_events) == 1
+    title = action_events[0].action.title
+    # "Plan outline:\n" prefix + 1500 chars + "…"
+    assert title.startswith("Plan outline:\n")
+    assert title.endswith("…")
+    assert len(title) < 1520
+
+
+# --- _OUTLINE_PENDING lifecycle ---
+
+
+def test_set_discuss_cooldown_adds_outline_pending():
+    """set_discuss_cooldown should add session to _OUTLINE_PENDING."""
+    set_discuss_cooldown("sess-pending")
+    assert "sess-pending" in _OUTLINE_PENDING
+
+
+def test_outline_min_chars_constant():
+    """_OUTLINE_MIN_CHARS should be 200."""
+    assert _OUTLINE_MIN_CHARS == 200

--- a/tests/test_pi_compaction.py
+++ b/tests/test_pi_compaction.py
@@ -1,0 +1,103 @@
+"""Tests for Pi runner context compaction event translation."""
+
+from __future__ import annotations
+
+from untether.model import ActionEvent
+from untether.runners.pi import PiStreamState, translate_pi_event
+from untether.model import ResumeToken
+from untether.schemas import pi as pi_schema
+
+
+def _make_state() -> PiStreamState:
+    return PiStreamState(
+        resume=ResumeToken(engine="pi", value="test-session"), started=True
+    )
+
+
+def test_auto_compaction_start():
+    """AutoCompactionStart should produce an action_started event."""
+    state = _make_state()
+    event = pi_schema.AutoCompactionStart(reason="threshold")
+    events = translate_pi_event(event, title="pi", meta=None, state=state)
+    assert len(events) == 1
+    assert isinstance(events[0], ActionEvent)
+    assert events[0].phase == "started"
+    assert "compacting context" in events[0].action.title
+    assert "threshold" in events[0].action.title
+    assert events[0].action.kind == "note"
+    assert state.compaction_seq == 1
+
+
+def test_auto_compaction_end():
+    """AutoCompactionEnd should produce an action_completed event."""
+    state = _make_state()
+    state.compaction_seq = 1
+    state.compaction_action_id = "compaction_1"
+
+    result_data = {
+        "tokensBefore": 118432,
+        "summary": "Summarised context",
+    }
+    event = pi_schema.AutoCompactionEnd(
+        result=result_data, aborted=False, willRetry=False
+    )
+    events = translate_pi_event(event, title="pi", meta=None, state=state)
+    assert len(events) == 1
+    assert isinstance(events[0], ActionEvent)
+    assert events[0].phase == "completed"
+    assert "118,432 tokens" in events[0].action.title
+    assert events[0].ok is True
+    assert state.compaction_action_id is None
+
+
+def test_auto_compaction_end_aborted():
+    """Aborted compaction should show as failed."""
+    state = _make_state()
+    state.compaction_seq = 1
+    state.compaction_action_id = "compaction_1"
+
+    event = pi_schema.AutoCompactionEnd(result=None, aborted=True, willRetry=False)
+    events = translate_pi_event(event, title="pi", meta=None, state=state)
+    assert len(events) == 1
+    assert events[0].ok is False
+    assert "aborted" in events[0].action.title
+
+
+def test_auto_compaction_end_no_tokens():
+    """Compaction without token count should show generic message."""
+    state = _make_state()
+    state.compaction_seq = 1
+    state.compaction_action_id = "compaction_1"
+
+    event = pi_schema.AutoCompactionEnd(result={}, aborted=False)
+    events = translate_pi_event(event, title="pi", meta=None, state=state)
+    assert len(events) == 1
+    assert events[0].action.title == "context compacted"
+
+
+def test_auto_compaction_start_no_reason():
+    """AutoCompactionStart with no reason should still work."""
+    state = _make_state()
+    event = pi_schema.AutoCompactionStart(reason=None)
+    events = translate_pi_event(event, title="pi", meta=None, state=state)
+    assert len(events) == 1
+    assert "compacting context" in events[0].action.title
+    # No reason suffix
+    assert "(" not in events[0].action.title
+
+
+def test_compaction_sequence():
+    """Full compaction start + end sequence."""
+    state = _make_state()
+
+    start_event = pi_schema.AutoCompactionStart(reason="threshold")
+    start_events = translate_pi_event(start_event, title="pi", meta=None, state=state)
+    assert len(start_events) == 1
+    action_id = start_events[0].action.id
+
+    end_event = pi_schema.AutoCompactionEnd(
+        result={"tokensBefore": 50000}, aborted=False
+    )
+    end_events = translate_pi_event(end_event, title="pi", meta=None, state=state)
+    assert len(end_events) == 1
+    assert end_events[0].action.id == action_id

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -6,7 +6,7 @@ from untether.telegram.render import render_markdown, split_markdown_body
 def test_render_markdown_basic_entities() -> None:
     text, entities = render_markdown("**bold** and `code`")
 
-    assert text == "bold and code\n\n"
+    assert text == "bold and code"
     assert entities == [
         {"type": "bold", "offset": 0, "length": 4},
         {"type": "code", "offset": 9, "length": 4},
@@ -16,7 +16,7 @@ def test_render_markdown_basic_entities() -> None:
 def test_render_markdown_code_fence_language_is_string() -> None:
     text, entities = render_markdown("```py\nprint('x')\n```")
 
-    assert text == "print('x')\n\n"
+    assert text == "print('x')"
     assert entities is not None
     assert any(e.get("type") == "pre" and e.get("language") == "py" for e in entities)
     assert any(e.get("type") == "code" for e in entities)

--- a/tests/test_verbose_command.py
+++ b/tests/test_verbose_command.py
@@ -1,0 +1,93 @@
+"""Tests for /verbose toggle command."""
+
+from __future__ import annotations
+
+import pytest
+
+from untether.telegram.commands.verbose import (
+    BACKEND,
+    VerboseCommand,
+    _VERBOSE_OVERRIDES,
+    get_verbosity_override,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    """Clear verbose overrides before each test."""
+    _VERBOSE_OVERRIDES.clear()
+    yield
+    _VERBOSE_OVERRIDES.clear()
+
+
+def _make_ctx(args: str = "", chat_id: int = 123) -> object:
+    """Create a minimal command context for testing."""
+    from unittest.mock import MagicMock
+
+    ctx = MagicMock()
+    ctx.args_text = args
+    ctx.message.channel_id = chat_id
+    return ctx
+
+
+@pytest.mark.anyio
+async def test_verbose_on():
+    cmd = VerboseCommand()
+    ctx = _make_ctx("on")
+    result = await cmd.handle(ctx)
+    assert result is not None
+    assert "on" in result.text.lower()
+    assert get_verbosity_override(123) == "verbose"
+
+
+@pytest.mark.anyio
+async def test_verbose_off():
+    cmd = VerboseCommand()
+    _VERBOSE_OVERRIDES[123] = "verbose"
+    ctx = _make_ctx("off")
+    result = await cmd.handle(ctx)
+    assert result is not None
+    assert "off" in result.text.lower()
+    assert get_verbosity_override(123) == "compact"
+
+
+@pytest.mark.anyio
+async def test_verbose_toggle_on():
+    """No args should toggle: off → on."""
+    cmd = VerboseCommand()
+    ctx = _make_ctx("")
+    result = await cmd.handle(ctx)
+    assert result is not None
+    assert "on" in result.text.lower()
+    assert get_verbosity_override(123) == "verbose"
+
+
+@pytest.mark.anyio
+async def test_verbose_toggle_off():
+    """No args should toggle: on → off."""
+    cmd = VerboseCommand()
+    _VERBOSE_OVERRIDES[123] = "verbose"
+    ctx = _make_ctx("")
+    result = await cmd.handle(ctx)
+    assert result is not None
+    assert "off" in result.text.lower()
+    assert get_verbosity_override(123) == "compact"
+
+
+@pytest.mark.anyio
+async def test_verbose_clear():
+    cmd = VerboseCommand()
+    _VERBOSE_OVERRIDES[123] = "verbose"
+    ctx = _make_ctx("clear")
+    result = await cmd.handle(ctx)
+    assert result is not None
+    assert "cleared" in result.text.lower()
+    assert get_verbosity_override(123) is None
+
+
+def test_get_verbosity_override_default():
+    assert get_verbosity_override(999) is None
+
+
+def test_backend_id():
+    assert BACKEND.id == "verbose"

--- a/tests/test_verbose_progress.py
+++ b/tests/test_verbose_progress.py
@@ -1,0 +1,378 @@
+"""Tests for verbose progress mode rendering."""
+
+from __future__ import annotations
+
+from untether.markdown import (
+    MarkdownFormatter,
+    format_verbose_detail,
+)
+from untether.model import Action
+from untether.progress import ActionState, ProgressState
+
+
+# --- format_verbose_detail tests ---
+
+
+class TestFormatVerboseDetail:
+    """Test format_verbose_detail for each tool type."""
+
+    def test_bash_command(self):
+        action = Action(
+            id="1",
+            kind="command",
+            title="git status",
+            detail={"name": "Bash", "input": {"command": "git diff --cached"}},
+        )
+        result = format_verbose_detail(action)
+        assert result == "git diff --cached"
+
+    def test_bash_command_truncated(self):
+        action = Action(
+            id="1",
+            kind="command",
+            title="long command",
+            detail={"name": "Bash", "input": {"command": "x" * 300}},
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert len(result) <= 201  # 200 + ellipsis char
+
+    def test_read_file(self):
+        action = Action(
+            id="1",
+            kind="tool",
+            title="Read",
+            detail={
+                "name": "Read",
+                "input": {"file_path": "/home/user/project/src/settings.py"},
+                "result_len": 4821,
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "settings.py" in result
+        assert "4821 chars" in result
+
+    def test_read_no_result_len(self):
+        action = Action(
+            id="1",
+            kind="tool",
+            title="Read",
+            detail={
+                "name": "Read",
+                "input": {"file_path": "/home/user/project/README.md"},
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "README.md" in result
+        assert "chars" not in result
+
+    def test_edit_file(self):
+        action = Action(
+            id="1",
+            kind="tool",
+            title="Edit",
+            detail={
+                "name": "Edit",
+                "input": {
+                    "file_path": "/home/user/project/src/markdown.py",
+                    "old_string": "def old_function():",
+                    "new_string": "def new_function():",
+                },
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "markdown.py" in result
+        assert "old_function" in result
+
+    def test_write_file(self):
+        action = Action(
+            id="1",
+            kind="tool",
+            title="Write",
+            detail={
+                "name": "Write",
+                "input": {"file_path": "/home/user/project/new_file.py"},
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "new_file.py" in result
+
+    def test_grep_pattern(self):
+        action = Action(
+            id="1",
+            kind="tool",
+            title="Grep",
+            detail={
+                "name": "Grep",
+                "input": {"pattern": "verbose.*mode", "path": "src/"},
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "verbose.*mode" in result
+
+    def test_glob_pattern(self):
+        action = Action(
+            id="1",
+            kind="tool",
+            title="Glob",
+            detail={
+                "name": "Glob",
+                "input": {"pattern": "**/*.py"},
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "**/*.py" in result
+
+    def test_task_subagent(self):
+        action = Action(
+            id="1",
+            kind="subagent",
+            title="Task",
+            detail={
+                "name": "Task",
+                "input": {"description": "Explore codebase patterns"},
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "Explore codebase patterns" in result
+
+    def test_web_search(self):
+        action = Action(
+            id="1",
+            kind="web_search",
+            title="WebSearch",
+            detail={
+                "name": "WebSearch",
+                "input": {"query": "untether telegram verbose mode"},
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "untether telegram verbose mode" in result
+
+    def test_mcp_tool(self):
+        action = Action(
+            id="1",
+            kind="tool",
+            title="brave_web_search",
+            detail={
+                "name": "brave_web_search",
+                "server": "brave-search",
+                "tool": "brave_web_search",
+                "input": {"query": "test"},
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "brave-search:brave_web_search" in result
+
+    def test_no_detail(self):
+        action = Action(id="1", kind="tool", title="unknown", detail={})
+        result = format_verbose_detail(action)
+        assert result is None
+
+    def test_none_detail(self):
+        action = Action(id="1", kind="tool", title="unknown", detail=None)
+        result = format_verbose_detail(action)
+        assert result is None
+
+    def test_fallback_string_arg(self):
+        action = Action(
+            id="1",
+            kind="tool",
+            title="CustomTool",
+            detail={
+                "name": "CustomTool",
+                "input": {"some_arg": "some value"},
+            },
+        )
+        result = format_verbose_detail(action)
+        assert result is not None
+        assert "some value" in result
+
+    def test_empty_command(self):
+        """Bash action with empty command returns None."""
+        action = Action(
+            id="1",
+            kind="command",
+            title="",
+            detail={"name": "Bash", "input": {"command": ""}},
+        )
+        result = format_verbose_detail(action)
+        assert result is None
+
+
+# --- MarkdownFormatter verbose mode tests ---
+
+
+def _make_action_state(
+    action_id: str,
+    kind: str = "tool",
+    title: str = "Read",
+    phase: str = "completed",
+    ok: bool = True,
+    detail: dict | None = None,
+) -> ActionState:
+    action = Action(id=action_id, kind=kind, title=title, detail=detail)
+    return ActionState(
+        action=action,
+        phase=phase,
+        ok=ok,
+        display_phase=phase,
+        completed=phase == "completed",
+        first_seen=0,
+        last_update=0,
+    )
+
+
+class TestMarkdownFormatterVerbose:
+    """Test MarkdownFormatter with verbose mode."""
+
+    def test_compact_mode_no_detail(self):
+        """Compact mode should not include detail lines."""
+        formatter = MarkdownFormatter(verbosity="compact")
+        state = ProgressState(
+            engine="claude",
+            action_count=1,
+            actions=(
+                _make_action_state(
+                    "1",
+                    detail={
+                        "name": "Read",
+                        "input": {"file_path": "/src/test.py"},
+                    },
+                ),
+            ),
+            resume=None,
+            resume_line=None,
+            context_line=None,
+        )
+        lines = formatter._format_actions(state)
+        assert len(lines) == 1
+        assert "→" not in lines[0]
+
+    def test_verbose_mode_adds_detail(self):
+        """Verbose mode should add a detail line below each action."""
+        formatter = MarkdownFormatter(verbosity="verbose")
+        state = ProgressState(
+            engine="claude",
+            action_count=1,
+            actions=(
+                _make_action_state(
+                    "1",
+                    detail={
+                        "name": "Read",
+                        "input": {"file_path": "/src/test.py"},
+                    },
+                ),
+            ),
+            resume=None,
+            resume_line=None,
+            context_line=None,
+        )
+        lines = formatter._format_actions(state)
+        assert len(lines) == 2
+        assert "→" in lines[1]
+        assert "test.py" in lines[1]
+
+    def test_verbose_detail_indented(self):
+        """Verbose detail lines should be indented with 2 spaces."""
+        formatter = MarkdownFormatter(verbosity="verbose")
+        state = ProgressState(
+            engine="claude",
+            action_count=1,
+            actions=(
+                _make_action_state(
+                    "1",
+                    detail={
+                        "name": "Grep",
+                        "input": {"pattern": "verbose"},
+                    },
+                ),
+            ),
+            resume=None,
+            resume_line=None,
+            context_line=None,
+        )
+        lines = formatter._format_actions(state)
+        assert lines[1].startswith("  ")
+
+    def test_verbose_no_detail_for_empty(self):
+        """Actions with no extractable detail should not get detail lines."""
+        formatter = MarkdownFormatter(verbosity="verbose")
+        state = ProgressState(
+            engine="claude",
+            action_count=1,
+            actions=(_make_action_state("1", detail={}),),
+            resume=None,
+            resume_line=None,
+            context_line=None,
+        )
+        lines = formatter._format_actions(state)
+        assert len(lines) == 1
+
+    def test_verbose_multiple_actions(self):
+        """Multiple actions each get their own detail lines."""
+        formatter = MarkdownFormatter(verbosity="verbose")
+        state = ProgressState(
+            engine="claude",
+            action_count=2,
+            actions=(
+                _make_action_state(
+                    "1",
+                    kind="command",
+                    title="git status",
+                    detail={"name": "Bash", "input": {"command": "git status"}},
+                ),
+                _make_action_state(
+                    "2",
+                    detail={
+                        "name": "Read",
+                        "input": {"file_path": "/src/main.py"},
+                    },
+                ),
+            ),
+            resume=None,
+            resume_line=None,
+            context_line=None,
+        )
+        lines = formatter._format_actions(state)
+        assert len(lines) == 4  # 2 action lines + 2 detail lines
+
+    def test_max_actions_respected_in_verbose(self):
+        """max_actions limits the number of actions shown in verbose mode."""
+        formatter = MarkdownFormatter(verbosity="verbose", max_actions=1)
+        state = ProgressState(
+            engine="claude",
+            action_count=2,
+            actions=(
+                _make_action_state(
+                    "1",
+                    detail={
+                        "name": "Read",
+                        "input": {"file_path": "/src/old.py"},
+                    },
+                ),
+                _make_action_state(
+                    "2",
+                    detail={
+                        "name": "Read",
+                        "input": {"file_path": "/src/new.py"},
+                    },
+                ),
+            ),
+            resume=None,
+            resume_line=None,
+            context_line=None,
+        )
+        lines = formatter._format_actions(state)
+        # Only the last action (max_actions=1) with its detail
+        assert len(lines) == 2
+        assert "new.py" in lines[1]

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **`/verbose` command + `[progress]` config** — per-chat verbose toggle shows tool details (file paths, commands, patterns) in progress messages; global verbosity/max_actions settings [#25](https://github.com/littlebearapps/untether/issues/25)
- **Pi context compaction** — `AutoCompactionStart`/`AutoCompactionEnd` rendered as progress actions with token counts [#26](https://github.com/littlebearapps/untether/issues/26)
- **`UNTETHER_CONFIG_PATH` env var** — override config file location for multi-instance setups [#27](https://github.com/littlebearapps/untether/issues/27)
- **Outline visibility fix** — outline text preserved in Pause & Outline Plan flow instead of being scrolled off by max_actions [#28](https://github.com/littlebearapps/untether/issues/28)
- **Footer spacing fix** — strip sulguk trailing `\n\n` that caused blank lines between footer items [#29](https://github.com/littlebearapps/untether/issues/29)
- **ExceptionGroup unwrapping, transport resilience, debug logging** [#30](https://github.com/littlebearapps/untether/issues/30)

Version bump: 0.24.0 → 0.25.0

## Test plan

- [x] 957 tests pass locally (80.79% coverage)
- [x] `ruff format` and `ruff check` clean
- [ ] All 9 CI checks pass (format, ruff, ty, pytest×3, build, lockfile, pip-audit, bandit, docs)
- [x] Dev files (`.envrc`, `.claude/settings.json`, `.claude/plans/`, `launch/`) excluded via `.gitignore`
- [x] Integration tested via `@untether_dev_bot`

Closes #25, #26, #27, #28, #29, #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)