### PR TITLE
fix: /new command now cancels running processes (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `/usage` showed Claude subscription data in non-Claude engine chats — now gated to subscription-supported engines with an engine-specific error message [#215](https://github.com/littlebearapps/untether/issues/215)
 - `/export` showed duplicate "Session Started" headers for resumed sessions — deduplicated so only the first `StartedEvent` renders [#218](https://github.com/littlebearapps/untether/issues/218)
 - Gemini CLI prompt injection — prompts starting with `-` were parsed as flags when passed via `-p <value>`; now uses `--prompt=<value>` to bind the value directly [#219](https://github.com/littlebearapps/untether/issues/219)
+- `/new` command now cancels running processes before clearing sessions — previously only cleared resume tokens, leaving old Claude/Codex/OpenCode processes running (~400 MB each), worsening memory pressure and triggering earlyoom kills [#222](https://github.com/littlebearapps/untether/issues/222)
 
 ### changes
 
@@ -94,6 +95,7 @@
 - engine command gate tests: `/planmode` Claude-only, `/usage` subscription-engine-only [#215](https://github.com/littlebearapps/untether/issues/215), [#216](https://github.com/littlebearapps/untether/issues/216)
 - export dedup test: duplicate started events deduplicated in markdown export [#218](https://github.com/littlebearapps/untether/issues/218)
 - Gemini `--prompt=` build_args test [#219](https://github.com/littlebearapps/untether/issues/219)
+- 10 new `/new` cancellation tests: `_cancel_chat_tasks` helper (None, empty, matching, other chats, already cancelled, multiple), chat `/new` with running task, cancel-only no sessions, no tasks no sessions, topic `/new` with running task [#222](https://github.com/littlebearapps/untether/issues/222)
 
 ### docs
 

--- a/docs/how-to/chat-sessions.md
+++ b/docs/how-to/chat-sessions.md
@@ -41,7 +41,7 @@ The second message automatically continues the same session — no reply needed.
 
 ## Reset a session
 
-Use `/new` to clear the stored session for the current scope:
+Use `/new` to cancel any running task and clear the stored session for the current scope:
 
 - In a private chat, it resets the chat.
 - In a group, it resets **your** session in that chat.
@@ -81,7 +81,7 @@ When `session_mode = "chat"`, Untether stores resume tokens in a JSON state file
 
 When you send a message, Untether checks the state file for a stored resume token matching the current engine and scope (chat or topic). If found, the engine continues that session. If not, a new session starts.
 
-The `/new` command clears stored tokens for the current scope. Switching to a different engine also starts a fresh session (each engine has its own token).
+The `/new` command cancels any running task and clears stored tokens for the current scope. Switching to a different engine also starts a fresh session (each engine has its own token).
 
 !!! note "Handoff mode has no state file"
     In handoff mode (`session_mode = "stateless"`), no sessions are stored. Each message starts fresh. Continue a session by replying to its bot message or using `/continue`.

--- a/docs/how-to/topics.md
+++ b/docs/how-to/topics.md
@@ -84,7 +84,7 @@ Note: Outside topics (private chats or main group chats), `/ctx` binds the chat 
 
 ## Reset a topic session
 
-Use `/new` inside the topic to clear stored sessions for that thread.
+Use `/new` inside the topic to cancel any running task and clear stored sessions for that thread.
 
 ## Set a default engine per topic
 

--- a/docs/reference/commands-and-directives.md
+++ b/docs/reference/commands-and-directives.md
@@ -55,14 +55,14 @@ This line is parsed from replies and takes precedence over new directives. For b
 | `/config` | Interactive settings menu — plan mode, ask mode, verbose, engine, model, reasoning, trigger toggles with inline buttons. |
 | `/stats` | Per-engine session statistics — runs, actions, and duration for today, this week, and all time. Pass an engine name to filter (e.g. `/stats claude`). |
 | `/auth` | Headless device re-authentication for Codex — runs `codex login --device-auth` and sends the verification URL + device code. `/auth status` checks CLI availability. Codex-only. |
-| `/new` | Clear stored sessions for the current scope (topic/chat). |
+| `/new` | Cancel any running task and clear stored sessions for the current scope (topic/chat). |
 | `/continue [prompt]` | Resume the most recent session in the project directory. Picks up CLI-started sessions from Telegram. Optional prompt appended. Not supported for AMP. |
 
 Notes:
 
 - Outside topics, `/ctx` binds the chat context.
 - In topics, `/ctx` binds the topic context.
-- `/new` clears sessions but does **not** clear a bound context.
+- `/new` cancels running tasks and clears sessions but does **not** clear a bound context.
 - `/continue` uses the engine's native "continue" flag: `--continue` (Claude, OpenCode, Pi), `resume --last` (Codex), or `--resume latest` (Gemini).
 
 ## CLI

--- a/docs/reference/transports/telegram.md
+++ b/docs/reference/transports/telegram.md
@@ -249,7 +249,7 @@ Commands:
   project chats.
 - `/ctx` shows the bound context and stored session engines inside topics.
   Outside topics, `/ctx set ...` and `/ctx clear` bind the chat context.
-- `/new` inside a topic clears stored resume tokens for that topic.
+- `/new` inside a topic cancels any running task and clears stored resume tokens for that topic.
 
 State is stored in `telegram_topics_state.json` alongside the config file.
 Delete it to reset all topic bindings and stored sessions.

--- a/docs/tutorials/conversation-modes.md
+++ b/docs/tutorials/conversation-modes.md
@@ -38,7 +38,7 @@ To pin a project or branch for the chat, use:
 !!! user "You"
     /ctx set <project> [@branch]
 
-`/new` clears the session but keeps the bound context.
+`/new` cancels any running task and clears the session, but keeps the bound context.
 
 Tip: set a default engine for this chat with `/agent set claude`.
 

--- a/docs/tutorials/first-run.md
+++ b/docs/tutorials/first-run.md
@@ -105,7 +105,7 @@ Untether extracts the resume token from the message you replied to and continues
     Use `show_resume_line = true` if you want this behavior all the time.
 
 !!! tip "Reset with /new"
-    `/new` clears stored sessions for the current chat or topic.
+    `/new` cancels any running task and clears stored sessions for the current chat or topic.
 
 ## 6. Cancel a run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.0rc11"
+version = "0.35.0rc12"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/untether/telegram/commands/topics.py
+++ b/src/untether/telegram/commands/topics.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...context import RunContext
+from ...logging import get_logger
 from ...markdown import MarkdownParts
+from ...runner_bridge import RunningTasks
 from ...transport_runtime import TransportRuntime
 from ...transport import RenderedMessage, SendOptions
 from ..chat_prefs import ChatPrefsStore
@@ -31,6 +33,25 @@ from .reply import make_reply
 
 if TYPE_CHECKING:
     from ..bridge import TelegramBridgeConfig
+
+logger = get_logger(__name__)
+
+
+def _cancel_chat_tasks(
+    chat_id: int,
+    running_tasks: RunningTasks | None,
+) -> int:
+    """Cancel all running tasks for a chat.
+
+    Returns the number of tasks cancelled.
+    """
+    cancelled = 0
+    if running_tasks:
+        for ref, task in running_tasks.items():
+            if ref.channel_id == chat_id and not task.cancel_requested.is_set():
+                task.cancel_requested.set()
+                cancelled += 1
+    return cancelled
 
 
 async def _handle_ctx_command(
@@ -225,6 +246,7 @@ async def _handle_new_command(
     *,
     resolved_scope: str | None = None,
     scope_chat_ids: frozenset[int] | None = None,
+    running_tasks: RunningTasks | None = None,
 ) -> None:
     reply = make_reply(cfg, msg)
     error = _topics_command_error(
@@ -240,8 +262,12 @@ async def _handle_new_command(
     if tkey is None:
         await reply(text="this command only works inside a topic.")
         return
+    cancelled = _cancel_chat_tasks(msg.chat_id, running_tasks)
+    if cancelled:
+        logger.info("new.cancelled_running", chat_id=msg.chat_id, count=cancelled)
     await store.clear_sessions(*tkey)
-    await reply(text="\N{BROOM} cleared stored sessions for this topic.")
+    label = "cancelled run and cleared" if cancelled else "cleared"
+    await reply(text=f"\N{BROOM} {label} stored sessions for this topic.")
 
 
 async def _handle_chat_new_command(
@@ -249,16 +275,22 @@ async def _handle_chat_new_command(
     msg: TelegramIncomingMessage,
     store: ChatSessionStore,
     session_key: tuple[int, int | None] | None,
+    running_tasks: RunningTasks | None = None,
 ) -> None:
     reply = make_reply(cfg, msg)
-    if session_key is None:
+    cancelled = _cancel_chat_tasks(msg.chat_id, running_tasks)
+    if cancelled:
+        logger.info("new.cancelled_running", chat_id=msg.chat_id, count=cancelled)
+    if session_key is None and not cancelled:
         await reply(text="no stored sessions to clear for this chat.")
         return
-    await store.clear_sessions(session_key[0], session_key[1])
+    if session_key is not None:
+        await store.clear_sessions(session_key[0], session_key[1])
+    label = "cancelled run and cleared" if cancelled else "cleared"
     if msg.chat_type == "private":
-        text = "\N{BROOM} cleared stored sessions for this chat."
+        text = f"\N{BROOM} {label} stored sessions for this chat."
     else:
-        text = "\N{BROOM} cleared stored sessions for you in this chat."
+        text = f"\N{BROOM} {label} stored sessions for you in this chat."
     await reply(text=text)
 
 

--- a/src/untether/telegram/loop.py
+++ b/src/untether/telegram/loop.py
@@ -225,6 +225,7 @@ def _dispatch_builtin_command(
                 topic_store,
                 resolved_scope=resolved_scope,
                 scope_chat_ids=scope_chat_ids,
+                running_tasks=ctx.running_tasks,
             )
         elif command_id == "topic":
             handler = partial(
@@ -442,6 +443,7 @@ class TelegramCommandContext:
     scope_chat_ids: frozenset[int]
     reply: Callable[..., Awaitable[None]]
     task_group: TaskGroup
+    running_tasks: RunningTasks | None = None
 
 
 def _classify_message(
@@ -1877,16 +1879,20 @@ async def run_main_loop(
                                 state.topic_store,
                                 resolved_scope=state.resolved_topics_scope,
                                 scope_chat_ids=state.topics_chat_ids,
+                                running_tasks=state.running_tasks,
                             )
                         )
                         return
                     if state.chat_session_store is not None:
                         tg.start_soon(
-                            handle_chat_new_command,
-                            cfg,
-                            msg,
-                            state.chat_session_store,
-                            chat_session_key,
+                            partial(
+                                handle_chat_new_command,
+                                cfg,
+                                msg,
+                                state.chat_session_store,
+                                chat_session_key,
+                                running_tasks=state.running_tasks,
+                            )
                         )
                         return
                     if state.topic_store is not None:
@@ -1898,6 +1904,7 @@ async def run_main_loop(
                                 state.topic_store,
                                 resolved_scope=state.resolved_topics_scope,
                                 scope_chat_ids=state.topics_chat_ids,
+                                running_tasks=state.running_tasks,
                             )
                         )
                         return
@@ -1949,6 +1956,7 @@ async def run_main_loop(
                         scope_chat_ids=state.topics_chat_ids,
                         reply=reply,
                         task_group=tg,
+                        running_tasks=state.running_tasks,
                     ),
                     command_id=command_id,
                 ):

--- a/tests/test_command_engine_gates.py
+++ b/tests/test_command_engine_gates.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 

--- a/tests/test_telegram_topics_command.py
+++ b/tests/test_telegram_topics_command.py
@@ -3,12 +3,14 @@ from pathlib import Path
 
 import pytest
 
+from untether.runner_bridge import RunningTask
 from untether.settings import TelegramTopicsSettings
 from untether.config import ProjectConfig, ProjectsConfig
 from untether.runners.mock import Return, ScriptRunner
 from untether.telegram.chat_sessions import ChatSessionStore
 from untether.telegram.chat_prefs import ChatPrefsStore, resolve_prefs_path
 from untether.telegram.commands.topics import (
+    _cancel_chat_tasks,
     _handle_chat_ctx_command,
     _handle_chat_new_command,
     _handle_ctx_command,
@@ -17,6 +19,7 @@ from untether.telegram.commands.topics import (
 )
 from untether.telegram.topic_state import TopicStateStore
 from untether.telegram.types import TelegramIncomingMessage
+from untether.transport import MessageRef
 from tests.telegram_fakes import (
     DEFAULT_ENGINE_ID,
     FakeTransport,
@@ -187,3 +190,154 @@ async def test_topic_command_requires_args(tmp_path: Path) -> None:
 
     text = transport.send_calls[-1]["message"].text
     assert "usage: /topic" in text
+
+
+# --- /new cancellation tests ---
+
+
+def test_cancel_chat_tasks_none() -> None:
+    """No-op when running_tasks is None."""
+    assert _cancel_chat_tasks(123, None) == 0
+
+
+def test_cancel_chat_tasks_empty() -> None:
+    """No-op when no tasks running."""
+    assert _cancel_chat_tasks(123, {}) == 0
+
+
+def test_cancel_chat_tasks_cancels_matching() -> None:
+    """Cancels tasks matching the chat_id."""
+    task = RunningTask()
+    ref = MessageRef(channel_id=123, message_id=1)
+    running_tasks = {ref: task}
+
+    cancelled = _cancel_chat_tasks(123, running_tasks)
+
+    assert cancelled == 1
+    assert task.cancel_requested.is_set()
+
+
+def test_cancel_chat_tasks_skips_other_chats() -> None:
+    """Does not cancel tasks in other chats."""
+    task = RunningTask()
+    ref = MessageRef(channel_id=999, message_id=1)
+    running_tasks = {ref: task}
+
+    cancelled = _cancel_chat_tasks(123, running_tasks)
+
+    assert cancelled == 0
+    assert not task.cancel_requested.is_set()
+
+
+def test_cancel_chat_tasks_skips_already_cancelled() -> None:
+    """Does not double-cancel already-cancelled tasks."""
+    task = RunningTask()
+    task.cancel_requested.set()
+    ref = MessageRef(channel_id=123, message_id=1)
+    running_tasks = {ref: task}
+
+    cancelled = _cancel_chat_tasks(123, running_tasks)
+
+    assert cancelled == 0
+
+
+def test_cancel_chat_tasks_multiple() -> None:
+    """Cancels multiple tasks in the same chat."""
+    task1 = RunningTask()
+    task2 = RunningTask()
+    ref1 = MessageRef(channel_id=123, message_id=1)
+    ref2 = MessageRef(channel_id=123, message_id=2)
+    running_tasks = {ref1: task1, ref2: task2}
+
+    cancelled = _cancel_chat_tasks(123, running_tasks)
+
+    assert cancelled == 2
+    assert task1.cancel_requested.is_set()
+    assert task2.cancel_requested.is_set()
+
+
+@pytest.mark.anyio
+async def test_chat_new_command_cancels_running(tmp_path: Path) -> None:
+    """'/new' cancels a running task and mentions it in the reply."""
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    store = ChatSessionStore(tmp_path / "sessions.json")
+    msg = _msg("/new", chat_type="private")
+
+    task = RunningTask()
+    ref = MessageRef(channel_id=msg.chat_id, message_id=42)
+    running_tasks = {ref: task}
+
+    await _handle_chat_new_command(
+        cfg, msg, store, session_key=(msg.chat_id, None), running_tasks=running_tasks
+    )
+
+    assert task.cancel_requested.is_set()
+    text = transport.send_calls[-1]["message"].text
+    assert "cancelled run" in text
+    assert "cleared" in text
+
+
+@pytest.mark.anyio
+async def test_chat_new_command_cancel_only_no_sessions(tmp_path: Path) -> None:
+    """'/new' with running task but no stored sessions still succeeds."""
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    store = ChatSessionStore(tmp_path / "sessions.json")
+    msg = _msg("/new", chat_type="private")
+
+    task = RunningTask()
+    ref = MessageRef(channel_id=msg.chat_id, message_id=42)
+    running_tasks = {ref: task}
+
+    await _handle_chat_new_command(
+        cfg, msg, store, session_key=None, running_tasks=running_tasks
+    )
+
+    assert task.cancel_requested.is_set()
+    text = transport.send_calls[-1]["message"].text
+    assert "cancelled run" in text
+
+
+@pytest.mark.anyio
+async def test_chat_new_command_no_tasks_no_sessions(tmp_path: Path) -> None:
+    """'/new' with no running tasks and no sessions shows 'no stored sessions'."""
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    store = ChatSessionStore(tmp_path / "sessions.json")
+    msg = _msg("/new", chat_type="private")
+
+    await _handle_chat_new_command(cfg, msg, store, session_key=None, running_tasks={})
+
+    text = transport.send_calls[-1]["message"].text
+    assert "no stored sessions" in text
+
+
+@pytest.mark.anyio
+async def test_new_command_cancels_running_in_topic(tmp_path: Path) -> None:
+    """'/new' in topic mode cancels running tasks."""
+    transport = FakeTransport()
+    cfg = replace(
+        make_cfg(transport),
+        topics=TelegramTopicsSettings(enabled=True, scope="all"),
+    )
+    store = TopicStateStore(tmp_path / "topics.json")
+    msg = _msg("/new", thread_id=10, chat_type="supergroup")
+
+    task = RunningTask()
+    ref = MessageRef(channel_id=msg.chat_id, message_id=42)
+    running_tasks = {ref: task}
+
+    await _handle_new_command(
+        cfg,
+        msg,
+        store=store,
+        resolved_scope="all",
+        scope_chat_ids=frozenset({msg.chat_id}),
+        running_tasks=running_tasks,
+    )
+
+    assert task.cancel_requested.is_set()
+    text = transport.send_calls[-1]["message"].text
+    assert "cancelled run" in text
+    assert "cleared" in text

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.0rc11"
+version = "0.35.0rc12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- `/new` now cancels all running tasks for the chat before clearing sessions
- Previously only cleared resume tokens, leaving old processes running (~400 MB each)
- This leaked processes and worsened memory pressure, contributing to earlyoom kills (rc=143)
- Reply message shows "cancelled run and cleared" when a process was killed

Closes #222

## Changes

- `src/untether/telegram/commands/topics.py` — `_cancel_chat_tasks()` helper; updated both `/new` handlers
- `src/untether/telegram/loop.py` — `running_tasks` in `TelegramCommandContext`; passed through all call sites
- `tests/test_telegram_topics_command.py` — 10 new tests
- 7 docs updated to reflect new `/new` behaviour
- Bumped to `0.35.0rc12`

## Test plan

- [x] Unit tests: 1803 passed, 81.37% coverage
- [x] Integration tested via `@untether_dev_bot`:
  - Claude: `/new` while running → cancelled + cleared
  - Codex: `/new` while running → cancelled + cleared
  - OpenCode: `/new` while running → cancelled + cleared
  - No running task: shows "cleared stored sessions"
- [x] Logs show `new.cancelled_running` event with chat_id and count
- [x] No errors or warnings in dev bot logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)