### PR TITLE
feat: hot-reload trigger config without restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Untether adds interactive permission control, plan mode support, and several UX 
 - **Resume line formatting** — visual separation with blank line and ↩️ prefix in final message footer
 - **`/continue`** — cross-environment resume; pick up the most recent CLI session from Telegram using each engine's native continue flag (`--continue`, `resume --last`, `--resume latest`); supported for Claude, Codex, OpenCode, Pi, Gemini (not AMP)
 - **Timezone-aware cron triggers** — per-cron `timezone` or global `default_timezone` with IANA names (e.g. `Australia/Melbourne`); DST-aware via `zoneinfo`; invalid names rejected at config parse time
+- **Hot-reload trigger configuration** — editing `untether.toml` applies cron/webhook changes immediately without restart; `TriggerManager` holds mutable state that the cron scheduler and webhook server reference at runtime; `handle_reload()` re-parses `[triggers]` on config file change
 
 See `.claude/skills/claude-stream-json/` and `.claude/rules/control-channel.md` for implementation details.
 
@@ -85,6 +86,7 @@ Telegram <-> TelegramPresenter <-> RunnerBridge <-> Runner (claude/codex/opencod
 | `commands.py` | Command result types |
 | `scripts/validate_release.py` | Release validation (changelog format, issue links, version match) |
 | `scripts/healthcheck.sh` | Post-deploy health check (systemd, version, logs, Bot API) |
+| `triggers/manager.py` | TriggerManager: mutable cron/webhook holder for hot-reload; atomic config swap on TOML change |
 | `triggers/server.py` | Webhook HTTP server (aiohttp); multipart parsing from cached body, fire-and-forget dispatch |
 | `triggers/dispatcher.py` | Routes webhooks/crons to `run_job()` or non-agent action handlers |
 | `triggers/cron.py` | Cron expression parser, timezone-aware scheduler loop |
@@ -166,7 +168,7 @@ Rules in `.claude/rules/` auto-load when editing matching files:
 
 ## Tests
 
-2025 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
+2038 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
 
 Key test files:
 
@@ -203,6 +205,7 @@ Key test files:
 - `test_trigger_fetch.py` — 12 tests: HTTP GET/POST, file read, parse modes, failure handling, prompt building
 - `test_trigger_auth.py` — 12 tests: bearer token, HMAC-SHA256/SHA1, timing-safe comparison
 - `test_trigger_rate_limit.py` — 5 tests: token bucket fill/drain, per-key isolation, refill timing
+- `test_trigger_manager.py` — 13 tests: TriggerManager init/update/clear, webhook server hot-reload (add/remove/update routes, secret changes, health count), cron schedule swapping, timezone updates
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The wizard offers three **workflow modes** — pick the one that fits:
 - 🔄 **Cross-environment resume** — start a session in your terminal, pick it up from Telegram with `/continue`; works with Claude Code, Codex, OpenCode, Pi, and Gemini ([guide](docs/how-to/cross-environment-resume.md))
 - 📎 **File transfer** — upload files to your repo with `/file put`, download with `/file get`; agents can also deliver files automatically by writing to `.untether-outbox/` during a run — sent as Telegram documents on completion
 - 🛡️ **Graceful recovery** — orphan progress messages cleaned up on restart; stall detection with CPU-aware diagnostics; auto-continue for Claude Code sessions that exit prematurely
-- ⏰ **Scheduled tasks** — cron expressions with timezone support and webhook triggers
+- ⏰ **Scheduled tasks** — cron expressions with timezone support, webhook triggers, and hot-reload configuration (no restart required)
 - 💬 **Forum topics** — map Telegram topics to projects and branches
 - 📤 **Session export** — `/export` for markdown or JSON transcripts
 - 🗂️ **File browser** — `/browse` to navigate project files with inline buttons

--- a/docs/how-to/webhooks-and-cron.md
+++ b/docs/how-to/webhooks-and-cron.md
@@ -244,6 +244,30 @@ Each webhook and cron can specify where the Telegram notification appears:
 
 The server includes a health endpoint at `GET /health` for uptime monitoring.
 
+## Hot-reload configuration
+
+When `watch_config = true` is set in your top-level config, you can add, remove, or modify
+webhooks and crons by editing `untether.toml` — changes are applied automatically without
+restarting Untether. Active runs are not interrupted.
+
+For example, to add a new cron, just edit the TOML and save:
+
+```toml
+[[triggers.crons]]
+id = "new-task"
+schedule = "0 14 * * 1-5"
+prompt = "Check the deployment status"
+timezone = "Australia/Melbourne"
+```
+
+The new cron will start firing on the next minute tick. Similarly, new webhooks become
+accessible immediately, and removed webhooks start returning 404.
+
+!!! note
+    Server settings (`host`, `port`, `rate_limit`) and the `enabled` toggle still
+    require a restart. See the [Triggers reference — Hot-reload](../reference/triggers/triggers.md#hot-reload)
+    for the full list.
+
 ## Security notes
 
 - The server binds to localhost by default. Use a reverse proxy (nginx, Caddy) with TLS to expose it to the internet.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -452,6 +452,12 @@ routing details.
 | `enabled` | bool | `false` | Master switch. No server or cron loop starts when `false`. |
 | `default_timezone` | string\|null | `null` | Default IANA timezone for all crons (e.g. `"Australia/Melbourne"`). Per-cron `timezone` overrides. |
 
+!!! tip "Hot-reload"
+    When `watch_config = true`, changes to webhooks, crons, schedules, and timezones
+    are applied automatically without restart. Server settings (`host`, `port`,
+    `rate_limit`) and the `enabled` toggle still require a restart.
+    See the [Triggers reference — Hot-reload](triggers/triggers.md#hot-reload) for details.
+
 ### `[triggers.server]`
 
 | Key | Type | Default | Notes |

--- a/docs/reference/triggers/triggers.md
+++ b/docs/reference/triggers/triggers.md
@@ -551,11 +551,49 @@ Expected responses:
 | `413 Payload Too Large` | Body exceeds `max_body_bytes`. |
 | `429 Too Many Requests` | Rate limit exceeded. |
 
+## Hot-reload
+
+When `watch_config = true` is set in the top-level config, changes to the `[triggers]` section
+of `untether.toml` are detected automatically and applied without restarting Untether. This means
+you can add, remove, or modify crons and webhooks by editing the TOML file — changes take effect
+within seconds, and active runs are not interrupted.
+
+### What reloads without restart
+
+| Change | When it takes effect |
+|--------|---------------------|
+| Add/remove/modify cron schedules | Next minute tick |
+| Add new webhooks | Immediately (next HTTP request) |
+| Remove webhooks | Immediately (returns 404) |
+| Change webhook auth/secrets | Next HTTP request |
+| Change webhook action type | Next HTTP request |
+| Change multipart/file upload settings | Next HTTP request |
+| Change cron fetch config | Next cron fire |
+| Change cron timezone | Next minute tick |
+| Change `default_timezone` | Next minute tick |
+
+### What requires a restart
+
+| Change | Why |
+|--------|-----|
+| `triggers.enabled` (off to on) | Webhook server and cron scheduler must be started |
+| `triggers.server.host` or `port` | aiohttp binds once at startup |
+| `triggers.server.rate_limit` | Rate limiter initialised at startup |
+
+### How it works
+
+A `TriggerManager` holds the current cron list and webhook lookup table. The cron scheduler
+reads `manager.crons` on each tick, and the webhook server calls `manager.webhook_for_path()`
+on each request. When the config file changes, `handle_reload()` re-parses the `[triggers]`
+TOML section and calls `manager.update()`, which atomically swaps the configuration. In-flight
+iterations over the old cron list are unaffected because `update()` creates new container objects.
+
 ## Key files
 
 | File | Purpose |
 |------|---------|
 | `src/untether/triggers/__init__.py` | Package init, re-exports settings models. |
+| `src/untether/triggers/manager.py` | `TriggerManager`: mutable cron/webhook holder for hot-reload. Atomic config swap on TOML change. |
 | `src/untether/triggers/actions.py` | Non-agent action handlers: `file_write`, `http_forward`, `notify_only`. |
 | `src/untether/triggers/settings.py` | Pydantic models: `TriggersSettings`, `WebhookConfig`, `CronConfig`, `TriggerServerSettings`. |
 | `src/untether/triggers/auth.py` | Bearer and HMAC-SHA256/SHA1 verification with timing-safe comparison. |

--- a/src/untether/telegram/loop.py
+++ b/src/untether/telegram/loop.py
@@ -527,6 +527,7 @@ class TelegramLoopState:
 
 if TYPE_CHECKING:
     from ..runner_bridge import RunningTasks
+    from ..triggers.manager import TriggerManager
 
 
 _FORWARD_FIELDS = (
@@ -1296,6 +1297,31 @@ async def run_main_loop(
                     )
                     state.transport_id = reload.settings.transport
 
+                # --- Hot-reload trigger configuration ---
+                if trigger_manager is not None:
+                    try:
+                        from ..config import read_config
+                        from ..triggers.settings import (
+                            TriggersSettings,
+                            parse_trigger_config,
+                        )
+
+                        raw_toml = read_config(reload.config_path)
+                        raw_triggers = raw_toml.get("triggers")
+                        if isinstance(raw_triggers, dict) and raw_triggers.get(
+                            "enabled"
+                        ):
+                            new_settings = parse_trigger_config(raw_triggers)
+                            trigger_manager.update(new_settings)
+                        else:
+                            # Triggers disabled or removed — clear all.
+                            trigger_manager.update(TriggersSettings())
+                    except (ValueError, TypeError, OSError) as exc:
+                        logger.warning(
+                            "config.reload.triggers_failed",
+                            error=str(exc),
+                        )
+
             if watch_enabled and config_path is not None:
 
                 async def run_config_watch() -> None:
@@ -1486,34 +1512,34 @@ async def run_main_loop(
             scheduler = ThreadScheduler(task_group=tg, run_job=run_thread_job)
 
             # --- Trigger system (webhooks + cron) ---
+            trigger_manager: TriggerManager | None = None
             if cfg.trigger_config and cfg.trigger_config.get("enabled"):
                 from ..triggers.cron import run_cron_scheduler
                 from ..triggers.dispatcher import TriggerDispatcher
+                from ..triggers.manager import TriggerManager
                 from ..triggers.server import run_webhook_server
                 from ..triggers.settings import parse_trigger_config
 
                 try:
                     trigger_settings = parse_trigger_config(cfg.trigger_config)
+                    trigger_manager = TriggerManager(trigger_settings)
                     trigger_dispatcher = TriggerDispatcher(
                         run_job=run_job,
                         transport=cfg.exec_cfg.transport,
                         default_chat_id=cfg.chat_id,
                         task_group=tg,
                     )
-                    if trigger_settings.webhooks:
+                    # Always start the cron scheduler — it idles when the
+                    # cron list is empty and picks up new crons on reload.
+                    tg.start_soon(
+                        run_cron_scheduler, trigger_manager, trigger_dispatcher
+                    )
+                    if trigger_settings.webhooks or trigger_settings.server:
                         tg.start_soon(
                             run_webhook_server,
                             trigger_settings,
                             trigger_dispatcher,
-                        )
-                    if trigger_settings.crons:
-                        tg.start_soon(
-                            partial(
-                                run_cron_scheduler,
-                                trigger_settings.crons,
-                                trigger_dispatcher,
-                                default_timezone=trigger_settings.default_timezone,
-                            ),
+                            trigger_manager,
                         )
                     logger.info(
                         "triggers.enabled",

--- a/src/untether/triggers/cron.py
+++ b/src/untether/triggers/cron.py
@@ -9,7 +9,7 @@ import anyio
 
 from ..logging import get_logger
 from .dispatcher import TriggerDispatcher
-from .settings import CronConfig
+from .manager import TriggerManager
 
 logger = get_logger(__name__)
 
@@ -82,17 +82,23 @@ def _resolve_now(
 
 
 async def run_cron_scheduler(
-    crons: list[CronConfig],
+    manager: TriggerManager,
     dispatcher: TriggerDispatcher,
-    *,
-    default_timezone: str | None = None,
 ) -> None:
-    """Tick every minute and dispatch crons whose schedule matches."""
-    logger.info("triggers.cron.started", crons=len(crons))
+    """Tick every minute and dispatch crons whose schedule matches.
+
+    Reads ``manager.crons`` and ``manager.default_timezone`` on each tick
+    so that config hot-reloads take effect immediately.
+    """
+    logger.info("triggers.cron.started", crons=len(manager.crons))
     last_fired: dict[str, tuple[int, int]] = {}  # cron_id -> (hour, minute)
 
     while True:
         utc_now = datetime.datetime.now(datetime.UTC)
+        # Snapshot the cron list for this tick — safe even if update()
+        # replaces manager._crons mid-iteration (new list, old ref valid).
+        crons = manager.crons
+        default_timezone = manager.default_timezone
         for cron in crons:
             try:
                 local_now = _resolve_now(utc_now, cron.timezone, default_timezone)

--- a/src/untether/triggers/manager.py
+++ b/src/untether/triggers/manager.py
@@ -1,0 +1,94 @@
+"""Mutable holder for trigger configuration, supporting hot-reload.
+
+The ``TriggerManager`` is shared between the cron scheduler and webhook
+server.  On config reload, the manager's state is atomically replaced
+so that subsequent ticks/requests see the new configuration immediately.
+"""
+
+from __future__ import annotations
+
+from ..logging import get_logger
+from .settings import CronConfig, TriggersSettings, WebhookConfig
+
+logger = get_logger(__name__)
+
+__all__ = ["TriggerManager"]
+
+
+class TriggerManager:
+    """Thread-safe (single-event-loop) mutable trigger configuration holder.
+
+    The cron scheduler reads ``crons`` and ``default_timezone`` each tick.
+    The webhook server calls ``webhook_for_path()`` on each request.
+    ``update()`` replaces both atomically via simple attribute assignment —
+    safe in a single-threaded asyncio loop because coroutines only yield
+    at ``await`` points.
+    """
+
+    __slots__ = ("_crons", "_default_timezone", "_webhooks_by_path")
+
+    def __init__(self, settings: TriggersSettings | None = None) -> None:
+        self._crons: list[CronConfig] = []
+        self._webhooks_by_path: dict[str, WebhookConfig] = {}
+        self._default_timezone: str | None = None
+        if settings is not None:
+            self.update(settings)
+
+    def update(self, settings: TriggersSettings) -> None:
+        """Replace cron and webhook configuration.
+
+        Creates new container objects so that in-flight iterations over
+        the previous ``crons`` list are unaffected.
+        """
+        old_cron_ids = {c.id for c in self._crons}
+        old_webhook_ids = {wh.id for wh in self._webhooks_by_path.values()}
+
+        self._crons = list(settings.crons)
+        self._webhooks_by_path = {wh.path: wh for wh in settings.webhooks}
+        self._default_timezone = settings.default_timezone
+
+        new_cron_ids = {c.id for c in self._crons}
+        new_webhook_ids = {wh.id for wh in self._webhooks_by_path.values()}
+
+        # Log changes for observability.
+        added_crons = new_cron_ids - old_cron_ids
+        removed_crons = old_cron_ids - new_cron_ids
+        added_webhooks = new_webhook_ids - old_webhook_ids
+        removed_webhooks = old_webhook_ids - new_webhook_ids
+
+        if added_crons or removed_crons or added_webhooks or removed_webhooks:
+            logger.info(
+                "triggers.manager.updated",
+                crons_added=sorted(added_crons) if added_crons else None,
+                crons_removed=sorted(removed_crons) if removed_crons else None,
+                webhooks_added=sorted(added_webhooks) if added_webhooks else None,
+                webhooks_removed=sorted(removed_webhooks) if removed_webhooks else None,
+                total_crons=len(self._crons),
+                total_webhooks=len(self._webhooks_by_path),
+            )
+
+        # Warn about unauthenticated webhooks.
+        for wh in settings.webhooks:
+            if wh.auth == "none" and wh.id in added_webhooks:
+                logger.warning(
+                    "triggers.webhook.no_auth",
+                    webhook_id=wh.id,
+                    path=wh.path,
+                )
+
+    @property
+    def crons(self) -> list[CronConfig]:
+        """Current cron list — the scheduler iterates this each tick."""
+        return self._crons
+
+    @property
+    def default_timezone(self) -> str | None:
+        return self._default_timezone
+
+    def webhook_for_path(self, path: str) -> WebhookConfig | None:
+        """Look up a webhook by its HTTP path."""
+        return self._webhooks_by_path.get(path)
+
+    @property
+    def webhook_count(self) -> int:
+        return len(self._webhooks_by_path)

--- a/src/untether/triggers/server.py
+++ b/src/untether/triggers/server.py
@@ -13,6 +13,7 @@ from ..logging import get_logger
 from .actions import _deny_reason, _resolve_file_path
 from .auth import verify_auth
 from .dispatcher import TriggerDispatcher
+from .manager import TriggerManager
 from .rate_limit import TokenBucketLimiter
 from .settings import TriggersSettings, WebhookConfig
 from .templating import render_prompt
@@ -168,9 +169,31 @@ async def _parse_multipart(
 def build_webhook_app(
     settings: TriggersSettings,
     dispatcher: TriggerDispatcher,
+    manager: TriggerManager | None = None,
 ) -> web.Application:
-    """Build the aiohttp application for webhook handling."""
-    routes_by_path: dict[str, WebhookConfig] = {wh.path: wh for wh in settings.webhooks}
+    """Build the aiohttp application for webhook handling.
+
+    If *manager* is provided, webhook lookups use ``manager.webhook_for_path()``
+    so that config hot-reloads take effect on the next request.  When *manager*
+    is ``None`` (backwards compat / tests), a static lookup table is used.
+    """
+    # Static fallback when no manager is provided.
+    _static_routes: dict[str, WebhookConfig] | None = (
+        None if manager is not None else {wh.path: wh for wh in settings.webhooks}
+    )
+
+    def _lookup(path: str) -> WebhookConfig | None:
+        if manager is not None:
+            return manager.webhook_for_path(path)
+        assert _static_routes is not None
+        return _static_routes.get(path)
+
+    def _webhook_count() -> int:
+        if manager is not None:
+            return manager.webhook_count
+        assert _static_routes is not None
+        return len(_static_routes)
+
     rate_limiter = TokenBucketLimiter(
         rate=settings.server.rate_limit,
         window=60.0,
@@ -182,24 +205,26 @@ def build_webhook_app(
     # silently dropped.  Tasks remove themselves on completion.
     _dispatch_tasks: set[asyncio.Task[None]] = set()
 
-    # Warn about unauthenticated webhooks at build time.
-    for wh in settings.webhooks:
-        if wh.auth == "none":
-            logger.warning(
-                "triggers.webhook.no_auth",
-                webhook_id=wh.id,
-                path=wh.path,
-            )
+    # Warn about unauthenticated webhooks at build time (only when no manager;
+    # TriggerManager.update() handles this for hot-reload).
+    if manager is None:
+        for wh in settings.webhooks:
+            if wh.auth == "none":
+                logger.warning(
+                    "triggers.webhook.no_auth",
+                    webhook_id=wh.id,
+                    path=wh.path,
+                )
 
     async def handle_health(request: web.Request) -> web.Response:
         return web.Response(
-            text=json.dumps({"status": "ok", "webhooks": len(routes_by_path)}),
+            text=json.dumps({"status": "ok", "webhooks": _webhook_count()}),
             content_type="application/json",
         )
 
     async def handle_webhook(request: web.Request) -> web.Response:
         path = request.path
-        webhook = routes_by_path.get(path)
+        webhook = _lookup(path)
         if webhook is None:
             return web.Response(status=404, text="not found")
 
@@ -325,9 +350,10 @@ def build_webhook_app(
 async def run_webhook_server(
     settings: TriggersSettings,
     dispatcher: TriggerDispatcher,
+    manager: TriggerManager | None = None,
 ) -> None:
     """Run the webhook HTTP server until cancelled."""
-    app = build_webhook_app(settings, dispatcher)
+    app = build_webhook_app(settings, dispatcher, manager=manager)
 
     runner = web.AppRunner(app, access_log=None)
     await runner.setup()

--- a/tests/test_trigger_manager.py
+++ b/tests/test_trigger_manager.py
@@ -1,0 +1,334 @@
+"""Tests for TriggerManager — mutable trigger config holder for hot-reload."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from untether.transport import MessageRef
+from untether.triggers.manager import TriggerManager
+from untether.triggers.server import build_webhook_app
+from untether.triggers.settings import TriggersSettings, parse_trigger_config
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _settings(**overrides: Any) -> TriggersSettings:
+    base: dict[str, Any] = {"enabled": True}
+    base.update(overrides)
+    return parse_trigger_config(base)
+
+
+def _webhook(
+    wh_id: str = "wh1",
+    path: str = "/hooks/test",
+    secret: str = "tok_123",
+    **kw: Any,
+) -> dict[str, Any]:
+    return {
+        "id": wh_id,
+        "path": path,
+        "auth": "bearer",
+        "secret": secret,
+        "prompt_template": "Event: {{text}}",
+        **kw,
+    }
+
+
+def _cron(
+    cron_id: str = "cr1",
+    schedule: str = "0 9 * * *",
+    prompt: str = "hello",
+    **kw: Any,
+) -> dict[str, Any]:
+    return {"id": cron_id, "schedule": schedule, "prompt": prompt, **kw}
+
+
+@dataclass
+class FakeTransport:
+    sent: list[dict[str, Any]] = field(default_factory=list)
+    _next_id: int = 1
+
+    async def send(self, *, channel_id, message, options=None):
+        ref = MessageRef(channel_id=channel_id, message_id=self._next_id)
+        self._next_id += 1
+        self.sent.append({"channel_id": channel_id, "text": message.text})
+        return ref
+
+    async def edit(self, *, ref, message, wait=True):
+        return ref
+
+    async def delete(self, *, ref):
+        return True
+
+    async def close(self):
+        pass
+
+
+@dataclass
+class FakeTaskGroup:
+    tasks: list = field(default_factory=list)
+
+    def start_soon(self, fn, *args):
+        self.tasks.append((fn, args))
+
+
+@dataclass
+class RunJobCapture:
+    calls: list = field(default_factory=list)
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append(args)
+
+
+def _make_dispatcher(transport=None, run_job=None):
+    from untether.triggers.dispatcher import TriggerDispatcher
+
+    transport = transport or FakeTransport()
+    run_job = run_job or RunJobCapture()
+    return TriggerDispatcher(
+        run_job=run_job,
+        transport=transport,
+        default_chat_id=100,
+        task_group=FakeTaskGroup(),  # type: ignore[arg-type]
+    )
+
+
+# ── TriggerManager unit tests ───────────────────────────────────────
+
+
+class TestTriggerManagerInit:
+    def test_empty_init(self):
+        mgr = TriggerManager()
+        assert mgr.crons == []
+        assert mgr.webhook_for_path("/any") is None
+        assert mgr.webhook_count == 0
+        assert mgr.default_timezone is None
+
+    def test_init_with_settings(self):
+        s = _settings(
+            webhooks=[_webhook()],
+            crons=[_cron()],
+            default_timezone="Australia/Melbourne",
+        )
+        mgr = TriggerManager(s)
+        assert len(mgr.crons) == 1
+        assert mgr.crons[0].id == "cr1"
+        assert mgr.webhook_for_path("/hooks/test") is not None
+        assert mgr.webhook_count == 1
+        assert mgr.default_timezone == "Australia/Melbourne"
+
+
+class TestTriggerManagerUpdate:
+    def test_update_replaces_crons(self):
+        mgr = TriggerManager(_settings(crons=[_cron("a")]))
+        assert len(mgr.crons) == 1
+        assert mgr.crons[0].id == "a"
+
+        mgr.update(_settings(crons=[_cron("b"), _cron("c")]))
+        assert len(mgr.crons) == 2
+        ids = {c.id for c in mgr.crons}
+        assert ids == {"b", "c"}
+
+    def test_update_replaces_webhooks(self):
+        mgr = TriggerManager(_settings(webhooks=[_webhook("wh1", "/hooks/one")]))
+        assert mgr.webhook_for_path("/hooks/one") is not None
+        assert mgr.webhook_for_path("/hooks/two") is None
+
+        mgr.update(_settings(webhooks=[_webhook("wh2", "/hooks/two")]))
+        assert mgr.webhook_for_path("/hooks/one") is None
+        assert mgr.webhook_for_path("/hooks/two") is not None
+
+    def test_update_clears_when_empty(self):
+        mgr = TriggerManager(
+            _settings(
+                webhooks=[_webhook()],
+                crons=[_cron()],
+            )
+        )
+        assert mgr.webhook_count == 1
+        assert len(mgr.crons) == 1
+
+        mgr.update(TriggersSettings())
+        assert mgr.webhook_count == 0
+        assert mgr.crons == []
+
+    def test_update_timezone(self):
+        mgr = TriggerManager(_settings(default_timezone="America/New_York"))
+        assert mgr.default_timezone == "America/New_York"
+
+        mgr.update(_settings(default_timezone="Australia/Melbourne"))
+        assert mgr.default_timezone == "Australia/Melbourne"
+
+    def test_old_cron_list_unaffected_by_update(self):
+        """In-flight iteration safety: old list ref stays valid after update."""
+        mgr = TriggerManager(_settings(crons=[_cron("a")]))
+        old_crons = mgr.crons  # grab reference
+        mgr.update(_settings(crons=[_cron("b")]))
+        # Old reference should still have the old data.
+        assert len(old_crons) == 1
+        assert old_crons[0].id == "a"
+        # New data via property.
+        assert mgr.crons[0].id == "b"
+
+
+# ── Webhook server with TriggerManager ──────────────────────────────
+
+
+class TestWebhookServerWithManager:
+    @pytest.mark.anyio
+    async def test_health_reflects_manager_count(self):
+        settings = _settings(webhooks=[_webhook()])
+        mgr = TriggerManager(settings)
+        dispatcher = _make_dispatcher()
+        app = build_webhook_app(settings, dispatcher, manager=mgr)
+
+        async with TestClient(TestServer(app)) as cl:
+            resp = await cl.get("/health")
+            data = await resp.json()
+            assert data["webhooks"] == 1
+
+            # Hot-reload: add a second webhook.
+            mgr.update(
+                _settings(
+                    webhooks=[
+                        _webhook("wh1", "/hooks/one"),
+                        _webhook("wh2", "/hooks/two"),
+                    ]
+                )
+            )
+            resp = await cl.get("/health")
+            data = await resp.json()
+            assert data["webhooks"] == 2
+
+    @pytest.mark.anyio
+    async def test_new_webhook_accessible_after_update(self):
+        settings = _settings(webhooks=[_webhook("wh1", "/hooks/one")])
+        mgr = TriggerManager(settings)
+        dispatcher = _make_dispatcher()
+        app = build_webhook_app(settings, dispatcher, manager=mgr)
+
+        async with TestClient(TestServer(app)) as cl:
+            # /hooks/two doesn't exist yet.
+            resp = await cl.post(
+                "/hooks/two",
+                headers={"Authorization": "Bearer tok_456"},
+                json={"text": "hi"},
+            )
+            assert resp.status == 404
+
+            # Hot-reload: add /hooks/two.
+            mgr.update(
+                _settings(
+                    webhooks=[
+                        _webhook("wh1", "/hooks/one"),
+                        _webhook("wh2", "/hooks/two", secret="tok_456"),
+                    ]
+                )
+            )
+
+            resp = await cl.post(
+                "/hooks/two",
+                headers={"Authorization": "Bearer tok_456"},
+                json={"text": "hi"},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.anyio
+    async def test_removed_webhook_returns_404(self):
+        settings = _settings(
+            webhooks=[
+                _webhook("wh1", "/hooks/one"),
+                _webhook("wh2", "/hooks/two"),
+            ]
+        )
+        mgr = TriggerManager(settings)
+        dispatcher = _make_dispatcher()
+        app = build_webhook_app(settings, dispatcher, manager=mgr)
+
+        async with TestClient(TestServer(app)) as cl:
+            # Both exist.
+            resp = await cl.post(
+                "/hooks/one",
+                headers={"Authorization": "Bearer tok_123"},
+                json={"text": "hi"},
+            )
+            assert resp.status == 202
+
+            # Hot-reload: remove /hooks/one.
+            mgr.update(_settings(webhooks=[_webhook("wh2", "/hooks/two")]))
+
+            resp = await cl.post(
+                "/hooks/one",
+                headers={"Authorization": "Bearer tok_123"},
+                json={"text": "hi"},
+            )
+            assert resp.status == 404
+
+    @pytest.mark.anyio
+    async def test_webhook_secret_update_takes_effect(self):
+        settings = _settings(
+            webhooks=[_webhook("wh1", "/hooks/test", secret="old_secret")]
+        )
+        mgr = TriggerManager(settings)
+        dispatcher = _make_dispatcher()
+        app = build_webhook_app(settings, dispatcher, manager=mgr)
+
+        async with TestClient(TestServer(app)) as cl:
+            # Old secret works.
+            resp = await cl.post(
+                "/hooks/test",
+                headers={"Authorization": "Bearer old_secret"},
+                json={"text": "hi"},
+            )
+            assert resp.status == 202
+
+            # Hot-reload: change secret.
+            mgr.update(
+                _settings(
+                    webhooks=[_webhook("wh1", "/hooks/test", secret="new_secret")]
+                )
+            )
+
+            # Old secret fails.
+            resp = await cl.post(
+                "/hooks/test",
+                headers={"Authorization": "Bearer old_secret"},
+                json={"text": "hi"},
+            )
+            assert resp.status == 401
+
+            # New secret works.
+            resp = await cl.post(
+                "/hooks/test",
+                headers={"Authorization": "Bearer new_secret"},
+                json={"text": "hi"},
+            )
+            assert resp.status == 202
+
+
+# ── Cron scheduler with TriggerManager ──────────────────────────────
+
+
+class TestCronSchedulerWithManager:
+    def test_manager_crons_readable(self):
+        """Cron scheduler reads manager.crons each tick."""
+        mgr = TriggerManager(_settings(crons=[_cron("a"), _cron("b")]))
+        assert len(mgr.crons) == 2
+
+        mgr.update(_settings(crons=[_cron("c")]))
+        assert len(mgr.crons) == 1
+        assert mgr.crons[0].id == "c"
+
+    def test_manager_default_timezone_readable(self):
+        mgr = TriggerManager(_settings(default_timezone="America/New_York"))
+        assert mgr.default_timezone == "America/New_York"
+
+        mgr.update(_settings(default_timezone="Australia/Melbourne"))
+        assert mgr.default_timezone == "Australia/Melbourne"
+
+        mgr.update(_settings())
+        assert mgr.default_timezone is None


### PR DESCRIPTION
## Summary

Implements hot-reload for trigger configuration (crons and webhooks) so that editing `untether.toml` applies changes immediately without restarting Untether or killing active runs. Closes #269.

- **New `TriggerManager` class** (`triggers/manager.py`) — mutable holder that both the cron scheduler and webhook server reference at runtime
- **Cron scheduler** reads `manager.crons` each tick — new crons fire immediately, removed crons stop matching, `last_fired` dict preserved to prevent double-firing
- **Webhook server** uses `manager.webhook_for_path()` per request — new webhooks accessible immediately, removed webhooks return 404, auth/secret changes take effect on next request
- **Config watcher** (`handle_reload()`) re-reads raw TOML `[triggers]` section and calls `manager.update()` on every config file change

### What's now live-reloadable (no restart needed)

| Setting | Mechanism |
|---------|-----------|
| Cron schedules (add/remove/modify) | TriggerManager — scheduler reads each tick |
| Webhook routes (add/remove/modify) | TriggerManager — per-request lookup |
| Webhook auth/secrets | TriggerManager — per-request lookup |
| Webhook actions (agent_run, file_write, etc.) | TriggerManager — per-request lookup |
| Multipart/file upload settings | TriggerManager — per-request lookup |
| Cron fetch config | TriggerManager — read at fire time |
| Cron timezone (per-cron and default) | TriggerManager — read each tick |
| Projects config / chat routing | Already reloadable via TransportRuntime |
| Engine defaults | Already reloadable via TransportRuntime |
| Watchdog, preamble, footer, cost settings | Already per-run via load_settings_if_exists() |
| Command menu, topic scope | Already refreshed in handle_reload() |

### What still requires a restart

| Setting | Why |
|---------|-----|
| Bot token / chat ID | Baked into Telegram client at startup |
| Webhook server host/port | aiohttp binds once; changing port needs new listener |
| Transport type | Architectural — entire transport stack |
| `triggers.enabled` toggle (off→on) | Webhook server and cron scheduler must be started |
| `session_mode` (stateless↔chat) | Requires state store initialisation |
| `topics.enabled` toggle | Requires topic state store initialisation |
| New engine binaries | Resolved via `shutil.which()` at startup |
| `allowed_user_ids` / `chat_ids` | Frozen in `TelegramBridgeConfig` (future work) |
| Voice transcription settings | Frozen in `TelegramBridgeConfig` (future work) |
| Files settings | Frozen in `TelegramBridgeConfig` (future work) |

### Future work: unfreezing TelegramBridgeConfig

The `TelegramBridgeConfig` dataclass is `frozen=True`, which blocks hot-reload for voice, files, chat_ids, and timing settings. These fields are already read per-message (correct pattern), so unfreezing the config or introducing a config wrapper would make them reloadable with minimal logic changes. Tracked separately from this PR.

## Design decisions

- **Backwards-compatible**: `build_webhook_app()` accepts `manager=None` (default), so all existing tests pass without changes
- **In-flight safety**: `TriggerManager.update()` creates new list/dict objects, so iterations over the old cron list are unaffected (Python's `for` loop grabs the iterator at the start)
- **Webhook server always starts** when triggers are enabled — even with no initial webhooks — so new webhooks added via reload are immediately accessible
- **Cron scheduler always starts** when triggers are enabled — idles when cron list is empty, picks up new crons on next tick

## Test plan

- [x] 13 new tests in `test_trigger_manager.py`:
  - Manager init, update, clear, timezone, in-flight iteration safety
  - Webhook server: add/remove/update routes, secret changes, health count
  - Cron schedule swapping, timezone updates
- [x] All 2038 existing tests pass (81.55% coverage)
- [x] Lint and format clean (`ruff check`, `ruff format --check`)
- [ ] Integration test via `@untether_dev_bot`: edit TOML, add cron, verify fires without restart
- [ ] Integration test: add webhook route, verify accessible without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)