### PR TITLE
fix: suppress auto-continue on signal deaths (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `/export` showed duplicate "Session Started" headers for resumed sessions — deduplicated so only the first `StartedEvent` renders [#218](https://github.com/littlebearapps/untether/issues/218)
 - Gemini CLI prompt injection — prompts starting with `-` were parsed as flags when passed via `-p <value>`; now uses `--prompt=<value>` to bind the value directly [#219](https://github.com/littlebearapps/untether/issues/219)
 - `/new` command now cancels running processes before clearing sessions — previously only cleared resume tokens, leaving old Claude/Codex/OpenCode processes running (~400 MB each), worsening memory pressure and triggering earlyoom kills [#222](https://github.com/littlebearapps/untether/issues/222)
+- auto-continue no longer triggers on signal deaths (rc=143/SIGTERM, rc=137/SIGKILL) — earlyoom kills have `last_event_type=user` which matched the upstream bug detection, causing a death spiral where 4 killed sessions were immediately respawned into the same memory pressure [#222](https://github.com/littlebearapps/untether/issues/222)
 
 ### changes
 
@@ -96,6 +97,7 @@
 - export dedup test: duplicate started events deduplicated in markdown export [#218](https://github.com/littlebearapps/untether/issues/218)
 - Gemini `--prompt=` build_args test [#219](https://github.com/littlebearapps/untether/issues/219)
 - 10 new `/new` cancellation tests: `_cancel_chat_tasks` helper (None, empty, matching, other chats, already cancelled, multiple), chat `/new` with running task, cancel-only no sessions, no tasks no sessions, topic `/new` with running task [#222](https://github.com/littlebearapps/untether/issues/222)
+- 12 new auto-continue signal death tests: `_is_signal_death` (SIGTERM, SIGKILL, negative, normal, None), `_should_auto_continue` (rc=143, rc=137, rc=-9, rc=-15 blocked; rc=0, rc=None, rc=1 allowed), `proc_returncode` default on `JsonlStreamState` [#222](https://github.com/littlebearapps/untether/issues/222)
 
 ### docs
 

--- a/src/untether/runner.py
+++ b/src/untether/runner.py
@@ -206,6 +206,7 @@ class JsonlStreamState:
         default_factory=lambda: deque(maxlen=10)
     )
     stderr_capture: list[str] = field(default_factory=list)
+    proc_returncode: int | None = None
 
 
 class JsonlSubprocessRunner(BaseRunner):
@@ -926,6 +927,7 @@ class JsonlSubprocessRunner(BaseRunner):
                 reader_done.set()
 
             rc = await proc.wait()
+            stream.proc_returncode = rc
             logger.info("subprocess.exit", pid=proc.pid, rc=rc)
             if stream.did_emit_completed:
                 return

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -151,6 +151,19 @@ def _load_auto_continue_settings():
         return AutoContinueSettings()
 
 
+def _is_signal_death(rc: int | None) -> bool:
+    """Return True if the return code indicates the process was killed by a signal.
+
+    rc=143 (SIGTERM/128+15), rc=137 (SIGKILL/128+9), or negative values
+    (Python's representation of signal death, e.g. -9 for SIGKILL).
+    """
+    if rc is None:
+        return False
+    if rc < 0:
+        return True  # negative = killed by signal (Python convention)
+    return rc > 128  # 128+N = killed by signal N (shell convention)
+
+
 def _should_auto_continue(
     *,
     last_event_type: str | None,
@@ -159,12 +172,17 @@ def _should_auto_continue(
     resume_value: str | None,
     auto_continued_count: int,
     max_retries: int,
+    proc_returncode: int | None = None,
 ) -> bool:
     """Detect Claude Code silent session termination bug (#34142, #30333).
 
     Returns True when the last raw JSONL event was a tool_result ("user")
     meaning Claude never got a turn to process the results before the CLI
     exited.
+
+    Does NOT trigger on signal deaths (SIGTERM/SIGKILL from earlyoom or
+    other external killers) — those have rc>128 or rc<0.  The upstream bug
+    exits with rc=0.
     """
     if cancelled:
         return False
@@ -173,6 +191,8 @@ def _should_auto_continue(
     if last_event_type != "user":
         return False
     if not resume_value:
+        return False
+    if _is_signal_death(proc_returncode):
         return False
     return auto_continued_count < max_retries
 
@@ -1890,6 +1910,7 @@ async def handle_message(
     ac_settings = _load_auto_continue_settings()
     _ac_resume = completed.resume or outcome.resume
     _ac_last_event = edits.stream.last_event_type if edits.stream else None
+    _ac_proc_rc = edits.stream.proc_returncode if edits.stream else None
     if ac_settings.enabled and _should_auto_continue(
         last_event_type=_ac_last_event,
         engine=runner.engine,
@@ -1897,6 +1918,7 @@ async def handle_message(
         resume_value=_ac_resume.value if _ac_resume else None,
         auto_continued_count=_auto_continued_count,
         max_retries=ac_settings.max_retries,
+        proc_returncode=_ac_proc_rc,
     ):
         logger.warning(
             "session.auto_continue",

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -4002,6 +4002,7 @@ class TestShouldAutoContinue:
         resume_value: str | None = "c3f20b1d-58f9-4173-a68e-8735256cf9ae",
         auto_continued_count: int = 0,
         max_retries: int = 1,
+        proc_returncode: int | None = 0,
     ) -> bool:
         from untether.runner_bridge import _should_auto_continue
 
@@ -4012,6 +4013,7 @@ class TestShouldAutoContinue:
             resume_value=resume_value,
             auto_continued_count=auto_continued_count,
             max_retries=max_retries,
+            proc_returncode=proc_returncode,
         )
 
     def test_detects_bug_scenario(self):
@@ -4046,3 +4048,63 @@ class TestShouldAutoContinue:
 
     def test_disabled_when_max_retries_zero(self):
         assert self._call(auto_continued_count=0, max_retries=0) is False
+
+    def test_skips_sigterm_death(self):
+        """rc=143 (SIGTERM/earlyoom) — do NOT auto-continue."""
+        assert self._call(proc_returncode=143) is False
+
+    def test_skips_sigkill_death(self):
+        """rc=137 (SIGKILL) — do NOT auto-continue."""
+        assert self._call(proc_returncode=137) is False
+
+    def test_skips_negative_signal(self):
+        """rc=-9 (Python SIGKILL) — do NOT auto-continue."""
+        assert self._call(proc_returncode=-9) is False
+
+    def test_skips_negative_sigterm(self):
+        """rc=-15 (Python SIGTERM) — do NOT auto-continue."""
+        assert self._call(proc_returncode=-15) is False
+
+    def test_allows_rc_zero(self):
+        """rc=0 (upstream bug #34142) — DO auto-continue."""
+        assert self._call(proc_returncode=0) is True
+
+    def test_allows_rc_none(self):
+        """rc=None (unknown) — DO auto-continue (conservative)."""
+        assert self._call(proc_returncode=None) is True
+
+    def test_allows_rc_one(self):
+        """rc=1 (generic error) — DO auto-continue."""
+        assert self._call(proc_returncode=1) is True
+
+
+class TestIsSignalDeath:
+    """Tests for _is_signal_death helper."""
+
+    def test_sigterm(self):
+        from untether.runner_bridge import _is_signal_death
+
+        assert _is_signal_death(143) is True  # 128 + 15
+
+    def test_sigkill(self):
+        from untether.runner_bridge import _is_signal_death
+
+        assert _is_signal_death(137) is True  # 128 + 9
+
+    def test_negative_signal(self):
+        from untether.runner_bridge import _is_signal_death
+
+        assert _is_signal_death(-9) is True
+        assert _is_signal_death(-15) is True
+
+    def test_normal_exit(self):
+        from untether.runner_bridge import _is_signal_death
+
+        assert _is_signal_death(0) is False
+        assert _is_signal_death(1) is False
+        assert _is_signal_death(2) is False
+
+    def test_none(self):
+        from untether.runner_bridge import _is_signal_death
+
+        assert _is_signal_death(None) is False

--- a/tests/test_exec_runner.py
+++ b/tests/test_exec_runner.py
@@ -637,6 +637,7 @@ def test_jsonl_stream_state_defaults() -> None:
     assert stream.event_count == 0
     assert len(stream.recent_events) == 0
     assert stream.stderr_capture == []
+    assert stream.proc_returncode is None
 
 
 def test_jsonl_stream_state_recent_events_ring_buffer() -> None:


### PR DESCRIPTION
## Summary

Auto-continue was causing a death spiral when earlyoom killed Claude sessions. Now suppressed on signal deaths (rc=143/SIGTERM, rc=137/SIGKILL).

**The death spiral**: earlyoom kills 4 sessions → all have `last_event_type=user` → auto-continue respawns all 4 (~5 GB new processes) → earlyoom kills them again → repeat.

**The fix**: `_should_auto_continue` now checks `proc_returncode` — signal deaths (rc>128 or rc<0) are excluded. The upstream bug #34142/#30333 exits with rc=0, so auto-continue still triggers for its intended purpose.

Closes #222

## Changes

- `src/untether/runner_bridge.py` — `_is_signal_death()` helper + `proc_returncode` param on `_should_auto_continue`
- `src/untether/runner.py` — `proc_returncode` field on `JsonlStreamState`, set after `proc.wait()`
- `tests/test_exec_bridge.py` — 12 new tests (7 auto-continue + 5 signal death)
- `tests/test_exec_runner.py` — default assertion for `proc_returncode`

## Test plan

- [x] 1815 tests pass, 81.37% coverage
- [x] Existing auto-continue tests still pass (rc=0 upstream bug still detected)
- [x] Signal deaths (143, 137, -9, -15) correctly blocked
- [x] Normal exits (0, 1, None) correctly allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)