### PR TITLE
fix: address CodeRabbit findings on v0.35.1 release PR (#309)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,11 +307,16 @@ Untether runs on your machine and bridges your agents to Telegram. Here's exactl
 | **Filesystem** | `~/.untether/untether.toml` | Config file containing bot token — protect with `chmod 600` |
 | **Filesystem** | `~/.untether/*.json` | Chat preferences, session state, usage stats |
 | **Filesystem** | `.untether-outbox/` | Agent-delivered files (optional, per-project) |
-| **Processes** | Agent CLIs (claude, codex, etc.) | Spawned as subprocesses with your user permissions |
+| **Filesystem** | `/file put` upload paths | User-initiated file uploads from Telegram, written to configured destinations (default: project working dir) |
+| **Filesystem** | Webhook `file_write` action | When configured, webhooks can write POST bodies to disk at admin-defined paths (deny-globs apply) |
+| **Network** | Webhook `http_forward` action | When configured, webhooks can forward payloads to admin-defined URLs (SSRF-protected) |
+| **Processes** | Agent CLIs (claude, codex, etc.) | Spawned as subprocesses with your user permissions; agents have full filesystem access in their working directory |
 | **Credentials** | Telegram bot token | Stored in config file (plaintext TOML) |
 | **Credentials** | API keys | Read from environment variables, never stored by Untether |
 
-**What Untether does NOT do:** no telemetry, no analytics, no phone-home, no auto-updates, no root access, no system file modifications outside `~/.untether/`. Sensitive tokens are automatically [redacted from logs](https://github.com/littlebearapps/untether/blob/master/docs/how-to/security.md).
+**What Untether does NOT do:** no telemetry, no analytics, no phone-home, no auto-updates, no root access. Sensitive tokens (bot token, OpenAI keys, GitHub tokens) are automatically [redacted from logs](https://github.com/littlebearapps/untether/blob/master/docs/how-to/security.md).
+
+**What Untether *can* do at your direction:** spawned agents, `/file put`, the outbox, and webhook actions can all touch paths outside `~/.untether/` — that's the whole point. Use [`allowed_user_ids`](https://github.com/littlebearapps/untether/blob/master/docs/how-to/security.md), file deny-globs, and webhook auth to control who can trigger these flows.
 
 ---
 

--- a/docs/reference/integration-testing.md
+++ b/docs/reference/integration-testing.md
@@ -24,7 +24,7 @@ All integration test tiers are fully automated by Claude Code using Telegram MCP
 ### Test chats
 
 Tests are sent to 6 dedicated engine chats via `@untether_dev_bot` (bot ID `8678330610`).
-For DM-only tests (commands, `/at`, `/cancel`), use the Nathan DM chat ID `8678330610`.
+For DM-only tests (commands, `/at`, `/cancel`), use Nathan's personal DM chat ID with the bot — **not** the bot ID itself. The bot ID identifies the bot account; private chats are addressed by the user's chat ID. Resolve via the Telegram MCP `resolve_username` or by inspecting incoming `update.message.from.id` in the dev logs.
 
 | Chat | Chat ID | Bot API chat_id |
 |------|---------|-----------------|

--- a/docs/reference/specification.md
+++ b/docs/reference/specification.md
@@ -1,10 +1,10 @@
-# Untether Specification v0.35.1 [2026-04-14]
+# Untether Specification v0.35.1 [2026-04-15]
 
 This document is **normative**. The words **MUST**, **SHOULD**, and **MAY** express requirements.
 
 ## 1. Scope
 
-Untether v0.35.0 specifies:
+Untether v0.35.1 specifies:
 
 - A **Telegram** bot bridge that runs an agent **Runner** and posts:
   - a throttled, edited **progress message**

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -876,12 +876,26 @@ class ProgressEdits:
                 # (CPU ticks incrementing between diagnostic snapshots).
                 # Extended thinking phases produce no JSONL events but the
                 # process is alive and busy — killing it is a false positive.
+                #
+                # tree_active covers the case where the main process is
+                # sleeping but child processes (subagents, tool subprocesses)
+                # are burning CPU. Without this branch, long subagent runs are
+                # killed after MAX_WARNINGS even though the child tree is
+                # making progress (#309 CodeRabbit feedback).
                 if cpu_active is True:
                     logger.info(
                         "progress_edits.stall_suppressed_by_activity",
                         channel_id=self.channel_id,
                         stall_warn_count=self._stall_warn_count,
                         pid=self.pid,
+                    )
+                elif tree_active is True and self._has_active_children(diag):
+                    logger.info(
+                        "progress_edits.stall_suppressed_by_tree_activity",
+                        channel_id=self.channel_id,
+                        stall_warn_count=self._stall_warn_count,
+                        pid=self.pid,
+                        child_pids=diag.child_pids if diag else [],
                     )
                 else:
                     auto_cancel_reason = "max_warnings"

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -611,6 +611,13 @@ def translate_claude_event(
                         "control_request.auto_approve_exit_plan_mode",
                         request_id=request_id,
                     )
+                    # #283: also bypass diff_preview gate for subsequent tools
+                    # — same as interactive approval. Without this, users in
+                    # auto permission mode + diff_preview enabled still see
+                    # individual tool gates after plan approval (#309).
+                    auto_session = factory.resume.value if factory.resume else None
+                    if auto_session is not None:
+                        _PLAN_EXIT_APPROVED.add(auto_session)
                     _REQUEST_TO_INPUT[request_id] = getattr(request, "input", {})
                     state.auto_approve_queue.append(request_id)
                     return []
@@ -624,6 +631,9 @@ def translate_claude_event(
                         _DISCUSS_APPROVED.discard(session_id)
                         _OUTLINE_PENDING.discard(session_id)
                         clear_discuss_cooldown(session_id)
+                        # #283: bypass diff_preview gate for subsequent tools
+                        # in this session (#309).
+                        _PLAN_EXIT_APPROVED.add(session_id)
                         logger.info(
                             "control_request.discuss_approved",
                             request_id=request_id,

--- a/src/untether/telegram/bridge.py
+++ b/src/untether/telegram/bridge.py
@@ -139,10 +139,13 @@ class TelegramBridgeConfig:
     """Runtime Telegram-bridge configuration.
 
     Unfrozen as of rc4 (#286) so that hot-reload can update voice, files,
-    chat_ids, allowed_user_ids, and timing settings without a restart.
-    Fields that remain architectural (``bot``, ``runtime``, ``chat_id``,
-    ``session_mode``, ``topics``, ``exec_cfg``) keep their initial values.
-    Use :meth:`update_from` to apply reloaded transport settings.
+    ``allowed_user_ids``, ``show_resume_line``, and timing settings without
+    a restart. Fields that remain architectural (``bot``, ``runtime``,
+    ``chat_id``, ``session_mode``, ``topics``, ``chat_ids``, ``exec_cfg``)
+    keep their initial values; ``chat_ids`` in particular is populated from
+    the projects table at startup and is not exposed via the transport
+    settings hot-reload path. Use :meth:`update_from` to apply reloaded
+    transport settings.
     """
 
     bot: BotClient

--- a/src/untether/telegram/commands/config.py
+++ b/src/untether/telegram/commands/config.py
@@ -1087,6 +1087,20 @@ async def _page_reasoning(ctx: CommandContext, action: str | None = None) -> Non
 
     if action in _RS_ACTIONS:
         level = _RS_ACTIONS[action]
+        # Defensive: only render-time UI exposes engine-allowed levels, but
+        # crafted callback_data could try to persist e.g. `max` on Codex.
+        # Reject anything outside the engine's allow list. #309 CodeRabbit.
+        allowed = allowed_reasoning_levels(current_engine)
+        if level not in allowed:
+            logger.warning(
+                "config.reasoning.unsupported_level",
+                chat_id=chat_id,
+                engine=current_engine,
+                level=level,
+                allowed=sorted(allowed),
+            )
+            await _page_home(ctx)
+            return
         current = await prefs.get_engine_override(chat_id, current_engine)
         updated = EngineOverrides(
             model=current.model if current else None,
@@ -1862,6 +1876,7 @@ class ConfigCommand:
                 "med": "Reasoning: medium",
                 "hi": "Reasoning: high",
                 "xhi": "Reasoning: xhigh",
+                "max": "Reasoning: max",
                 "clr": "Reasoning: cleared",
             },
             "aq": {

--- a/src/untether/telegram/parsing.py
+++ b/src/untether/telegram/parsing.py
@@ -247,8 +247,12 @@ async def poll_incoming(
             allowed = {chat_id}
         for upd in updates:
             offset = upd.update_id + 1
-            if on_offset_advanced is not None:
-                on_offset_advanced(upd.update_id)
             msg = parse_incoming_update(upd, chat_ids=allowed)
             if msg is not None:
                 yield msg
+            # Record offset *after* the consumer has handled (or skipped)
+            # the update, so a crash between yield and persist replays the
+            # update on next start instead of swallowing it. #309 CodeRabbit
+            # feedback (#287). The debounced writer batches these anyway.
+            if on_offset_advanced is not None:
+                on_offset_advanced(upd.update_id)

--- a/src/untether/triggers/actions.py
+++ b/src/untether/triggers/actions.py
@@ -135,10 +135,18 @@ async def execute_file_write(
             logger.warning("triggers.action.file_write.exists", path=str(target))
             return False, msg
         if webhook.on_conflict == "append_timestamp":
+            # Nanosecond resolution + collision probe so two requests in the
+            # same second/millisecond don't clobber each other (the entire
+            # point of append_timestamp). #309 CodeRabbit feedback.
             stem = target.stem
             suffix = target.suffix
-            ts = str(int(time.time()))
-            target = target.parent / f"{stem}_{ts}{suffix}"
+            ts_ns = time.time_ns()
+            candidate = target.parent / f"{stem}_{ts_ns}{suffix}"
+            probe = 0
+            while candidate.exists():
+                probe += 1
+                candidate = target.parent / f"{stem}_{ts_ns}_{probe}{suffix}"
+            target = candidate
 
     # Atomic write.
     try:

--- a/src/untether/triggers/cron.py
+++ b/src/untether/triggers/cron.py
@@ -91,7 +91,10 @@ async def run_cron_scheduler(
     so that config hot-reloads take effect immediately.
     """
     logger.info("triggers.cron.started", crons=len(manager.crons))
-    last_fired: dict[str, tuple[int, int]] = {}  # cron_id -> (hour, minute)
+    # Key the minute fully (year, month, day, hour, minute). A bare (hour, minute)
+    # key would suppress every subsequent day's run because tomorrow's 09:00 looks
+    # identical to today's. See #309 CodeRabbit feedback (Critical).
+    last_fired: dict[str, tuple[int, int, int, int, int]] = {}
 
     while True:
         utc_now = datetime.datetime.now(datetime.UTC)
@@ -107,7 +110,13 @@ async def run_cron_scheduler(
                 logger.exception("triggers.cron.match_failed", cron_id=cron.id)
                 continue
             if matched:
-                key = (local_now.hour, local_now.minute)
+                key = (
+                    local_now.year,
+                    local_now.month,
+                    local_now.day,
+                    local_now.hour,
+                    local_now.minute,
+                )
                 if last_fired.get(cron.id) == key:
                     continue  # already fired this minute
                 last_fired[cron.id] = key

--- a/src/untether/triggers/describe.py
+++ b/src/untether/triggers/describe.py
@@ -22,34 +22,54 @@ __all__ = ["describe_cron"]
 _DAY_NAMES = ("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
 
 
-def _format_dow(dow: str) -> str:
-    """Turn a day-of-week field into a label like 'Mon-Fri' or 'Sat,Sun'."""
+def _normalise_dow(value: int) -> int | None:
+    """Cron day-of-week 0 and 7 both mean Sunday. Anything else (including
+    out-of-range like 8) is invalid and the caller should fall back to raw."""
+    if value == 7:
+        return 0
+    if 0 <= value <= 6:
+        return value
+    return None
+
+
+def _format_dow(dow: str) -> str | None:
+    """Turn a day-of-week field into a label like 'Mon-Fri' or 'Sat,Sun'.
+
+    Returns ``None`` if the field uses an unsupported pattern or
+    out-of-range day. Caller falls back to the raw schedule string. (#309)
+    """
     if dow == "*":
         return ""
     # Range, e.g. "1-5"
     if "-" in dow and "," not in dow and "/" not in dow:
         try:
             start_s, end_s = dow.split("-", 1)
-            start = int(start_s) % 7
-            end = int(end_s) % 7
-            # Cron day-of-week: 0 or 7 = Sunday. Normalise 7→0.
+            start = _normalise_dow(int(start_s))
+            end = _normalise_dow(int(end_s))
+            if start is None or end is None:
+                return None
             return f"{_DAY_NAMES[start]}\u2013{_DAY_NAMES[end]}"
-        except (ValueError, IndexError):
-            return dow
+        except ValueError:
+            return None
     # Comma list, e.g. "0,6"
     if "," in dow and "-" not in dow and "/" not in dow:
         try:
-            parts = [_DAY_NAMES[int(p) % 7] for p in dow.split(",")]
-            return ",".join(parts)
-        except (ValueError, IndexError):
-            return dow
+            normalised = [_normalise_dow(int(p)) for p in dow.split(",")]
+            if any(n is None for n in normalised):
+                return None
+            return ",".join(_DAY_NAMES[n] for n in normalised)  # type: ignore[index]
+        except ValueError:
+            return None
     # Single day
     if dow.isdigit():
         try:
-            return _DAY_NAMES[int(dow) % 7]
-        except IndexError:
-            return dow
-    return dow
+            n = _normalise_dow(int(dow))
+            if n is None:
+                return None
+            return _DAY_NAMES[n]
+        except ValueError:
+            return None
+    return None
 
 
 def _format_timezone_suffix(timezone: str | None) -> str:
@@ -81,9 +101,11 @@ def describe_cron(schedule: str, timezone: str | None = None) -> str:
     minute, hour, dom, mon, dow = fields
 
     # Bail out on patterns we don't try to translate.
-    if "*" not in mon and mon != "*":
+    # `*` must be exact: `*/2` is a stepped wildcard and should NOT render as
+    # "daily" (#309). Use exact equality, not substring.
+    if mon != "*":
         return schedule
-    if "*" not in dom and dom != "*":
+    if dom != "*":
         return schedule
     if "/" in minute or "," in minute or "-" in minute:
         return schedule
@@ -100,6 +122,9 @@ def describe_cron(schedule: str, timezone: str | None = None) -> str:
 
     time_part = _format_time_12h(h, m)
     dow_part = _format_dow(dow)
+    if dow_part is None:
+        # Unsupported / out-of-range day-of-week — fall back to raw.
+        return schedule
     if dow_part == "":
         # Every day
         suffix_dow = " daily"

--- a/src/untether/triggers/rate_limit.py
+++ b/src/untether/triggers/rate_limit.py
@@ -30,5 +30,9 @@ class TokenBucketLimiter:
             self._buckets[key] = (tokens - 1.0, now)
             return True
         self._buckets[key] = (tokens, now)
-        logger.warning("rate_limit.denied", key=key, tokens=tokens)
+        # Logged at debug to avoid flooding logs (and feeding the issue
+        # watcher) on persistent burst attempts. Per-request denial visibility
+        # is not actionable; the HTTP 429 response carries the signal that
+        # matters. #309 CodeRabbit feedback.
+        logger.debug("rate_limit.denied", key=key, tokens=tokens)
         return False

--- a/tests/test_claude_control.py
+++ b/tests/test_claude_control.py
@@ -78,17 +78,23 @@ def _make_state_with_session(
 
 @pytest.fixture(autouse=True)
 def _clear_registries():
-    yield
-    _ACTIVE_RUNNERS.clear()
-    _SESSION_STDIN.clear()
-    _REQUEST_TO_SESSION.clear()
-    _REQUEST_TO_INPUT.clear()
-    _HANDLED_REQUESTS.clear()
-    _DISCUSS_COOLDOWN.clear()
-    _PLAN_EXIT_APPROVED.clear()
+    # Clear before and after each test — module-level registries can leak
+    # state from a prior module's first test if we only clear post-yield (#309).
     from untether.telegram.commands.claude_control import _DISCUSS_FEEDBACK_REFS
 
-    _DISCUSS_FEEDBACK_REFS.clear()
+    def _wipe() -> None:
+        _ACTIVE_RUNNERS.clear()
+        _SESSION_STDIN.clear()
+        _REQUEST_TO_SESSION.clear()
+        _REQUEST_TO_INPUT.clear()
+        _HANDLED_REQUESTS.clear()
+        _DISCUSS_COOLDOWN.clear()
+        _PLAN_EXIT_APPROVED.clear()
+        _DISCUSS_FEEDBACK_REFS.clear()
+
+    _wipe()
+    yield
+    _wipe()
 
 
 # ===========================================================================

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -1414,32 +1414,65 @@ class TestReasoning:
 
     @pytest.mark.anyio
     async def test_reasoning_set_all_levels(self, tmp_path):
-        """All 6 reasoning levels map correctly."""
+        """Reasoning levels persist correctly for each engine. Codex and
+        Claude support different level sets; the validator (#309) rejects
+        cross-engine mismatches like `rs:max` on codex."""
         from untether.telegram.chat_prefs import ChatPrefsStore, resolve_prefs_path
 
-        expected = {
-            "min": "minimal",
-            "low": "low",
-            "med": "medium",
-            "hi": "high",
-            "xhi": "xhigh",
-            "max": "max",
+        per_engine: dict[str, dict[str, str]] = {
+            "codex": {
+                "min": "minimal",
+                "low": "low",
+                "med": "medium",
+                "hi": "high",
+                "xhi": "xhigh",
+            },
+            "claude": {
+                "low": "low",
+                "med": "medium",
+                "hi": "high",
+                "max": "max",
+            },
         }
-        state_path = tmp_path / "prefs.json"
 
-        for action, level in expected.items():
-            cmd = ConfigCommand()
-            ctx = _make_ctx(
-                args_text=f"rs:{action}",
-                text=f"config:rs:{action}",
-                config_path=state_path,
-                default_engine="codex",
-            )
-            await cmd.handle(ctx)
-            prefs = ChatPrefsStore(resolve_prefs_path(state_path))
-            override = await prefs.get_engine_override(123, "codex")
-            assert override is not None
-            assert override.reasoning == level, f"rs:{action} should set {level}"
+        for engine, expected in per_engine.items():
+            state_path = tmp_path / f"prefs-{engine}.json"
+            for action, level in expected.items():
+                cmd = ConfigCommand()
+                ctx = _make_ctx(
+                    args_text=f"rs:{action}",
+                    text=f"config:rs:{action}",
+                    config_path=state_path,
+                    default_engine=engine,
+                )
+                await cmd.handle(ctx)
+                prefs = ChatPrefsStore(resolve_prefs_path(state_path))
+                override = await prefs.get_engine_override(123, engine)
+                assert override is not None, f"{engine}/rs:{action} did not persist"
+                assert override.reasoning == level, (
+                    f"{engine}/rs:{action} should set {level}"
+                )
+
+    @pytest.mark.anyio
+    async def test_reasoning_set_max_rejected_for_codex(self, tmp_path):
+        """#309 regression: codex does not support `max`; manual callback_data
+        attempting `rs:max` against codex must be rejected, not silently
+        persisted."""
+        from untether.telegram.chat_prefs import ChatPrefsStore, resolve_prefs_path
+
+        state_path = tmp_path / "prefs.json"
+        cmd = ConfigCommand()
+        ctx = _make_ctx(
+            args_text="rs:max",
+            text="config:rs:max",
+            config_path=state_path,
+            default_engine="codex",
+        )
+        await cmd.handle(ctx)
+        prefs = ChatPrefsStore(resolve_prefs_path(state_path))
+        override = await prefs.get_engine_override(123, "codex")
+        # Either no override at all, or reasoning is None — but never `max`.
+        assert override is None or override.reasoning != "max"
 
     @pytest.mark.anyio
     async def test_reasoning_clear_returns_home(self, tmp_path):

--- a/tests/test_describe_cron.py
+++ b/tests/test_describe_cron.py
@@ -106,3 +106,29 @@ class TestDefaults:
     def test_timezone_none_explicit(self):
         """Explicit None ≡ default."""
         assert describe_cron("0 9 * * *") == describe_cron("0 9 * * *", None)
+
+
+class TestRegression309:
+    """Regression tests for #309 CodeRabbit findings on describe.py."""
+
+    def test_stepped_dom_falls_back_to_raw(self):
+        """`*/2` in day-of-month — must NOT render as 'daily' (#309)."""
+        assert describe_cron("0 9 */2 * *", None) == "0 9 */2 * *"
+
+    def test_stepped_month_falls_back_to_raw(self):
+        """`*/2` in month — must NOT render as 'daily' (#309)."""
+        assert describe_cron("0 9 * */2 *", None) == "0 9 * */2 *"
+
+    def test_dow_out_of_range_falls_back(self):
+        """`8` is invalid for day-of-week — must NOT silently % 7 → 'Mon' (#309)."""
+        assert describe_cron("0 9 * * 8", None) == "0 9 * * 8"
+
+    def test_dow_range_with_invalid_end_falls_back(self):
+        assert describe_cron("0 9 * * 1-9", None) == "0 9 * * 1-9"
+
+    def test_dow_list_with_invalid_value_falls_back(self):
+        assert describe_cron("0 9 * * 1,8", None) == "0 9 * * 1,8"
+
+    def test_dow_seven_normalises_to_sunday(self):
+        """`7` is the canonical-form Sunday in cron; should still render."""
+        assert describe_cron("0 9 * * 7", None) == "9:00 AM Sun"

--- a/tests/test_trigger_cron.py
+++ b/tests/test_trigger_cron.py
@@ -233,6 +233,79 @@ async def test_run_once_false_keeps_cron_active(monkeypatch):
     assert manager.cron_ids() == ["repeating"]
 
 
+@pytest.mark.anyio
+async def test_daily_cron_fires_on_consecutive_days(monkeypatch):
+    """Regression: #309 — cron last_fired key must include date.
+
+    A bug in v0.35.1rc1-rc6 keyed last_fired by (hour, minute) only, so a daily
+    cron at 09:00 would fire today and then be suppressed forever (tomorrow's
+    09:00 looks identical). Verify the scheduler fires on each calendar day.
+    """
+    settings = parse_trigger_config(
+        {
+            "enabled": True,
+            "crons": [
+                {
+                    "id": "daily",
+                    "schedule": "0 9 * * *",
+                    "prompt": "hi",
+                    "timezone": "UTC",
+                },
+            ],
+        }
+    )
+    manager = TriggerManager(settings)
+    dispatcher = FakeDispatcher()
+
+    # Fake clock — advance one day per scheduler tick.
+    base_utc = datetime.datetime(2026, 4, 15, 9, 0, tzinfo=datetime.UTC)
+    clock = [base_utc, base_utc + datetime.timedelta(days=1)]
+    tick = [0]
+
+    def fake_now(tz: Any = None) -> datetime.datetime:
+        if tick[0] >= len(clock):
+            return clock[-1]
+        return clock[tick[0]]
+
+    monkeypatch.setattr("untether.triggers.cron.datetime.datetime", _NowStub(fake_now))
+
+    _real_sleep = anyio.sleep
+
+    async def fast_sleep(s: float) -> None:
+        tick[0] += 1
+        await _real_sleep(0)
+
+    monkeypatch.setattr("untether.triggers.cron.anyio.sleep", fast_sleep)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(run_cron_scheduler, manager, dispatcher)
+        for _ in range(6):
+            await _real_sleep(0)
+        tg.cancel_scope.cancel()
+
+    # Must have fired on day 1 AND day 2 (both at 09:00).
+    assert dispatcher.fired.count("daily") >= 2, (
+        f"Expected ≥2 fires across 2 days, got {dispatcher.fired}"
+    )
+
+
+class _NowStub:
+    """Minimal datetime replacement that overrides .now() and .UTC."""
+
+    UTC = datetime.UTC
+
+    def __init__(self, now_fn):
+        self._now = now_fn
+
+    def now(self, tz: Any = None) -> datetime.datetime:
+        n = self._now(tz)
+        if tz is not None and n.tzinfo is None:
+            return n.replace(tzinfo=tz)
+        if tz is not None:
+            return n.astimezone(tz)
+        return n
+
+
 def test_run_once_survives_reload_via_config():
     """A reload with the same TOML re-adds a run_once cron that was removed."""
     settings = parse_trigger_config(


### PR DESCRIPTION
## Summary

CodeRabbit reviewed v0.35.1 release PR #309 and flagged 1 critical + 15 major + 4 outside-diff findings. After per-finding triage (verified each against the actual code), this PR fixes 15 real issues, skips 3 false positives, and defers 2 to follow-up issues.

**Headline:** the most important fix is **#11 — daily/weekly crons stop firing after their first run** because `last_fired` was keyed by `(hour, minute)` only. Without this fix, every recurring cron in v0.35.1 dies after the first day. This is the headline trigger feature of the release.

## Fixes by priority

### P0 — Critical regressions in v0.35.1 features

| # | File | Issue |
|---|---|---|
| 11 | `triggers/cron.py` | Daily/weekly crons fire only once. `last_fired` keyed by `(hour, minute)` — tomorrow's 09:00 looks identical to today's. Now keyed by full date+time. |
| 4 | `runner_bridge.py` | Long subagent runs force-killed at `STALL_MAX_WARNINGS` because auto-cancel exemption only checked `cpu_active`. Now exempts `tree_active` when active children present. |
| 9 | `triggers/actions.py` | `append_timestamp` on_conflict used second-resolution names — two requests in the same second clobbered each other (defeats the entire point of `append_timestamp`). Now uses `time.time_ns()` + collision probe. |

### P1 — Functional bugs in supporting features

| # | File | Issue |
|---|---|---|
| 5 | `runners/claude.py` | `_PLAN_EXIT_APPROVED` only set in interactive approval. Auto-approve drain (auto permission mode + post-discuss) skipped the bookkeeping, defeating #283 in those flows. |
| 8 | `telegram/parsing.py` | Offset persisted before yield — crash between yield and consumer could record an unprocessed update as done. Now persists after yield. |
| 16 | `triggers/rate_limit.py` | Per-hit warning logs flood structured output and feed the issue watcher. Dropped to debug. |
| 20 | `telegram/commands/config.py` | Reasoning levels not validated against engine support — manual callback_data could persist e.g. \`max\` on Codex. Defensive check added. |
| 6 | `telegram/bridge.py` | Docstring claimed \`chat_ids\` was hot-reloadable but it's never sourced from settings. Corrected docstring. |

### P2 — Doc/display quality

| # | File | Issue |
|---|---|---|
| 13/14 | \`triggers/describe.py\` | Invalid DOW values normalised via \`% 7\` (8 → Mon); stepped patterns like \`*/2\` rendered as "daily" due to substring check. Both now fall back to raw schedule. |
| 19 | \`config.py\` | \`rs:max\` action had no toast entry. Added. |
| 3 | \`README.md\` | Access matrix overstated isolation, omitted \`/file put\`, outbox, and webhook \`file_write\`/\`http_forward\` actions. Now accurate. |
| 1 | \`integration-testing.md\` | Bot ID reused as DM chat ID. Clarified DM target is the user's chat ID. |
| 17 | \`specification.md\` | Header said v0.35.1 but body said "Untether v0.35.0 specifies:". Synced. |
| 18 | \`test_claude_control.py\` | Cleanup fixture only ran post-yield. Now runs pre- and post-yield. |

### Skipped (false positives / out of scope)

- **#2** version bump suggestion (\`0.35.1\` → \`0.36.0\` because \`/at\` is a feature) — Nathan's call, not auto-applicable mid-cycle
- **#7** restart-only keys hot-reloaded — false positive: \`update_from\` is selective and only touches hot fields
- **#12** cron snapshot iteration — false positive: \`remove_cron\` REPLACES the list, doesn't mutate in place

### Deferred (follow-up issues to be filed)

- **#10** \`http_forward\` Content-Type override on raw bodies
- **#15** duplicate cron ID / webhook path validation

## Tests added

- \`test_trigger_cron.py\` — multi-day cron regression test (covers #11)
- \`test_describe_cron.py\` — 6 regression tests for #13/#14 fallback paths
- \`test_config_command.py\` — split per-engine reasoning level test + codex \`rs:max\` rejection test (covers #20)
- \`test_claude_control.py\` — pre/post-yield cleanup (covers #18)

## Test plan

- [x] \`uv run pytest\` — **2172 passed**, 1 skipped, 81.51% coverage (was 2164 before fixes)
- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] \`uv run ruff check src/\` — clean
- [x] \`uv lock --check\` — in sync
- [x] \`uv build\` — wheel + sdist built successfully
- [ ] CI on this PR
- [ ] After merge, PR #309 (dev → master) gets the fixes automatically

## Why this targets dev not master

These fixes need to land on \`dev\` so they're picked up by the v0.35.1 release PR (#309 dev→master) automatically. Same release-guard model as the other v0.35.1 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)