### PR TITLE
docs: audit fixes for v0.35.0 release

### DIFF
--- a/.claude/rules/control-channel.md
+++ b/.claude/rules/control-channel.md
@@ -20,7 +20,7 @@ _SESSION_STDIN: dict[str, anyio.abc.ByteSendStream]   # session_id -> stdin
 _REQUEST_TO_SESSION: dict[str, str]                    # request_id -> session_id
 _DISCUSS_COOLDOWN: dict[str, tuple[float, int]]        # session_id -> (timestamp, deny_count)
 _DISCUSS_APPROVED: set[str]                            # sessions with post-outline approval
-_PENDING_ASK_REQUESTS: dict[str, str]                  # request_id -> question text
+_PENDING_ASK_REQUESTS: dict[str, tuple[int, str]]       # request_id -> (channel_id, question)
 ```
 
 - Register on first `system.init` event (when session_id is known)
@@ -29,10 +29,10 @@ _PENDING_ASK_REQUESTS: dict[str, str]                  # request_id -> question 
 
 ## Auto-approve
 
-Non-interactive tools are auto-approved without showing buttons:
-- List maintained in `_AUTO_APPROVE_TOOLS` set
-- `ControlInitializeRequest`: always auto-approved immediately
-- Tool requests: check `tool_name in _AUTO_APPROVE_TOOLS`
+Non-interactive requests are auto-approved without showing buttons:
+- Request types in `_AUTO_APPROVE_TYPES` tuple: `ControlInitializeRequest`, `ControlHookCallbackRequest`, `ControlMcpMessageRequest`, `ControlRewindFilesRequest`, `ControlInterruptRequest`
+- Tool requests: auto-approved UNLESS `tool_name in _TOOLS_REQUIRING_APPROVAL`
+- `_TOOLS_REQUIRING_APPROVAL = {"ExitPlanMode", "AskUserQuestion"}`
 - `ExitPlanMode`: NEVER auto-approved — always show Telegram buttons
 - `AskUserQuestion`: NEVER auto-approved — shown in Telegram for user to reply with text
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Untether adds interactive permission control, plan mode support, and several UX 
 - **Auto-continue** — detects Claude Code sessions that exit after receiving tool results without processing them (upstream bugs #34142, #30333) and auto-resumes; suppressed on signal deaths (rc=143/SIGTERM, rc=137/SIGKILL) to prevent death spirals under memory pressure; configurable via `[auto_continue]` with `enabled` (default true) and `max_retries` (default 1)
 - **File upload deduplication** — auto-appends `_1`, `_2`, … when target file exists, instead of requiring `--force`; media groups without captions auto-save to `incoming/`
 - **Agent-initiated file delivery (outbox)** — agents write files to `.untether-outbox/` during a run; Untether sends them as Telegram documents on completion with `📎` captions; deny-glob security, size limits, file count cap, auto-cleanup; `[transports.telegram.files]` config
+- **Progress persistence** — active progress messages persisted to `active_progress.json`; on restart, orphan messages edited to "⚠️ interrupted by restart" with keyboard removed
 - **Resume line formatting** — visual separation with blank line and ↩️ prefix in final message footer
 - **`/continue`** — cross-environment resume; pick up the most recent CLI session from Telegram using each engine's native continue flag (`--continue`, `resume --last`, `--resume latest`); supported for Claude, Codex, OpenCode, Pi, Gemini (not AMP)
 
@@ -324,7 +325,7 @@ Before tagging a release:
 
 ## Documentation screenshots
 
-47 screenshots in `docs/assets/screenshots/` with a tracking checklist in `CAPTURES.md`. README uses a composite hero collage (`hero-collage.jpg`) built with ImageMagick for mobile responsiveness. Doc files use HTML `<img>` tags with `width="360"` and `loading="lazy"` (works in both GitHub and MkDocs). 14 screenshots are still missing and commented out with `<!-- TODO: capture screenshot -->` markers.
+48 screenshots in `docs/assets/screenshots/` with a tracking checklist in `CAPTURES.md`. README uses a composite hero collage (`hero-collage.jpg`) built with ImageMagick for mobile responsiveness. Doc files use HTML `<img>` tags with `width="360"` and `loading="lazy"` (works in both GitHub and MkDocs). 14 screenshots are still missing and commented out with `<!-- TODO: capture screenshot -->` markers.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Pre-release doc audit fixes:

- Fix `_PENDING_ASK_REQUESTS` type annotation in control-channel rule (`dict[str, tuple[int, str]]` not `dict[str, str]`)
- Fix auto-approve mechanism docs: use actual variable names (`_AUTO_APPROVE_TYPES`, `_TOOLS_REQUIRING_APPROVAL`) instead of non-existent `_AUTO_APPROVE_TOOLS`
- Update screenshot count 47 -> 48
- Add progress persistence feature to CLAUDE.md features list

## Test plan

- [ ] CI passes (docs-only change, no code impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)