### PR TITLE
fix: v0.35.1 — security hardening, stall false positive reduction, uptime reset

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -14,9 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger website rebuild
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           curl -s -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.WEBSITE_DISPATCH_TOKEN }}" \
             https://api.github.com/repos/littlebearapps/littlebearapps.com/dispatches \
-            -d '{"event_type":"release-published","client_payload":{"repo":"untether","tag":"${{ github.event.release.tag_name }}"}}'
+            -d "$(jq -n --arg tag "$TAG_NAME" '{"event_type":"release-published","client_payload":{"repo":"untether","tag":$tag}}')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,13 @@
 # changelog
 
-## v0.35.1 (unreleased)
-
-### security
-
-- validate callback query sender in group chats — reject button presses from unauthorised users; prevents malicious group members from approving/denying other users' tool requests [#192](https://github.com/littlebearapps/untether/issues/192)
-  - also validate sender on cancel button callback — the cancel handler was routed directly, bypassing the dispatch validation
-- escape release tag name in notify-website CI workflow — use `jq` for proper JSON encoding instead of direct interpolation, preventing JSON injection from crafted tag names [#193](https://github.com/littlebearapps/untether/issues/193)
-- sanitise flag-like prompts in Gemini and AMP runners — prompts starting with `-` are space-prefixed to prevent CLI flag injection; moved `sanitize_prompt()` to base runner class for all engines [#194](https://github.com/littlebearapps/untether/issues/194)
+## v0.35.1 (2026-04-03)
 
 ### fixes
+
+- **security:** validate callback query sender in group chats — reject button presses from unauthorised users; prevents malicious group members from approving/denying other users' tool requests [#192](https://github.com/littlebearapps/untether/issues/192)
+  - also validate sender on cancel button callback — the cancel handler was routed directly, bypassing the dispatch validation
+- **security:** escape release tag name in notify-website CI workflow — use `jq` for proper JSON encoding instead of direct interpolation, preventing JSON injection from crafted tag names [#193](https://github.com/littlebearapps/untether/issues/193)
+- **security:** sanitise flag-like prompts in Gemini and AMP runners — prompts starting with `-` are space-prefixed to prevent CLI flag injection; moved `sanitize_prompt()` to base runner class for all engines [#194](https://github.com/littlebearapps/untether/issues/194)
 
 - reduce stall warning false positives during Agent subagent work — tree CPU tracking across process descendants, child-aware 15 min threshold when child processes or elevated TCP detected, early diagnostic collection for CPU baseline, total stall warning counter that persists through recovery, improved "Waiting for child processes" notification messages [#264](https://github.com/littlebearapps/untether/issues/264)
 - `/ping` uptime now resets on service restart — previously the module-level start time was cached across `/restart` commands; now `reset_uptime()` is called on each service start [#234](https://github.com/littlebearapps/untether/issues/234)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### security
 
 - validate callback query sender in group chats — reject button presses from unauthorised users; prevents malicious group members from approving/denying other users' tool requests [#192](https://github.com/littlebearapps/untether/issues/192)
+  - also validate sender on cancel button callback — the cancel handler was routed directly, bypassing the dispatch validation
 - escape release tag name in notify-website CI workflow — use `jq` for proper JSON encoding instead of direct interpolation, preventing JSON injection from crafted tag names [#193](https://github.com/littlebearapps/untether/issues/193)
 - sanitise flag-like prompts in Gemini and AMP runners — prompts starting with `-` are space-prefixed to prevent CLI flag injection; moved `sanitize_prompt()` to base runner class for all engines [#194](https://github.com/littlebearapps/untether/issues/194)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # changelog
 
+## v0.35.1 (unreleased)
+
+### security
+
+- validate callback query sender in group chats — reject button presses from unauthorised users; prevents malicious group members from approving/denying other users' tool requests [#192](https://github.com/littlebearapps/untether/issues/192)
+- escape release tag name in notify-website CI workflow — use `jq` for proper JSON encoding instead of direct interpolation, preventing JSON injection from crafted tag names [#193](https://github.com/littlebearapps/untether/issues/193)
+- sanitise flag-like prompts in Gemini and AMP runners — prompts starting with `-` are space-prefixed to prevent CLI flag injection; moved `sanitize_prompt()` to base runner class for all engines [#194](https://github.com/littlebearapps/untether/issues/194)
+
+### fixes
+
+- reduce stall warning false positives during Agent subagent work — tree CPU tracking across process descendants, child-aware 15 min threshold when child processes or elevated TCP detected, early diagnostic collection for CPU baseline, total stall warning counter that persists through recovery, improved "Waiting for child processes" notification messages [#264](https://github.com/littlebearapps/untether/issues/264)
+- `/ping` uptime now resets on service restart — previously the module-level start time was cached across `/restart` commands; now `reset_uptime()` is called on each service start [#234](https://github.com/littlebearapps/untether/issues/234)
+
 ## v0.35.0 (2026-03-31)
 
 ### fixes

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 <p align="center">
   <a href="https://github.com/littlebearapps/untether/actions/workflows/ci.yml"><img src="https://github.com/littlebearapps/untether/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://pypi.org/project/untether/"><img src="https://img.shields.io/pypi/v/untether" alt="PyPI" /></a>
+  <a href="https://pypi.org/project/untether/"><img src="https://img.shields.io/pypi/dm/untether" alt="PyPI Downloads" /></a>
   <a href="https://pypi.org/project/untether/"><img src="https://img.shields.io/pypi/pyversions/untether" alt="Python" /></a>
   <a href="https://github.com/littlebearapps/untether/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License" /></a>
 </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.0"
+version = "0.35.1"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/untether/runner.py
+++ b/src/untether/runner.py
@@ -303,6 +303,18 @@ class JsonlSubprocessRunner(BaseRunner):
         message = f"invalid JSON from {self.tag()}; ignoring line"
         return [self.note_event(message, state=state, detail={"line": line})]
 
+    @staticmethod
+    def sanitize_prompt(prompt: str) -> str:
+        """Prevent flag injection by prepending a space to flag-like prompts.
+
+        If a user prompt starts with ``-``, CLI argument parsers may interpret
+        it as a flag.  Prepending a space neutralises this without altering the
+        prompt semantics for the engine.
+        """
+        if prompt.startswith("-"):
+            return f" {prompt}"
+        return prompt
+
     def decode_jsonl(self, *, line: bytes) -> Any | None:
         text = line.decode("utf-8", errors="replace")
         try:

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -730,6 +730,7 @@ class ProgressEdits:
         self._last_event_at: float = clock()
         self._stall_warned: bool = False
         self._stall_warn_count: int = 0
+        self._total_stall_warn_count: int = 0
         self._last_stall_warn_at: float = 0.0
         self._peak_idle: float = 0.0
         self._prev_diag: Any = None
@@ -763,14 +764,36 @@ class ProgressEdits:
 
     async def _stall_monitor(self) -> None:
         """Periodically check for event stalls, log diagnostics, and notify."""
-        from .utils.proc_diag import collect_proc_diag, is_cpu_active
+        from .utils.proc_diag import (
+            collect_proc_diag,
+            is_cpu_active,
+            is_tree_cpu_active,
+        )
 
         while True:
             await anyio.sleep(self._stall_check_interval)
             elapsed = self.clock() - self._last_event_at
             self._peak_idle = max(self._peak_idle, elapsed)
 
-            # Use longer threshold when waiting for user approval or running a tool
+            # Collect diagnostics on every cycle so we always have a CPU
+            # baseline for the next check (fixes cpu_active=None on first
+            # stall warning) and can use child/TCP info for threshold
+            # selection.
+            diag = collect_proc_diag(self.pid) if self.pid else None
+            cpu_active = (
+                is_cpu_active(self._prev_diag, diag)
+                if self._prev_diag and diag
+                else None
+            )
+            tree_active = (
+                is_tree_cpu_active(self._prev_diag, diag)
+                if self._prev_diag and diag
+                else None
+            )
+            self._prev_diag = diag
+
+            # Use longer threshold when waiting for user approval, running a
+            # tool, or when child processes are active (Agent subagents).
             mcp_server = self._has_running_mcp_tool()
             if self._has_pending_approval():
                 threshold = self._STALL_THRESHOLD_APPROVAL
@@ -778,6 +801,9 @@ class ProgressEdits:
             elif mcp_server is not None:
                 threshold = self._STALL_THRESHOLD_MCP_TOOL
                 threshold_reason = "running_mcp_tool"
+            elif self._has_active_children(diag):
+                threshold = self._STALL_THRESHOLD_SUBAGENT
+                threshold_reason = "active_children"
             elif self._has_running_tool():
                 threshold = self._STALL_THRESHOLD_TOOL
                 threshold_reason = "running_tool"
@@ -802,23 +828,15 @@ class ProgressEdits:
 
             self._stall_warned = True
             self._stall_warn_count += 1
+            self._total_stall_warn_count += 1
             self._last_stall_warn_at = now
 
-            diag = collect_proc_diag(self.pid) if self.pid else None
             last_action = self._last_action_summary()
 
             recent = list(self.stream.recent_events) if self.stream else []
             stderr_hint = (
                 self.stream.stderr_capture[-3:]
                 if self.stream and self.stream.stderr_capture
-                else None
-            )
-
-            # Compute CPU activity before updating _prev_diag (needs both
-            # the previous and current snapshots to compare ticks).
-            cpu_active = (
-                is_cpu_active(self._prev_diag, diag)
-                if self._prev_diag and diag
                 else None
             )
 
@@ -838,10 +856,10 @@ class ProgressEdits:
                 rss_kb=diag.rss_kb if diag else None,
                 fd_count=diag.fd_count if diag else None,
                 cpu_active=cpu_active,
+                tree_active=tree_active,
                 recent_events=[(round(t, 1), lbl) for t, lbl in recent[-5:]],
                 stderr_hint=stderr_hint,
             )
-            self._prev_diag = diag
 
             # Auto-cancel: dead process, no-PID zombie, or absolute cap
             auto_cancel_reason: str | None = None
@@ -967,6 +985,32 @@ class ProgressEdits:
                     anyio.ClosedResourceError,
                 ):
                     self.signal_send.send_nowait(None)
+            elif (
+                tree_active is True
+                and main_sleeping
+                and self._has_active_children(diag)
+                and self._stall_warn_count > 1
+            ):
+                # Subagent child processes actively working — first warning
+                # already sent, suppress repeats.  Similar to tool-active
+                # suppression but triggered by tree CPU (child processes)
+                # instead of tracked tool state.
+                logger.info(
+                    "progress_edits.stall_children_active_suppressed",
+                    channel_id=self.channel_id,
+                    seconds_since_last_event=round(elapsed, 1),
+                    stall_warn_count=self._stall_warn_count,
+                    pid=self.pid,
+                    child_pids=diag.child_pids if diag else [],
+                    tcp_total=diag.tcp_total if diag else 0,
+                )
+                self.event_seq += 1
+                with contextlib.suppress(
+                    anyio.WouldBlock,
+                    anyio.BrokenResourceError,
+                    anyio.ClosedResourceError,
+                ):
+                    self.signal_send.send_nowait(None)
             else:
                 # Telegram notification (cpu_active=False/None, or frozen
                 # ring buffer escalation despite CPU activity)
@@ -1016,6 +1060,16 @@ class ProgressEdits:
                         ]
                 elif mcp_server is not None:
                     parts = [f"⏳ MCP tool running: {mcp_server} ({mins} min)"]
+                elif threshold_reason == "active_children":
+                    n_children = len(diag.child_pids) if diag else 0
+                    if tree_active is True:
+                        parts = [
+                            f"⏳ Waiting for child processes ({n_children} children, {mins} min)"
+                        ]
+                    else:
+                        parts = [
+                            f"⏳ Child processes idle ({n_children} children, {mins} min)"
+                        ]
                 else:
                     # Extract tool name from last running action for
                     # actionable stall messages ("Bash command still running"
@@ -1050,6 +1104,7 @@ class ProgressEdits:
                     not mcp_hung
                     and not frozen_escalate
                     and mcp_server is None
+                    and threshold_reason != "active_children"
                     and not (_tool_name and main_sleeping)
                     and cpu_active is not True
                 )
@@ -1110,6 +1165,19 @@ class ProgressEdits:
                     return parts[1] if len(parts) >= 2 else name
             break  # only check the most recent
         return None
+
+    def _has_active_children(self, diag: Any) -> bool:
+        """True if the process has active child processes or elevated TCP.
+
+        Detects Agent subagent work that runs in child processes after the
+        tracked action event has completed.  Uses child PIDs and TCP
+        connection count as signals.
+        """
+        if diag is None or not diag.alive:
+            return False
+        if diag.child_pids:
+            return True
+        return diag.tcp_total > self._TCP_ACTIVE_THRESHOLD
 
     def _last_action_summary(self) -> str | None:
         """Return a short description of the most recent action."""
@@ -1337,9 +1405,11 @@ class ProgressEdits:
     _STALL_THRESHOLD_SECONDS: float = 300.0  # 5 minutes
     _STALL_THRESHOLD_TOOL: float = 600.0  # 10 minutes when a tool is actively running
     _STALL_THRESHOLD_MCP_TOOL: float = 900.0  # 15 min for MCP tools (network-bound)
+    _STALL_THRESHOLD_SUBAGENT: float = 900.0  # 15 min for child process / subagent work
     _STALL_THRESHOLD_APPROVAL: float = 1800.0  # 30 minutes when waiting for approval
     _STALL_MAX_WARNINGS: int = 10  # absolute cap
     _STALL_MAX_WARNINGS_NO_PID: int = 3  # aggressive cap when pid=None + no events
+    _TCP_ACTIVE_THRESHOLD: int = 20  # TCP connections above this suggest active work
 
     async def on_event(self, evt: UntetherEvent) -> None:
         if not self.tracker.note_event(evt):
@@ -1357,7 +1427,7 @@ class ProgressEdits:
             )
             self._stall_warned = False
             self._stall_warn_count = 0
-            self._prev_diag = None
+            # Keep _prev_diag so next stall episode has a CPU baseline
             self._frozen_ring_count = 0
             self._prev_recent_events = None
         self._last_event_at = now
@@ -1645,7 +1715,7 @@ async def run_runner_with_cancel(
         engine=runner.engine,
         duration_seconds=round(duration, 1),
         event_count=event_count,
-        stall_warnings=edits._stall_warn_count,
+        stall_warnings=edits._total_stall_warn_count,
         peak_idle_seconds=round(edits._peak_idle, 1),
         last_event_type=edits.stream.last_event_type if edits.stream else None,
         cancelled=outcome.cancelled,
@@ -1782,6 +1852,7 @@ async def handle_message(
         edits._stall_repeat_seconds = watchdog.stall_repeat_seconds
         edits._STALL_THRESHOLD_TOOL = watchdog.tool_timeout
         edits._STALL_THRESHOLD_MCP_TOOL = watchdog.mcp_tool_timeout
+        edits._STALL_THRESHOLD_SUBAGENT = watchdog.subagent_timeout
         if hasattr(runner, "_LIVENESS_TIMEOUT_SECONDS"):
             runner._LIVENESS_TIMEOUT_SECONDS = watchdog.liveness_timeout
         if hasattr(runner, "_stall_auto_kill"):

--- a/src/untether/runners/amp.py
+++ b/src/untether/runners/amp.py
@@ -352,7 +352,7 @@ class AmpRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         args.append("--stream-json")
         if self.stream_json_input:
             args.append("--stream-json-input")
-        args.extend(["-x", prompt])
+        args.extend(["-x", self.sanitize_prompt(prompt)])
         return args
 
     def stdin_payload(

--- a/src/untether/runners/gemini.py
+++ b/src/untether/runners/gemini.py
@@ -348,7 +348,7 @@ class GeminiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             args.extend(["--approval-mode", run_options.permission_mode])
         else:
             args.extend(["--approval-mode", "yolo"])
-        args.append(f"--prompt={prompt}")
+        args.append(f"--prompt={self.sanitize_prompt(prompt)}")
         return args
 
     def stdin_payload(

--- a/src/untether/runners/pi.py
+++ b/src/untether/runners/pi.py
@@ -412,7 +412,7 @@ class PiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             args.append("--continue")
         else:
             args.extend(["--session", state.resume.value])
-        args.append(self._sanitize_prompt(prompt))
+        args.append(self.sanitize_prompt(prompt))
         return args
 
     def stdin_payload(
@@ -559,11 +559,6 @@ class PiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         token = uuid4().hex
         filename = f"{safe_timestamp}_{token}.jsonl"
         return str(session_dir / filename)
-
-    def _sanitize_prompt(self, prompt: str) -> str:
-        if prompt.startswith("-"):
-            return f" {prompt}"
-        return prompt
 
     def _quote_token(self, token: str) -> str:
         if not token:

--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -175,6 +175,7 @@ class WatchdogSettings(BaseModel):
     stall_repeat_seconds: float = Field(default=180.0, ge=30, le=600)
     tool_timeout: float = Field(default=600.0, ge=60, le=7200)
     mcp_tool_timeout: float = Field(default=900.0, ge=60, le=7200)
+    subagent_timeout: float = Field(default=900.0, ge=60, le=7200)
 
 
 class ProgressSettings(BaseModel):

--- a/src/untether/telegram/commands/cancel.py
+++ b/src/untether/telegram/commands/cancel.py
@@ -100,6 +100,24 @@ async def handle_callback_cancel(
     running_tasks: RunningTasks,
     scheduler: ThreadScheduler | None = None,
 ) -> None:
+    # Validate sender in group chats — prevent unauthorised users cancelling
+    # another user's running task (#192).
+    if (
+        cfg.allowed_user_ids
+        and query.sender_id is not None
+        and query.sender_id not in cfg.allowed_user_ids
+    ):
+        logger.warning(
+            "cancel.sender_not_allowed",
+            chat_id=query.chat_id,
+            sender_id=query.sender_id,
+        )
+        await cfg.bot.answer_callback_query(
+            callback_query_id=query.callback_query_id,
+            text="Not authorised",
+        )
+        return
+
     progress_ref = MessageRef(channel_id=query.chat_id, message_id=query.message_id)
     running_task = running_tasks.get(progress_ref)
     if running_task is None:

--- a/src/untether/telegram/commands/dispatch.py
+++ b/src/untether/telegram/commands/dispatch.py
@@ -155,6 +155,25 @@ async def _dispatch_callback(
     callback_query_id: str | None = None,
 ) -> None:
     """Dispatch a callback query to a command backend."""
+    # Validate sender in group chats — prevent unauthorised users pressing
+    # another user's approval buttons (#192).
+    if (
+        cfg.allowed_user_ids
+        and msg.sender_id is not None
+        and msg.sender_id not in cfg.allowed_user_ids
+    ):
+        logger.warning(
+            "callback.sender_not_allowed",
+            chat_id=msg.chat_id,
+            sender_id=msg.sender_id,
+            command=command_id,
+        )
+        if callback_query_id is not None:
+            await cfg.bot.answer_callback_query(
+                callback_query_id, text="Not authorised"
+            )
+        return
+
     allowlist = cfg.runtime.allowlist
     chat_id = msg.chat_id
     user_msg_id = msg.message_id

--- a/src/untether/telegram/commands/ping.py
+++ b/src/untether/telegram/commands/ping.py
@@ -6,7 +6,18 @@ import time
 
 from ...commands import CommandBackend, CommandContext, CommandResult
 
-_STARTED_AT = time.monotonic()
+_STARTED_AT: float = 0.0
+
+
+def reset_uptime() -> None:
+    """Reset the uptime counter (called on service start)."""
+    global _STARTED_AT
+    _STARTED_AT = time.monotonic()
+
+
+# Set initial value at import time; reset_uptime() is called again from
+# the Telegram loop on each service start to handle /restart correctly.
+reset_uptime()
 
 
 def _format_uptime(seconds: float) -> str:

--- a/src/untether/telegram/loop.py
+++ b/src/untether/telegram/loop.py
@@ -1247,6 +1247,12 @@ async def run_main_loop(
         _signal.signal(_signal.SIGINT, _shutdown_handler)
         logger.info("signal.handler.installed", signals=["SIGTERM", "SIGINT"])
 
+        # Reset uptime counter so /ping reports time since this start, not
+        # since the module was first imported (#234).
+        from .commands.ping import reset_uptime
+
+        reset_uptime()
+
         async with anyio.create_task_group() as tg:
             poller_fn: Callable[
                 [TelegramBridgeConfig], AsyncIterator[TelegramIncomingUpdate]

--- a/src/untether/utils/proc_diag.py
+++ b/src/untether/utils/proc_diag.py
@@ -25,6 +25,8 @@ class ProcessDiag:
     tcp_established: int = 0
     tcp_total: int = 0
     child_pids: list[int] = field(default_factory=list)
+    tree_cpu_utime: int | None = None  # sum of utime for pid + descendants
+    tree_cpu_stime: int | None = None  # sum of stime for pid + descendants
 
 
 def _is_alive(pid: int) -> bool:
@@ -119,6 +121,36 @@ def _find_children(pid: int) -> list[int]:
     return children
 
 
+def _find_descendants(pid: int, *, _depth: int = 0, _max_depth: int = 4) -> list[int]:
+    """Find all descendant PIDs recursively (depth-limited)."""
+    if _depth >= _max_depth:
+        return []
+    children = _find_children(pid)
+    descendants = list(children)
+    for child in children:
+        descendants.extend(
+            _find_descendants(child, _depth=_depth + 1, _max_depth=_max_depth)
+        )
+    return descendants
+
+
+def _collect_tree_cpu(
+    utime: int | None, stime: int | None, descendants: list[int]
+) -> tuple[int | None, int | None]:
+    """Sum CPU ticks across process + all descendants."""
+    if utime is None or stime is None:
+        return None, None
+    tree_utime = utime
+    tree_stime = stime
+    for desc_pid in descendants:
+        _, d_utime, d_stime = _read_stat(desc_pid)
+        if d_utime is not None:
+            tree_utime += d_utime
+        if d_stime is not None:
+            tree_stime += d_stime
+    return tree_utime, tree_stime
+
+
 def collect_proc_diag(pid: int) -> ProcessDiag | None:
     """Collect process diagnostics from /proc. Returns None on non-Linux."""
     if sys.platform != "linux":
@@ -133,6 +165,8 @@ def collect_proc_diag(pid: int) -> ProcessDiag | None:
     fd_count = _count_fds(pid)
     tcp_est, tcp_total = _count_tcp(pid)
     children = _find_children(pid)
+    descendants = _find_descendants(pid)
+    tree_utime, tree_stime = _collect_tree_cpu(utime, stime, descendants)
 
     return ProcessDiag(
         pid=pid,
@@ -146,6 +180,8 @@ def collect_proc_diag(pid: int) -> ProcessDiag | None:
         tcp_established=tcp_est,
         tcp_total=tcp_total,
         child_pids=children,
+        tree_cpu_utime=tree_utime,
+        tree_cpu_stime=tree_stime,
     )
 
 
@@ -195,4 +231,25 @@ def is_cpu_active(prev: ProcessDiag | None, curr: ProcessDiag | None) -> bool | 
         return None
     prev_total = prev.cpu_utime + prev.cpu_stime
     curr_total = curr.cpu_utime + curr.cpu_stime
+    return curr_total > prev_total
+
+
+def is_tree_cpu_active(
+    prev: ProcessDiag | None, curr: ProcessDiag | None
+) -> bool | None:
+    """True if aggregate CPU ticks across pid + descendants increased.
+
+    Returns None if either snapshot lacks tree CPU data.
+    """
+    if prev is None or curr is None:
+        return None
+    if (
+        prev.tree_cpu_utime is None
+        or prev.tree_cpu_stime is None
+        or curr.tree_cpu_utime is None
+        or curr.tree_cpu_stime is None
+    ):
+        return None
+    prev_total = prev.tree_cpu_utime + prev.tree_cpu_stime
+    curr_total = curr.tree_cpu_utime + curr.tree_cpu_stime
     return curr_total > prev_total

--- a/tests/test_build_args.py
+++ b/tests/test_build_args.py
@@ -409,6 +409,44 @@ class TestAmpBuildArgs:
         args = runner.build_args("hello", None, state=state)
         assert "--dangerously-allow-all" not in args
 
+    def test_flag_like_prompt_sanitised(self) -> None:
+        """Prompts starting with - are sanitised to prevent flag injection (#194)."""
+        runner = self._runner()
+        state = runner.new_state("--help", None)
+        args = runner.build_args("--help", None, state=state)
+        idx = args.index("-x")
+        assert args[idx + 1] == " --help"
+
+
+# ---------------------------------------------------------------------------
+# Gemini prompt sanitisation (#194)
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiPromptSanitisation:
+    def _runner(self, **kwargs: Any):
+        from untether.runners.gemini import GeminiRunner
+
+        return GeminiRunner(**kwargs)
+
+    def test_flag_like_prompt_sanitised(self) -> None:
+        """Prompts starting with - are sanitised in --prompt= value (#194)."""
+        runner = self._runner()
+        state = runner.new_state("--help", None)
+        with patch("untether.runners.gemini.get_run_options", return_value=None):
+            args = runner.build_args("--help", None, state=state)
+        prompt_arg = [a for a in args if a.startswith("--prompt=")]
+        assert len(prompt_arg) == 1
+        assert prompt_arg[0] == "--prompt= --help"
+
+    def test_normal_prompt_unchanged(self) -> None:
+        runner = self._runner()
+        state = runner.new_state("hello world", None)
+        with patch("untether.runners.gemini.get_run_options", return_value=None):
+            args = runner.build_args("hello world", None, state=state)
+        prompt_arg = [a for a in args if a.startswith("--prompt=")]
+        assert prompt_arg[0] == "--prompt=hello world"
+
 
 # ---------------------------------------------------------------------------
 # Pi

--- a/tests/test_callback_dispatch.py
+++ b/tests/test_callback_dispatch.py
@@ -9,9 +9,14 @@ import pytest
 from tests.telegram_fakes import FakeBot, FakeTransport, make_cfg
 from untether.commands import CommandContext, CommandResult
 from untether.runner_bridge import _EPHEMERAL_MSGS
+from untether.telegram.bridge import TelegramBridgeConfig
 from untether.telegram.commands import dispatch as dispatch_mod
 from untether.telegram.commands.dispatch import _dispatch_callback, _parse_callback_data
 from untether.telegram.types import TelegramCallbackQuery
+
+
+class _StubScheduler:
+    """Minimal scheduler stub for dispatch tests."""
 
 
 class TestParseCallbackData:
@@ -148,8 +153,10 @@ class _StubBackend:
     ):
         self._result = result
         self._raise_exc = raise_exc
+        self._handle_called = 0
 
     async def handle(self, ctx: CommandContext) -> CommandResult | None:
+        self._handle_called += 1
         if self._raise_exc is not None:
             raise self._raise_exc
         return self._result
@@ -448,3 +455,120 @@ async def test_dispatch_callback_skip_reply_sends_without_reply_to(
     options = call["options"]
     assert options is not None
     assert options.reply_to is None
+
+
+# ---------------------------------------------------------------------------
+# Callback sender validation (#192)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_callback_rejected_for_unauthorised_sender() -> None:
+    """In groups, callback from a user not in allowed_user_ids is rejected."""
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    cfg = TelegramBridgeConfig(
+        bot=cfg.bot,
+        runtime=cfg.runtime,
+        chat_id=cfg.chat_id,
+        startup_msg="",
+        exec_cfg=cfg.exec_cfg,
+        allowed_user_ids=(999,),  # only user 999 allowed
+    )
+    bot: FakeBot = cfg.bot  # type: ignore[assignment]
+    backend = _StubBackend(CommandResult(text="Should not reach"))
+
+    # sender_id=1 is NOT in allowed_user_ids=(999,)
+    query = _make_callback_query("test_cmd:args")
+
+    from unittest.mock import patch
+
+    with patch("untether.telegram.commands.dispatch.get_command", return_value=backend):
+        await _dispatch_callback(
+            cfg,
+            query,
+            "test_cmd",
+            "args",
+            thread_id=None,
+            running_tasks={},
+            scheduler=_StubScheduler(),
+            on_thread_known=None,
+            stateful_mode=False,
+            default_engine_override=None,
+            callback_query_id="cb-123",
+        )
+
+    # Backend should NOT have been called
+    assert backend._handle_called == 0
+    # Callback should be answered with rejection
+    assert len(bot.callback_calls) == 1
+    assert bot.callback_calls[0]["text"] == "Not authorised"
+    # No messages sent
+    assert len(transport.send_calls) == 0
+
+
+@pytest.mark.anyio
+async def test_callback_allowed_for_authorised_sender() -> None:
+    """Callback from a user in allowed_user_ids proceeds normally."""
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    cfg = TelegramBridgeConfig(
+        bot=cfg.bot,
+        runtime=cfg.runtime,
+        chat_id=cfg.chat_id,
+        startup_msg="",
+        exec_cfg=cfg.exec_cfg,
+        allowed_user_ids=(1,),  # sender_id=1 IS allowed
+    )
+    backend = _StubBackend(CommandResult(text="Approved"))
+
+    query = _make_callback_query("test_cmd:args")
+
+    from unittest.mock import patch
+
+    with patch("untether.telegram.commands.dispatch.get_command", return_value=backend):
+        await _dispatch_callback(
+            cfg,
+            query,
+            "test_cmd",
+            "args",
+            thread_id=None,
+            running_tasks={},
+            scheduler=_StubScheduler(),
+            on_thread_known=None,
+            stateful_mode=False,
+            default_engine_override=None,
+            callback_query_id="cb-123",
+        )
+
+    # Backend should have been called
+    assert backend._handle_called == 1
+
+
+@pytest.mark.anyio
+async def test_callback_allowed_when_no_user_restriction() -> None:
+    """When allowed_user_ids is empty, all senders are allowed (default)."""
+    transport = FakeTransport()
+    cfg = make_cfg(transport)  # default: allowed_user_ids=()
+    backend = _StubBackend(CommandResult(text="OK"))
+
+    query = _make_callback_query("test_cmd:args")
+
+    from unittest.mock import patch
+
+    with patch("untether.telegram.commands.dispatch.get_command", return_value=backend):
+        await _dispatch_callback(
+            cfg,
+            query,
+            "test_cmd",
+            "args",
+            thread_id=None,
+            running_tasks={},
+            scheduler=_StubScheduler(),
+            on_thread_known=None,
+            stateful_mode=False,
+            default_engine_override=None,
+            callback_query_id="cb-123",
+        )
+
+    assert backend._handle_called == 1

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -3621,6 +3621,465 @@ async def test_stall_tool_active_suppressed_even_with_frozen_ring() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Active children / subagent stall tests (#264)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_stall_threshold_elevated_with_active_children() -> None:
+    """When child processes exist, use the subagent threshold (900s) instead of normal (300s)."""
+    from unittest.mock import patch
+
+    from untether.utils.proc_diag import ProcessDiag
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05  # 50ms
+    edits._STALL_THRESHOLD_SUBAGENT = 0.5  # 500ms
+    edits._stall_repeat_seconds = 0.02
+    edits.pid = 12345
+    edits.event_seq = 5
+
+    def diag_with_children(pid: int) -> ProcessDiag:
+        return ProcessDiag(
+            pid=pid,
+            alive=True,
+            state="S",
+            cpu_utime=1000,
+            cpu_stime=200,
+            child_pids=[5001, 5002],
+            tree_cpu_utime=3000,
+            tree_cpu_stime=600,
+        )
+
+    with patch(
+        "untether.utils.proc_diag.collect_proc_diag",
+        side_effect=diag_with_children,
+    ):
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                # Advance past normal threshold but under subagent threshold
+                clock.set(100.1)  # 100ms elapsed — past normal 50ms
+                await anyio.sleep(0.05)
+                edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    # Should NOT have triggered a stall warning (under subagent threshold)
+    stall_msgs = [
+        c
+        for c in transport.send_calls
+        if "progress" in c["message"].text.lower()
+        or "stuck" in c["message"].text.lower()
+        or "waiting" in c["message"].text.lower()
+    ]
+    assert len(stall_msgs) == 0, (
+        f"Expected no stall warnings (under subagent threshold), got: "
+        f"{[c['message'].text for c in stall_msgs]}"
+    )
+
+
+@pytest.mark.anyio
+async def test_stall_threshold_elevated_with_high_tcp() -> None:
+    """When TCP count exceeds threshold, use subagent threshold even without child_pids."""
+    from unittest.mock import patch
+
+    from untether.utils.proc_diag import ProcessDiag
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits._STALL_THRESHOLD_SUBAGENT = 0.5
+    edits._TCP_ACTIVE_THRESHOLD = 20
+    edits._stall_repeat_seconds = 0.02
+    edits.pid = 12345
+    edits.event_seq = 5
+
+    def diag_high_tcp(pid: int) -> ProcessDiag:
+        return ProcessDiag(
+            pid=pid,
+            alive=True,
+            state="S",
+            cpu_utime=1000,
+            cpu_stime=200,
+            child_pids=[],  # no direct children
+            tcp_established=50,
+            tcp_total=100,  # well above threshold
+            tree_cpu_utime=1000,
+            tree_cpu_stime=200,
+        )
+
+    with patch(
+        "untether.utils.proc_diag.collect_proc_diag",
+        side_effect=diag_high_tcp,
+    ):
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                clock.set(100.1)  # past normal, under subagent
+                await anyio.sleep(0.05)
+                edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    stall_msgs = [
+        c
+        for c in transport.send_calls
+        if "progress" in c["message"].text.lower()
+        or "stuck" in c["message"].text.lower()
+        or "waiting" in c["message"].text.lower()
+    ]
+    assert len(stall_msgs) == 0
+
+
+@pytest.mark.anyio
+async def test_stall_children_suppressed_with_tree_cpu_active() -> None:
+    """When tree CPU is active + children exist, repeat warnings are suppressed."""
+    from unittest.mock import patch
+
+    from untether.utils.proc_diag import ProcessDiag
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits._STALL_THRESHOLD_SUBAGENT = 0.05  # same as normal for this test
+    edits._stall_repeat_seconds = 0.01
+    edits._STALL_MAX_WARNINGS = 100
+    edits.pid = 12345
+    edits.event_seq = 5
+
+    call_count = 0
+
+    def diag_tree_active(pid: int) -> ProcessDiag:
+        nonlocal call_count
+        call_count += 1
+        return ProcessDiag(
+            pid=pid,
+            alive=True,
+            state="S",
+            cpu_utime=1000,  # main CPU flat
+            cpu_stime=200,
+            child_pids=[5001, 5002],
+            tree_cpu_utime=1000 + call_count * 300,  # tree CPU increasing
+            tree_cpu_stime=200 + call_count * 50,
+        )
+
+    initial_seq = edits.event_seq
+
+    with patch(
+        "untether.utils.proc_diag.collect_proc_diag",
+        side_effect=diag_tree_active,
+    ):
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                for i in range(6):
+                    clock.set(100.1 + i * 0.1)
+                    await anyio.sleep(0.03)
+                edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    # First warning fires, repeats suppressed by child-active
+    stall_msgs = [
+        c
+        for c in transport.send_calls
+        if "child processes" in c["message"].text.lower()
+        or "progress" in c["message"].text.lower()
+        or "stuck" in c["message"].text.lower()
+    ]
+    assert len(stall_msgs) == 1, (
+        f"Expected 1 stall notification (repeats suppressed), got {len(stall_msgs)}: "
+        f"{[c['message'].text for c in stall_msgs]}"
+    )
+    # Heartbeat re-render should have bumped event_seq
+    assert edits.event_seq > initial_seq
+
+
+@pytest.mark.anyio
+async def test_stall_children_not_suppressed_with_tree_cpu_idle() -> None:
+    """When tree CPU is flat (idle children), warnings keep firing."""
+    from unittest.mock import patch
+
+    from untether.utils.proc_diag import ProcessDiag
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits._STALL_THRESHOLD_SUBAGENT = 0.05
+    edits._stall_repeat_seconds = 0.01
+    edits._STALL_MAX_WARNINGS = 100
+    edits.pid = 12345
+    edits.event_seq = 5
+    cancel_event = anyio.Event()
+    edits.cancel_event = cancel_event
+
+    def diag_tree_idle(pid: int) -> ProcessDiag:
+        return ProcessDiag(
+            pid=pid,
+            alive=True,
+            state="S",
+            cpu_utime=1000,
+            cpu_stime=200,
+            child_pids=[5001],
+            tree_cpu_utime=1000,  # flat — no child CPU activity
+            tree_cpu_stime=200,
+        )
+
+    with patch(
+        "untether.utils.proc_diag.collect_proc_diag",
+        side_effect=diag_tree_idle,
+    ):
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                for i in range(5):
+                    clock.set(100.1 + i * 0.1)
+                    await anyio.sleep(0.03)
+                edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    stall_msgs = [
+        c
+        for c in transport.send_calls
+        if "child processes" in c["message"].text.lower()
+        or "progress" in c["message"].text.lower()
+        or "stuck" in c["message"].text.lower()
+    ]
+    # Multiple warnings fire because tree CPU is idle (no suppression)
+    assert len(stall_msgs) >= 2, (
+        f"Expected >=2 stall warnings (tree idle), got {len(stall_msgs)}"
+    )
+
+
+@pytest.mark.anyio
+async def test_stall_first_warning_has_cpu_baseline() -> None:
+    """After early diagnostic collection, first stall warning has cpu_active != None."""
+    from unittest.mock import patch
+
+    from untether.utils.proc_diag import ProcessDiag
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.03  # triggers after ~3 cycles
+    edits._stall_repeat_seconds = 0.5
+    edits.pid = 12345
+    edits.event_seq = 5
+    cancel_event = anyio.Event()
+    edits.cancel_event = cancel_event
+
+    call_count = 0
+
+    def active_cpu_diag(pid: int) -> ProcessDiag:
+        nonlocal call_count
+        call_count += 1
+        return ProcessDiag(
+            pid=pid,
+            alive=True,
+            state="R",
+            cpu_utime=1000 + call_count * 100,
+            cpu_stime=200 + call_count * 20,
+            tree_cpu_utime=1000 + call_count * 100,
+            tree_cpu_stime=200 + call_count * 20,
+        )
+
+    with patch(
+        "untether.utils.proc_diag.collect_proc_diag",
+        side_effect=active_cpu_diag,
+    ):
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                # Wait enough for 2+ cycles before threshold
+                await anyio.sleep(0.02)
+                clock.set(100.05)  # past threshold
+                await anyio.sleep(0.03)
+                edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    # With early collection, _prev_diag was set before threshold crossing,
+    # so cpu_active should not be None.  CPU-active + running state = suppression
+    # (heartbeat only, no Telegram notification).
+    stall_msgs = [
+        c
+        for c in transport.send_calls
+        if "progress" in c["message"].text.lower()
+        or "stuck" in c["message"].text.lower()
+    ]
+    # Active CPU + running state → suppressed (heartbeat only)
+    assert len(stall_msgs) == 0, (
+        f"Expected 0 stall notifications (CPU active + running → suppressed), "
+        f"got: {[c['message'].text for c in stall_msgs]}"
+    )
+
+
+@pytest.mark.anyio
+async def test_stall_total_warn_count_survives_recovery() -> None:
+    """_total_stall_warn_count persists through recovery (unlike _stall_warn_count)."""
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+
+    # Simulate first stall episode
+    edits._stall_warned = True
+    edits._stall_warn_count = 3
+    edits._total_stall_warn_count = 3
+
+    # Recovery via new event
+    from untether.model import Action, ActionEvent
+
+    clock.set(101.0)
+    evt = ActionEvent(
+        engine="claude",
+        action=Action(id="a1", kind="tool", title="Read"),
+        phase="started",
+    )
+    await edits.on_event(evt)
+
+    # Per-episode count resets, total persists
+    assert edits._stall_warn_count == 0
+    assert edits._total_stall_warn_count == 3
+
+    # Simulate second stall episode
+    edits._stall_warned = True
+    edits._stall_warn_count = 2
+    edits._total_stall_warn_count = 5
+
+    clock.set(102.0)
+    evt2 = ActionEvent(
+        engine="claude",
+        action=Action(id="a2", kind="tool", title="Grep"),
+        phase="started",
+    )
+    await edits.on_event(evt2)
+
+    assert edits._stall_warn_count == 0
+    assert edits._total_stall_warn_count == 5
+
+
+@pytest.mark.anyio
+async def test_stall_message_active_children() -> None:
+    """When active_children threshold fires, message says 'child processes'."""
+    from unittest.mock import patch
+
+    from untether.utils.proc_diag import ProcessDiag
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits._STALL_THRESHOLD_SUBAGENT = 0.05  # match so it triggers
+    edits._stall_repeat_seconds = 0.5
+    edits._STALL_MAX_WARNINGS = 100
+    edits.pid = 12345
+    edits.event_seq = 5
+
+    # No tracked tool running, but children exist
+    def diag_children_idle_cpu(pid: int) -> ProcessDiag:
+        return ProcessDiag(
+            pid=pid,
+            alive=True,
+            state="S",
+            cpu_utime=1000,
+            cpu_stime=200,
+            child_pids=[5001, 5002, 5003],
+            tree_cpu_utime=1000,
+            tree_cpu_stime=200,
+        )
+
+    with patch(
+        "untether.utils.proc_diag.collect_proc_diag",
+        side_effect=diag_children_idle_cpu,
+    ):
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                clock.set(100.1)
+                await anyio.sleep(0.05)
+                edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    stall_msgs = [
+        c
+        for c in transport.send_calls
+        if "child processes" in c["message"].text.lower()
+    ]
+    assert len(stall_msgs) == 1, (
+        f"Expected 'child processes' message, got: "
+        f"{[c['message'].text for c in transport.send_calls]}"
+    )
+    assert "3 children" in stall_msgs[0]["message"].text
+
+
+@pytest.mark.anyio
+async def test_stall_prev_diag_persists_across_recovery() -> None:
+    """_prev_diag is NOT reset on recovery (provides baseline for next stall)."""
+    from untether.utils.proc_diag import ProcessDiag
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+
+    # Set up as if a stall was warned with diagnostic
+    fake_diag = ProcessDiag(
+        pid=12345,
+        alive=True,
+        state="S",
+        cpu_utime=1000,
+        cpu_stime=200,
+        tree_cpu_utime=2000,
+        tree_cpu_stime=400,
+    )
+    edits._stall_warned = True
+    edits._stall_warn_count = 2
+    edits._prev_diag = fake_diag
+
+    # Recovery via event
+    from untether.model import Action, ActionEvent
+
+    clock.set(101.0)
+    evt = ActionEvent(
+        engine="claude",
+        action=Action(id="a1", kind="tool", title="Read"),
+        phase="started",
+    )
+    await edits.on_event(evt)
+
+    # _prev_diag should persist (NOT reset to None)
+    assert edits._prev_diag is fake_diag
+    assert edits._stall_warned is False  # other flags still reset
+
+
+# ---------------------------------------------------------------------------
 # Plan outline rendering, keyboard, and cleanup tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_proc_diag.py
+++ b/tests/test_proc_diag.py
@@ -9,9 +9,11 @@ import pytest
 
 from untether.utils.proc_diag import (
     ProcessDiag,
+    _find_descendants,
     collect_proc_diag,
     format_diag,
     is_cpu_active,
+    is_tree_cpu_active,
 )
 
 # ---------------------------------------------------------------------------
@@ -185,6 +187,81 @@ def test_collect_self_format_roundtrip() -> None:
     result = format_diag(diag)
     assert "alive" in result
     assert len(result) > 10
+
+
+# ---------------------------------------------------------------------------
+# is_tree_cpu_active tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_tree_cpu_active_increasing() -> None:
+    prev = ProcessDiag(pid=1, alive=True, tree_cpu_utime=1000, tree_cpu_stime=500)
+    curr = ProcessDiag(pid=1, alive=True, tree_cpu_utime=1200, tree_cpu_stime=500)
+    assert is_tree_cpu_active(prev, curr) is True
+
+
+def test_is_tree_cpu_active_flat() -> None:
+    prev = ProcessDiag(pid=1, alive=True, tree_cpu_utime=1000, tree_cpu_stime=500)
+    curr = ProcessDiag(pid=1, alive=True, tree_cpu_utime=1000, tree_cpu_stime=500)
+    assert is_tree_cpu_active(prev, curr) is False
+
+
+def test_is_tree_cpu_active_none_prev() -> None:
+    curr = ProcessDiag(pid=1, alive=True, tree_cpu_utime=1000, tree_cpu_stime=500)
+    assert is_tree_cpu_active(None, curr) is None
+
+
+def test_is_tree_cpu_active_none_fields() -> None:
+    prev = ProcessDiag(pid=1, alive=True, tree_cpu_utime=None, tree_cpu_stime=None)
+    curr = ProcessDiag(pid=1, alive=True, tree_cpu_utime=1000, tree_cpu_stime=500)
+    assert is_tree_cpu_active(prev, curr) is None
+
+
+def test_is_tree_cpu_active_child_activity_only() -> None:
+    """Tree CPU increases even when main process CPU is flat (child work)."""
+    prev = ProcessDiag(
+        pid=1,
+        alive=True,
+        cpu_utime=100,
+        cpu_stime=50,
+        tree_cpu_utime=1000,
+        tree_cpu_stime=500,
+    )
+    curr = ProcessDiag(
+        pid=1,
+        alive=True,
+        cpu_utime=100,
+        cpu_stime=50,
+        tree_cpu_utime=1200,
+        tree_cpu_stime=600,
+    )
+    assert is_cpu_active(prev, curr) is False  # main process flat
+    assert is_tree_cpu_active(prev, curr) is True  # tree active from children
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="requires /proc")
+def test_collect_self_tree_cpu_populated() -> None:
+    """collect_proc_diag should populate tree CPU fields for live process."""
+    diag = collect_proc_diag(os.getpid())
+    assert diag is not None
+    assert diag.tree_cpu_utime is not None
+    assert diag.tree_cpu_stime is not None
+    # Tree CPU >= main process CPU (includes children)
+    assert diag.tree_cpu_utime >= (diag.cpu_utime or 0)
+    assert diag.tree_cpu_stime >= (diag.cpu_stime or 0)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="requires /proc")
+def test_find_descendants_self() -> None:
+    """_find_descendants for our own process should return a list."""
+    descendants = _find_descendants(os.getpid())
+    assert isinstance(descendants, list)
+
+
+def test_find_descendants_nonexistent() -> None:
+    """_find_descendants for a non-existent PID returns empty."""
+    descendants = _find_descendants(99999999)
+    assert descendants == []
 
 
 @pytest.mark.skipif(sys.platform == "linux", reason="tests non-Linux path")

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -969,6 +969,54 @@ async def test_handle_callback_cancel_without_task_acknowledges() -> None:
     assert "nothing is currently running" in bot.callback_calls[-1]["text"].lower()
 
 
+@pytest.mark.anyio
+async def test_handle_callback_cancel_rejected_for_unauthorised_sender() -> None:
+    """Cancel callback from an unauthorised user is rejected (#192)."""
+    transport = FakeTransport()
+    cfg = replace(make_cfg(transport), allowed_user_ids=(999,))
+    progress_id = 42
+    running_task = RunningTask()
+    running_tasks = {MessageRef(channel_id=123, message_id=progress_id): running_task}
+    query = TelegramCallbackQuery(
+        transport="telegram",
+        chat_id=123,
+        message_id=progress_id,
+        callback_query_id="cbq-unauth",
+        data="untether:cancel",
+        sender_id=123,  # NOT in allowed_user_ids
+    )
+
+    await handle_callback_cancel(cfg, query, running_tasks)
+
+    assert running_task.cancel_requested.is_set() is False
+    bot = cast(FakeBot, cfg.bot)
+    assert bot.callback_calls
+    assert bot.callback_calls[-1]["text"] == "Not authorised"
+
+
+@pytest.mark.anyio
+async def test_handle_callback_cancel_allowed_when_no_restriction() -> None:
+    """Cancel callback works when allowed_user_ids is empty (default)."""
+    transport = FakeTransport()
+    cfg = make_cfg(transport)
+    assert cfg.allowed_user_ids == ()
+    progress_id = 42
+    running_task = RunningTask()
+    running_tasks = {MessageRef(channel_id=123, message_id=progress_id): running_task}
+    query = TelegramCallbackQuery(
+        transport="telegram",
+        chat_id=123,
+        message_id=progress_id,
+        callback_query_id="cbq-open",
+        data="untether:cancel",
+        sender_id=123,
+    )
+
+    await handle_callback_cancel(cfg, query, running_tasks)
+
+    assert running_task.cancel_requested.is_set() is True
+
+
 def test_allowed_chat_ids_include_allowed_user_ids() -> None:
     cfg = replace(make_cfg(FakeTransport()), allowed_user_ids=(42,))
     allowed = telegram_loop._allowed_chat_ids(cfg)

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.0"
+version = "0.35.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- **Security:** Validate callback query sender in group chats (#192), escape tag name in CI workflow (#193), sanitise flag-like prompts in Gemini/AMP (#194)
- **Stall detection:** Reduce false positives during Agent subagent work with tree CPU tracking (#264)
- **Bug fix:** `/ping` uptime now resets on service restart (#234)

## Issues closed
- #192 — callback query sender not validated in group chats
- #193 — tag name injection in notify-website CI workflow
- #194 — user prompt passed as CLI arg without `--` separator (flag injection)
- #234 — `/ping` uptime does not reset on service restart
- #264 — stall warnings fire false positives during normal Agent/Bash workflows

## Integration test results
All tests passed against `@untether_dev_bot` (2026-04-03):
- Tier 7: `/ping` on all 6 engines + 6 command smoke tests
- Tier 1: Basic prompts on Claude, Gemini, AMP
- Tier 2: Cancel button, `/cancel`, `/new`
- Tier 6: 3 stall detection regression tests (0 false warnings)
- Issue-specific: uptime reset after `/restart`, flag injection on Gemini/AMP
- Log inspection: clean (no exceptions, no zombies, 5 FDs)

## Test plan
- [x] 1843 unit tests pass (81.39% coverage)
- [x] Ruff lint clean
- [x] Release validation passes
- [x] Integration tests pass on @untether_dev_bot
- [ ] Staging dogfood on @hetz_lba1_bot (after merge to dev → TestPyPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)