### PR TITLE
fix: bypass diff_preview gate after ExitPlanMode approval (#283)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,11 +166,11 @@ Rules in `.claude/rules/` auto-load when editing matching files:
 
 ## Tests
 
-2020 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
+2025 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
 
 Key test files:
 
-- `test_claude_control.py` — 67 tests: control requests, response routing, registry lifecycle, auto-approve/auto-deny, tool auto-approve, custom deny messages, discuss action, early toast, progressive cooldown, auto permission mode
+- `test_claude_control.py` — 99 tests: control requests, response routing, registry lifecycle, auto-approve/auto-deny, tool auto-approve, custom deny messages, discuss action, early toast, progressive cooldown, auto permission mode, diff_preview plan bypass
 - `test_callback_dispatch.py` — 26 tests: callback parsing, dispatch toast/ephemeral behaviour, early answering
 - `test_exec_bridge.py` — 140 tests: ephemeral notification cleanup, approval push notifications, progressive stall warnings, stall diagnostics, stall auto-cancel with CPU-active suppression (sleeping-process aware), tool-active repeat suppression, approval-aware stall threshold, MCP tool stall threshold, frozen ring buffer hung escalation, session summary, PID/stream threading, auto-continue detection, signal death suppression
 - `test_ask_user_question.py` — 29 tests: AskUserQuestion control request handling, question extraction, pending request registry, answer routing, option button rendering, multi-question flows, structured answer responses, ask mode toggle auto-deny

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.1rc2"
+version = "0.35.1rc3"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -94,6 +94,11 @@ _DISCUSS_COOLDOWN: dict[str, tuple[float, int]] = {}
 # When Claude Code next calls ExitPlanMode, it will be auto-approved.
 _DISCUSS_APPROVED: set[str] = set()
 
+# Plan exit approved: session_ids where ExitPlanMode was manually approved.
+# After plan approval, diff_preview tools (Edit/Write/Bash) auto-approve instead
+# of requiring per-tool manual approval — the user already reviewed the plan (#283).
+_PLAN_EXIT_APPROVED: set[str] = set()
+
 # Sessions where "Pause & Outline Plan" was clicked and we're waiting for outline text.
 # StreamTextBlock handler checks this to emit visible note events in the progress message.
 _OUTLINE_PENDING: set[str] = set()
@@ -548,12 +553,19 @@ def translate_claude_event(
                 tool_name = getattr(request, "tool_name", "unknown")
                 if tool_name not in _TOOLS_REQUIRING_APPROVAL:
                     # When diff_preview is enabled, route previewable tools
-                    # through interactive approval so users see the diff
+                    # through interactive approval so users see the diff.
+                    # Bypass after ExitPlanMode approval — the user already
+                    # reviewed the plan, per-tool approval is redundant (#283).
                     run_opts = get_run_options()
+                    session_id = factory.resume.value if factory.resume else None
+                    plan_approved = (
+                        session_id is not None and session_id in _PLAN_EXIT_APPROVED
+                    )
                     if (
                         run_opts
                         and run_opts.diff_preview is True
                         and tool_name in _DIFF_PREVIEW_TOOLS
+                        and not plan_approved
                     ):
                         logger.debug(
                             "control_request.diff_preview_gate",
@@ -1069,7 +1081,12 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             # Claude Code CLI requires updatedInput for can_use_tool responses
             if request_id in _REQUEST_TO_INPUT:
                 inner["updatedInput"] = _REQUEST_TO_INPUT.pop(request_id)
-            _REQUEST_TO_TOOL_NAME.pop(request_id, None)
+            tool_name = _REQUEST_TO_TOOL_NAME.pop(request_id, None)
+            # After plan approval, bypass diff_preview gate for subsequent
+            # tools — user already reviewed the plan (#283)
+            session_id_for_plan = _REQUEST_TO_SESSION.get(request_id)
+            if tool_name == "ExitPlanMode" and session_id_for_plan:
+                _PLAN_EXIT_APPROVED.add(session_id_for_plan)
         else:
             inner = {"behavior": "deny", "message": deny_message or "User denied"}
             # Clean up stored input on denial too
@@ -1983,6 +2000,9 @@ def _cleanup_session_registries(session_id: str) -> None:
     if session_id in _DISCUSS_APPROVED:
         cleaned.append("discuss_approved")
     _DISCUSS_APPROVED.discard(session_id)
+    if session_id in _PLAN_EXIT_APPROVED:
+        cleaned.append("plan_exit_approved")
+    _PLAN_EXIT_APPROVED.discard(session_id)
     if session_id in _OUTLINE_PENDING:
         cleaned.append("outline_pending")
     _OUTLINE_PENDING.discard(session_id)

--- a/tests/test_claude_control.py
+++ b/tests/test_claude_control.py
@@ -18,6 +18,7 @@ from untether.runners.claude import (
     _DISCUSS_COOLDOWN,
     _HANDLED_REQUESTS,
     _OUTLINE_PENDING,
+    _PLAN_EXIT_APPROVED,
     _REQUEST_TO_INPUT,
     _REQUEST_TO_SESSION,
     _REQUEST_TO_TOOL_NAME,
@@ -84,6 +85,7 @@ def _clear_registries():
     _REQUEST_TO_INPUT.clear()
     _HANDLED_REQUESTS.clear()
     _DISCUSS_COOLDOWN.clear()
+    _PLAN_EXIT_APPROVED.clear()
     from untether.telegram.commands.claude_control import _DISCUSS_FEEDBACK_REFS
 
     _DISCUSS_FEEDBACK_REFS.clear()
@@ -1610,6 +1612,75 @@ def test_diff_preview_enabled_non_previewable_still_auto_approved(
 
     assert events == []
     assert f"req-np-{tool_name}" in state.auto_approve_queue
+
+
+@pytest.mark.parametrize("tool_name", ["Edit", "Write", "Bash"])
+def test_diff_preview_bypassed_after_plan_exit_approved(tool_name: str) -> None:
+    """After ExitPlanMode is approved, diff_preview tools auto-approve (#283)."""
+    from untether.runners.run_options import EngineRunOptions, apply_run_options
+
+    state, factory = _make_state_with_session()
+    session_id = factory.resume.value
+    # Simulate plan exit approval
+    _PLAN_EXIT_APPROVED.add(session_id)
+
+    event = _decode_event(
+        {
+            "type": "control_request",
+            "request_id": f"req-pea-{tool_name}",
+            "request": {
+                "subtype": "can_use_tool",
+                "tool_name": tool_name,
+                "input": {},
+            },
+        }
+    )
+    with apply_run_options(EngineRunOptions(diff_preview=True)):
+        events = translate_claude_event(
+            event, title="claude", state=state, factory=factory
+        )
+
+    # Should be auto-approved despite diff_preview=True
+    assert events == []
+    assert f"req-pea-{tool_name}" in state.auto_approve_queue
+
+
+def test_diff_preview_not_bypassed_without_plan_exit() -> None:
+    """Without ExitPlanMode approval, diff_preview gate still applies (#283)."""
+    from untether.runners.run_options import EngineRunOptions, apply_run_options
+
+    state, factory = _make_state_with_session()
+    # _PLAN_EXIT_APPROVED is empty — no plan exit approved
+
+    event = _decode_event(
+        {
+            "type": "control_request",
+            "request_id": "req-nopea",
+            "request": {
+                "subtype": "can_use_tool",
+                "tool_name": "Edit",
+                "input": {"file_path": "/tmp/x", "old_string": "a", "new_string": "b"},
+            },
+        }
+    )
+    with apply_run_options(EngineRunOptions(diff_preview=True)):
+        events = translate_claude_event(
+            event, title="claude", state=state, factory=factory
+        )
+
+    # Should NOT be auto-approved — diff_preview gate still active
+    assert "req-nopea" not in state.auto_approve_queue
+    assert len(events) >= 1
+
+
+def test_plan_exit_approved_cleaned_up_on_session_end() -> None:
+    """_PLAN_EXIT_APPROVED is cleaned up when session ends (#283)."""
+    session_id = "sess-cleanup-283"
+    _PLAN_EXIT_APPROVED.add(session_id)
+    assert session_id in _PLAN_EXIT_APPROVED
+
+    _cleanup_session_registries(session_id)
+    assert session_id not in _PLAN_EXIT_APPROVED
 
 
 def test_diff_preview_edit_shows_diff_text() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.1rc2"
+version = "0.35.1rc3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **Bug**: when `diff_preview` was enabled (via `/config`) and session in plan mode, approving ExitPlanMode did NOT auto-approve subsequent Edit/Write/Bash tools — user had to manually approve every tool call, defeating the plan mode UX
- **Fix**: track plan exit approval per-session (`_PLAN_EXIT_APPROVED` registry), bypass the diff_preview gate after the plan is approved
- **Version**: bumps to v0.35.1rc3 for staging

Fixes [#283](https://github.com/littlebearapps/untether/issues/283)

## Changes

- `src/untether/runners/claude.py`: add `_PLAN_EXIT_APPROVED` session registry, check in diff_preview gate, set on ExitPlanMode approval in `write_control_response()`, clean up in `_cleanup_session_registries()`
- `tests/test_claude_control.py`: 5 new tests — bypass works (3 parametrized), gate still applies without plan exit, cleanup on session end
- `CLAUDE.md`: update test counts (2025 tests, 99 in test_claude_control)
- `pyproject.toml` + `uv.lock`: version bump to 0.35.1rc3

## Test plan

- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run ruff check src/` — clean
- [x] `uv run pytest` — 2025 passed, 81.56% coverage
- [ ] Integration test on `@untether_dev_bot`: enable diff_preview on a chat, run a plan mode session, approve ExitPlanMode, verify subsequent tools auto-approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)