### PR TITLE
docs: align with single-gate release flow + trim rule bloat

### DIFF
--- a/.claude/rules/release-discipline.md
+++ b/.claude/rules/release-discipline.md
@@ -42,11 +42,11 @@ Pre-release versions (`X.Y.ZrcN`) are used for staging on `@hetz_lba1_bot` befor
 
 - rc versions live on the `dev` branch — merged via PR from feature branches
 - rc versions do **NOT** require changelog entries — `validate_release.py` skips them
-- rc versions are **NOT** git-tagged — no `v0.35.0rc1` tags (avoids triggering `release.yml`)
+- rc versions are **NOT** tagged (`auto-tag-on-master.yml` skips pre-releases)
 - Commit message convention: `chore: staging X.Y.ZrcN`
-- Only final releases (`X.Y.Z`) get tagged and changelog entries on `master`
-- `dev` → TestPyPI (auto on push), `master` → PyPI (tag + manual approval)
-- See `docs/reference/dev-instance.md` for the full staging workflow
+- Only stable releases (`X.Y.Z`) get tagged and changelog entries on `master`
+- **Single-gate release flow**: `dev` push → TestPyPI (auto); `master` push of a stable version → `auto-tag-on-master.yml` creates `vX.Y.Z` → `release.yml` publishes to PyPI via OIDC → GitHub Release. The master PR review is the only manual approval — no PyPI environment gate, no manual tag step.
+- See `docs/reference/dev-instance.md` for the full staging workflow.
 
 ## Changelog format
 

--- a/.claude/rules/testing-conventions.md
+++ b/.claude/rules/testing-conventions.md
@@ -87,35 +87,12 @@ Watch for phantom responses (substantive output from empty input), session cross
 
 ### Additional MCP tools
 
-- `send_voice` — OGG/Opus voice files for T1 (voice message test)
-- `send_file` — file upload/media group tests (T2, T5)
-- Bash tool — `kill -TERM` for B4 (SIGTERM), `journalctl` for B5 (log inspection)
+- `send_voice` — OGG/Opus voice files for voice message tests
+- `send_file` — file upload/media group tests
+- Bash tool — `kill -TERM` for SIGTERM tests, `journalctl` for log inspection
 
 All integration test tiers are fully automatable by Claude Code.
 
 ## Key test files
 
-| File | Covers |
-|------|--------|
-| `test_claude_control.py` | Control channel, session registries, auto-approve, cooldown |
-| `test_callback_dispatch.py` | Callback parsing, dispatch, early answering |
-| `test_exec_bridge.py` | Ephemeral cleanup, approval notifications |
-| `test_ask_user_question.py` | AskUserQuestion handling, question extraction, answer routing |
-| `test_diff_preview.py` | Edit/Write/Bash diff preview formatting and truncation |
-| `test_cost_tracker.py` | Per-run/daily cost tracking, budget alerts, daily reset |
-| `test_export_command.py` | Session export (markdown/JSON), event recording, trimming |
-| `test_browse_command.py` | File browser, path registry, inline keyboards, project root |
-| `test_codex_runner.py` | Codex event translation, session locking |
-| `test_opencode_runner.py` | OpenCode event translation |
-| `test_pi_runner.py` | Pi event translation, session ID promotion |
-| `test_settings.py` | Config validation, engine config parsing |
-| `test_build_args.py` | CLI argument construction for all 6 engines |
-| `test_loop_coverage.py` | Update loop edge cases, message routing, shutdown |
-| `test_exec_runner.py` | Event tracking, ring buffer, PID in StartedEvent meta |
-| `test_runner_utils.py` | Error formatting, drain_stderr, stderr sanitisation |
-| `test_trigger_server.py` | Webhook HTTP server, multipart, rate limit burst, fire-and-forget dispatch |
-| `test_trigger_actions.py` | file_write (multipart short-circuit), http_forward (SSRF), notify_only |
-| `test_trigger_cron.py` | Cron expression matching, timezone conversion, step validation |
-| `test_trigger_settings.py` | CronConfig/WebhookConfig/TriggersSettings validation, timezone |
-| `test_trigger_ssrf.py` | SSRF blocking (IPv4/IPv6, DNS rebinding, allowlist) |
-| `test_trigger_fetch.py` | Cron data-fetch (HTTP, file read, parse modes, failure) |
+The full coverage matrix lives in [`docs/reference/integration-testing.md`](../../docs/reference/integration-testing.md) (per-tier playbook) and the README `## Tests` section in [`CLAUDE.md`](../../CLAUDE.md) (per-file coverage list, kept in sync with the test suite). When adding a new test file, update that list — not this rule.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -45,7 +45,8 @@ flowchart TB
 
     subgraph Triggers["Triggers Layer"]
         trigger_server[triggers/server.py<br/>webhook HTTP server<br/>multipart, rate limit]
-        trigger_cron[triggers/cron.py<br/>cron scheduler]
+        trigger_cron[triggers/cron.py<br/>cron scheduler<br/>timezone, run_once]
+        trigger_manager[triggers/manager.py<br/>TriggerManager<br/>hot-reload]
         trigger_dispatch[triggers/dispatcher.py<br/>dispatch to run_job]
         trigger_actions[triggers/actions.py<br/>file_write, http_forward, notify_only]
         trigger_fetch[triggers/fetch.py<br/>cron data-fetch]
@@ -85,6 +86,8 @@ flowchart TB
     presenter --> markdown
     tg_client --> telegram_api
     webhook_sources --> trigger_server
+    trigger_server --> trigger_manager
+    trigger_cron --> trigger_manager
     trigger_server --> trigger_dispatch
     trigger_server --> trigger_actions
     trigger_cron --> trigger_dispatch
@@ -419,6 +422,6 @@ flowchart TD
 | **Bridge** | `telegram/bridge.py`, `runner_bridge.py` | Message handling, execution coordination |
 | **Runner** | `runner.py`, `runners/*.py`, `schemas/*.py` | Agent CLI subprocess, JSONL parsing, event translation |
 | **Transport** | `transport.py`, `presenter.py`, `telegram/client.py` | Telegram API, message rendering |
-| **Triggers** | `triggers/server.py`, `triggers/cron.py`, `triggers/dispatcher.py`, `triggers/actions.py`, `triggers/fetch.py`, `triggers/ssrf.py` | Webhook server (multipart, rate limit), cron scheduler (data-fetch), non-agent actions, SSRF protection |
+| **Triggers** | `triggers/server.py`, `triggers/cron.py`, `triggers/manager.py`, `triggers/dispatcher.py`, `triggers/actions.py`, `triggers/fetch.py`, `triggers/ssrf.py`, `triggers/auth.py`, `triggers/rate_limit.py`, `triggers/describe.py`, `triggers/templating.py` | Webhook server (multipart, rate limit), cron scheduler (timezone, data-fetch, `run_once`), `TriggerManager` for hot-reload, non-agent actions (`file_write`/`http_forward`/`notify_only`), SSRF protection, HMAC/bearer auth, human-friendly cron description |
 | **Domain** | `model.py`, `progress.py`, `events.py` | Event types, action tracking |
 | **Utils** | `worktrees.py`, `utils/*.py`, `markdown.py` | Git worktrees, formatting, paths |

--- a/docs/reference/dev-instance.md
+++ b/docs/reference/dev-instance.md
@@ -70,8 +70,8 @@ Dev (local editable)     Staging (TestPyPI rc)           Release (PyPI)
 @untether_dev_bot        @hetz_lba1_bot                  (staging bot)
 
 Fix bugs, test locally   Bump to 0.35.0rc1               Bump to 0.35.0
-Integration tests        Push master → TestPyPI          Changelog + tag v0.35.0
-                         staging.sh install 0.35.0rc1     release.yml → PyPI
+Integration tests        Merge to dev → TestPyPI         PR dev → master, merge
+                         staging.sh install 0.35.0rc1     auto-tag-on-master.yml → release.yml → PyPI
                          Dogfood ~1 week                  staging.sh reset → restart
                          Issue watcher catches bugs
                          Fix → 0.35.0rc2 if needed
@@ -81,8 +81,8 @@ Integration tests        Push master → TestPyPI          Changelog + tag v0.35
 
 1. Bump version in `pyproject.toml` to `X.Y.Zrc1` (no changelog entry needed)
 2. Run `uv lock` to sync lockfile
-3. Commit: `chore: staging X.Y.Zrc1`
-4. Push to `master` — CI auto-publishes to TestPyPI
+3. Commit on a feature branch: `chore: staging X.Y.Zrc1`
+4. PR to `dev` and merge — push to `dev` auto-publishes to TestPyPI via CI
 5. Wait for CI to pass
 6. Install on staging bot:
    ```bash
@@ -93,19 +93,19 @@ Integration tests        Push master → TestPyPI          Changelog + tag v0.35
 
 ### Fix bugs during staging
 
-1. Fix on a branch, merge to master
-2. Bump to `X.Y.Zrc2`, run `uv lock`
-3. Commit: `chore: staging X.Y.Zrc2`
-4. Push → CI publishes to TestPyPI
-5. `scripts/staging.sh install X.Y.Zrc2 && systemctl --user restart untether`
+1. Fix on a feature branch, PR to `dev`, merge
+2. Bump to `X.Y.Zrc2`, run `uv lock`, commit, push (same dev cycle)
+3. CI publishes the new rc to TestPyPI on the dev push
+4. `scripts/staging.sh install X.Y.Zrc2 && systemctl --user restart untether`
 
-### Promote to release
+### Promote to release (single-gate flow)
 
-1. Bump to `X.Y.Z` in `pyproject.toml`
+1. Bump to `X.Y.Z` in `pyproject.toml` (drop the rc suffix)
 2. Add full changelog entry covering all changes since last stable release
-3. Run `uv lock`, commit, tag `vX.Y.Z`, push with tags
-4. `release.yml` publishes to PyPI
-5. `scripts/staging.sh reset && systemctl --user restart untether`
+3. Run `uv lock`, commit on a feature branch
+4. PR `dev` → `master`. Nathan reviews and squash-merges — **this is the single release gate**
+5. `auto-tag-on-master.yml` detects the stable version and creates `vX.Y.Z`; `release.yml` fires on the tag, runs full CI, publishes to PyPI via OIDC, and creates the GitHub Release. **No manual tag, no PyPI environment approval.**
+6. After PyPI publishes: `scripts/staging.sh reset && systemctl --user restart untether`
 
 ### Rollback from staging
 


### PR DESCRIPTION
Tail-end cleanup after the v0.35.1 release and the new auto-tag-on-master flow. Net **+27 / -47** lines.

## Stale process descriptions fixed

### \`docs/reference/dev-instance.md\`

The staging workflow section described the OLD release flow:

| Was | Now |
|---|---|
| "Push to master → CI auto-publishes to TestPyPI" | "Merge to dev → TestPyPI" (TestPyPI publishes on dev push, not master) |
| "Fix on a branch, merge to master" during staging | "Fix on a feature branch, PR to dev, merge" |
| "tag vX.Y.Z, push with tags" as Promote step | "PR dev → master → auto-tag-on-master.yml fires → release.yml → PyPI" |

This was actively misleading — following the old steps would skip TestPyPI entirely. Now matches reality: feature → dev (TestPyPI auto) → master PR (single gate) → auto-tag → release.yml → PyPI.

### \`.claude/rules/release-discipline.md\`

Line 48 said "tag + manual approval". Replaced with the single-gate description matching the canonical \`CLAUDE.md\` "Release guard" section, just stated in rule form for the auto-load-on-CHANGELOG context.

## Architecture diagram refreshed

\`docs/explanation/architecture.md\`:

- **Top-level mermaid:** added \`triggers/manager.py\` (TriggerManager, introduced in #269 for hot-reload) as a node connected to both \`trigger_server\` and \`trigger_cron\`. Without this node the diagram suggested manager.py didn't exist.
- **Triggers row in summary table:** was missing 5 of 11 trigger module files. Now lists all of them: \`server.py\`, \`cron.py\`, \`manager.py\`, \`dispatcher.py\`, \`actions.py\`, \`fetch.py\`, \`ssrf.py\`, \`auth.py\`, \`rate_limit.py\`, \`describe.py\`, \`templating.py\`.
- \`trigger_cron\` label updated to mention \`timezone, run_once\`.

## Rule consolidation: trim testing-conventions.md

The "Key test files" table at the bottom was 26 lines listing what each test file covers — that's reference material, not a hard testing rule. Replaced with a one-line cross-reference to \`docs/reference/integration-testing.md\` (per-tier playbook) and \`CLAUDE.md ## Tests\` (per-file coverage list, kept in sync with the suite).

The rule body is now ~95 lines and stays focused on the conventions a test author needs to know up front.

## Mermaid audit — all 13 diagrams checked

All mermaid blocks across the docs were spot-checked for v0.35.1 currency:

| File | Blocks | Status |
|---|---|---|
| \`docs/explanation/architecture.md\` | 8 | 1 updated (top-level layer + Triggers); 7 OK (domain model class diagram, run lifecycle, session locking, config structure, scheduler — all unaffected by trigger system or release flow) |
| \`docs/how-to/choose-a-mode.md\` | 4 | OK — pure user-flow session/topic sequence diagrams |
| \`docs/how-to/cross-environment-resume.md\` | 1 | OK — \`/continue\` flow sequence diagram |

## Other rule files reviewed — no changes needed

The audit also covered \`context-quality.md\`, \`control-channel.md\`, \`dev-workflow.md\`, \`runner-development.md\`, \`telegram-transport.md\`. All are current and focused.

The repeated "if released, run integration tests <X1-Xn>" footer that appears in 3 rules (control-channel, runner-development, telegram-transport) **is intentional** — those test IDs are file-specific (C1-C6 for claude_control changes, U1-U4 for runner changes, T1-T10 for telegram changes) and belong tied to the rules that trigger them.

## CLAUDE.md — verified current

CLAUDE.md was updated as part of #314 and already reflects:
- Hook output format fix (\`hookSpecificOutput\`/\`permissionDecision\`)
- \`auto-tag-on-master\` in the CI table
- Single-gate release flow under "Release guard"
- \`pypi\` environment auto-publishes (no reviewer)

No changes needed.

## Test plan

- [x] Manual reads of every changed file
- [x] All 13 mermaid blocks visually audited for currency
- [ ] CI on this PR — no Python source changed, so pytest is irrelevant; format/ruff/lockfile/docs jobs should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)