### PR TITLE
chore: staging 0.35.0rc7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.0rc6"
+version = "0.35.0rc7"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.0rc6"
+version = "0.35.0rc7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump to 0.35.0rc7 for TestPyPI/staging.

Includes all changes from PR #160:
- Startup mode indicator (assistant/workspace/handoff)
- Bug fixes #158, #159 (startup crash, topics validation)
- Three-mode documentation coverage
- Dev branch workflow (dev→TestPyPI, master→PyPI)
- Claude Code can merge PRs to dev
- 20 new tests, docs updates