### PR TITLE
fix: walk descendant tree on engine subprocess cleanup (#275)

### DIFF
--- a/src/untether/utils/proc_diag.py
+++ b/src/untether/utils/proc_diag.py
@@ -138,17 +138,30 @@ def _find_children(pid: int) -> list[int]:
     return children
 
 
-def _find_descendants(pid: int, *, _depth: int = 0, _max_depth: int = 4) -> list[int]:
-    """Find all descendant PIDs recursively (depth-limited)."""
+def find_descendants(pid: int, *, _depth: int = 0, _max_depth: int = 4) -> list[int]:
+    """Find all descendant PIDs recursively (depth-limited).
+
+    Public helper used by subprocess cleanup (#275) to capture a snapshot of
+    the process tree before signalling the parent — grandchildren in separate
+    process groups (e.g. vitest → workerd) are only reachable this way.
+
+    Depth-limited to 4 levels to bound the recursion on pathological trees;
+    the typical Claude Code → Bash → vitest → workerd chain is 3 deep with
+    margin.
+    """
     if _depth >= _max_depth:
         return []
     children = _find_children(pid)
     descendants = list(children)
     for child in children:
         descendants.extend(
-            _find_descendants(child, _depth=_depth + 1, _max_depth=_max_depth)
+            find_descendants(child, _depth=_depth + 1, _max_depth=_max_depth)
         )
     return descendants
+
+
+# Private alias kept for back-compat with existing test imports.
+_find_descendants = find_descendants
 
 
 def _collect_tree_cpu(
@@ -182,7 +195,7 @@ def collect_proc_diag(pid: int) -> ProcessDiag | None:
     fd_count = _count_fds(pid)
     tcp_est, tcp_total = _count_tcp(pid)
     children = _find_children(pid)
-    descendants = _find_descendants(pid)
+    descendants = find_descendants(pid)
     tree_utime, tree_stime = _collect_tree_cpu(utime, stime, descendants)
 
     return ProcessDiag(

--- a/src/untether/utils/subprocess.py
+++ b/src/untether/utils/subprocess.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import signal
+import sys
 from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import asynccontextmanager
 from typing import Any
@@ -10,6 +12,7 @@ import anyio
 from anyio.abc import Process
 
 from ..logging import get_logger
+from .proc_diag import find_descendants
 
 logger = get_logger(__name__)
 
@@ -47,12 +50,27 @@ def _signal_process(
 ) -> None:
     if proc.returncode is not None:
         return
+
+    # Snapshot descendants BEFORE signalling the parent (#275).  Once the
+    # parent dies, /proc/<pid>/task/*/children entries disappear and any
+    # grandchildren in separate process groups (e.g. vitest → workerd, which
+    # node spawns with fresh sessions) become invisible to `killpg`.  On
+    # non-Linux hosts or /proc read errors the snapshot is empty and
+    # behaviour falls back to the legacy pgroup-only path.
+    descendants: list[int] = []
+    if os.name == "posix" and proc.pid is not None and sys.platform == "linux":
+        try:
+            descendants = find_descendants(proc.pid)
+        except OSError:
+            descendants = []
+
+    used_posix = False
     if os.name == "posix" and proc.pid is not None:
+        used_posix = True
         try:
             os.killpg(proc.pid, sig)
-            return
         except ProcessLookupError:
-            return
+            pass  # Parent already gone; still deliver to captured descendants.
         except OSError as exc:
             logger.debug(
                 log_event,
@@ -60,10 +78,39 @@ def _signal_process(
                 error_type=exc.__class__.__name__,
                 pid=proc.pid,
             )
-    try:
-        fallback()
-    except ProcessLookupError:
+            used_posix = False  # Fall through to the anyio fallback.
+
+    if not used_posix:
+        with contextlib.suppress(ProcessLookupError):
+            fallback()
+
+    # Best-effort signal to orphan descendants in separate process groups.
+    # Ignored when the snapshot is empty (non-Linux, /proc error, or parent
+    # had no grandchildren).  #275.
+    _signal_descendants(descendants, sig, log_event)
+
+
+def _signal_descendants(pids: list[int], sig: signal.Signals, log_event: str) -> None:
+    """Deliver *sig* to each captured descendant PID, best-effort.
+
+    Swallows ``ProcessLookupError`` (already exited since the snapshot) and
+    ``PermissionError`` (process reparented to a different user's systemd).
+    Other ``OSError``s are logged at debug level and skipped.  #275.
+    """
+    if not pids:
         return
+    for pid in pids:
+        try:
+            os.kill(pid, sig)
+        except (ProcessLookupError, PermissionError):
+            continue
+        except OSError as exc:
+            logger.debug(
+                log_event,
+                error=str(exc),
+                error_type=exc.__class__.__name__,
+                pid=pid,
+            )
 
 
 @asynccontextmanager

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,8 +1,30 @@
+import signal
 import sys
+from dataclasses import dataclass
 
 import pytest
 
 from untether.utils import subprocess as subprocess_utils
+
+
+@dataclass
+class _FakeProc:
+    """Minimal Process stand-in for _signal_process tests.
+
+    ``subprocess_utils._signal_process`` only reads ``.pid`` / ``.returncode``
+    and invokes ``.terminate`` / ``.kill``; a real anyio Process isn't needed.
+    """
+
+    pid: int = 1234
+    returncode: int | None = None
+    terminate_called: int = 0
+    kill_called: int = 0
+
+    def terminate(self) -> None:
+        self.terminate_called += 1
+
+    def kill(self) -> None:
+        self.kill_called += 1
 
 
 @pytest.mark.anyio
@@ -47,3 +69,152 @@ async def test_manage_subprocess_uses_10s_kill_timeout(
         assert proc.returncode is None
 
     assert captured_timeout == [10.0]
+
+
+# ---------------------------------------------------------------------------
+# #275 — descendant-tree cleanup tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc only")
+def test_terminate_process_signals_captured_descendants(monkeypatch) -> None:
+    """SIGTERM is sent both to the pgroup AND to each descendant captured
+    before the killpg — grandchildren in separate process groups (#275, e.g.
+    vitest → workerd) don't get reached by killpg alone."""
+    calls: list[tuple[str, int, int]] = []
+
+    def fake_killpg(pid: int, sig: int) -> None:
+        calls.append(("killpg", pid, sig))
+
+    def fake_kill(pid: int, sig: int) -> None:
+        calls.append(("kill", pid, sig))
+
+    def fake_find(pid: int) -> list[int]:
+        assert pid == 1234
+        return [5001, 5002, 5003]
+
+    monkeypatch.setattr(subprocess_utils.os, "killpg", fake_killpg)
+    monkeypatch.setattr(subprocess_utils.os, "kill", fake_kill)
+    monkeypatch.setattr(subprocess_utils, "find_descendants", fake_find)
+
+    subprocess_utils.terminate_process(_FakeProc())
+
+    # killpg fires first, then each descendant PID individually.
+    assert calls[0] == ("killpg", 1234, signal.SIGTERM)
+    assert ("kill", 5001, signal.SIGTERM) in calls
+    assert ("kill", 5002, signal.SIGTERM) in calls
+    assert ("kill", 5003, signal.SIGTERM) in calls
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc only")
+def test_kill_process_signals_descendants_with_sigkill(monkeypatch) -> None:
+    """SIGKILL escalation also walks the descendant tree (#275)."""
+    calls: list[tuple[str, int, int]] = []
+
+    monkeypatch.setattr(
+        subprocess_utils.os,
+        "killpg",
+        lambda pid, sig: calls.append(("killpg", pid, sig)),
+    )
+    monkeypatch.setattr(
+        subprocess_utils.os,
+        "kill",
+        lambda pid, sig: calls.append(("kill", pid, sig)),
+    )
+    monkeypatch.setattr(subprocess_utils, "find_descendants", lambda pid: [9001])
+
+    subprocess_utils.kill_process(_FakeProc(pid=4242))
+
+    assert ("killpg", 4242, signal.SIGKILL) in calls
+    assert ("kill", 9001, signal.SIGKILL) in calls
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc only")
+def test_signal_process_swallows_descendant_process_lookup(monkeypatch) -> None:
+    """If a descendant already exited, ProcessLookupError is swallowed
+    (descendants snapshot is inherently racy — they may die between snapshot
+    and signal)."""
+    monkeypatch.setattr(subprocess_utils.os, "killpg", lambda pid, sig: None)
+
+    def raising_kill(pid: int, sig: int) -> None:
+        if pid == 7001:
+            raise ProcessLookupError
+        if pid == 7002:
+            raise PermissionError  # reparented to another user's systemd
+        # 7003 succeeds silently
+
+    monkeypatch.setattr(subprocess_utils.os, "kill", raising_kill)
+    monkeypatch.setattr(
+        subprocess_utils, "find_descendants", lambda pid: [7001, 7002, 7003]
+    )
+
+    # Must not raise.
+    subprocess_utils.terminate_process(_FakeProc())
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc only")
+def test_signal_process_descendant_oserror_is_logged_not_raised(
+    monkeypatch,
+) -> None:
+    """Unexpected OSError on a descendant signal is logged at debug, not
+    propagated — cleanup of the other descendants must continue."""
+    remaining: list[int] = []
+
+    def partial_kill(pid: int, sig: int) -> None:
+        if pid == 6001:
+            raise OSError(22, "bad argument")
+        remaining.append(pid)
+
+    monkeypatch.setattr(subprocess_utils.os, "killpg", lambda pid, sig: None)
+    monkeypatch.setattr(subprocess_utils.os, "kill", partial_kill)
+    monkeypatch.setattr(subprocess_utils, "find_descendants", lambda pid: [6001, 6002])
+
+    subprocess_utils.terminate_process(_FakeProc())
+
+    assert 6002 in remaining  # 6001 errored but 6002 still got signalled
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc only")
+def test_signal_process_degrades_when_find_descendants_raises(
+    monkeypatch,
+) -> None:
+    """OSError from find_descendants (e.g. /proc unavailable) falls back to
+    the legacy pgroup-only path without crashing."""
+    calls: list[str] = []
+
+    def fake_killpg(pid: int, sig: int) -> None:
+        calls.append("killpg")
+
+    def raise_oserror(pid: int) -> list[int]:
+        raise OSError("proc unavailable")
+
+    monkeypatch.setattr(subprocess_utils.os, "killpg", fake_killpg)
+    monkeypatch.setattr(subprocess_utils, "find_descendants", raise_oserror)
+
+    # Must not raise.
+    subprocess_utils.terminate_process(_FakeProc())
+    assert calls == ["killpg"]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc only")
+def test_signal_process_still_signals_descendants_when_parent_gone(
+    monkeypatch,
+) -> None:
+    """If the parent exits between snapshot and killpg (races are possible),
+    killpg raises ProcessLookupError — but captured descendants still need
+    signalling in case they're alive and reparented (#275 root cause)."""
+    descendants_signalled: list[int] = []
+
+    def fake_killpg(pid: int, sig: int) -> None:
+        raise ProcessLookupError  # parent died between snapshot and kill
+
+    def record_kill(pid: int, sig: int) -> None:
+        descendants_signalled.append(pid)
+
+    monkeypatch.setattr(subprocess_utils.os, "killpg", fake_killpg)
+    monkeypatch.setattr(subprocess_utils.os, "kill", record_kill)
+    monkeypatch.setattr(subprocess_utils, "find_descendants", lambda pid: [8001, 8002])
+
+    subprocess_utils.terminate_process(_FakeProc())
+
+    assert descendants_signalled == [8001, 8002]


### PR DESCRIPTION
## Summary

Fixes #275 — orphaned workerd processes (316 procs / 37 GB RAM) after cascading Claude Code SIGTERMs on lba-1.

### Root cause (from #275)

Node's `child_process.spawn()` creates `workerd` in fresh process groups when vitest's `@cloudflare/vitest-pool-workers` runs inside Claude Code's Bash tool. `os.killpg(claude_pid, SIGTERM)` in `manage_subprocess` only reached Claude's own pgroup; grandchildren in separate pgroups survived, were reparented to user systemd, and accumulated. `auto_continue` amplified the cascade — each respawn ran more tests, spawned more workerd, got SIGTERM'd from memory pressure, leaked more orphans.

### Fix

`_signal_process` in `src/untether/utils/subprocess.py` now:

1. Snapshots descendants via `proc_diag.find_descendants()` **before** `killpg` (grandchildren only visible via `/proc/<pid>/task/*/children` while the parent is still alive).
2. Runs the existing `os.killpg(pid, sig)` (unchanged behaviour for the common case).
3. Delivers `os.kill(pid, sig)` to each captured descendant PID, best-effort — swallows `ProcessLookupError` (already exited) and `PermissionError` (reparented to another user's systemd).

SIGKILL escalation (`kill_process`) re-snapshots and walks the tree again.

Graceful fallback: non-Linux or `/proc` read error → empty descendants list → legacy pgroup-only behaviour.

### Safety

The snapshot is **pre-kill by design**: we only signal processes we already observed as descendants of the engine subprocess. We don't walk `/proc` again after signalling, so there's no risk of killing unrelated processes that might reuse a PID.

## Changes

- `src/untether/utils/proc_diag.py` — promoted `_find_descendants` → public `find_descendants` with docstring referencing #275. Private alias `_find_descendants = find_descendants` kept for back-compat with existing test imports.
- `src/untether/utils/subprocess.py` — `_signal_process` extended with pre-kill descendant snapshot and best-effort `os.kill` on each. New `_signal_descendants` helper. Uses `contextlib.suppress(ProcessLookupError)` for the non-posix fallback.
- `tests/test_subprocess.py` — 6 new unit tests: SIGTERM/SIGKILL descendant walk, `ProcessLookupError`/`PermissionError` swallowing, generic `OSError` logged-not-raised, `find_descendants` failure degrades to legacy, parent-dead-before-killpg race still signals descendants.

## Test plan

- [x] `uv run pytest tests/test_subprocess.py tests/test_proc_diag.py` — 39 passed, 1 skipped
- [x] `uv run pytest -x -q` — 2202 passed, 1 skipped (+5 new tests), coverage 81.73%
- [x] `uv run ruff format src/ tests/` — no diff
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run python3 scripts/validate_release.py` — 3 passed, 0 failed
- [ ] Integration (dev bot): spawn `bash -c 'setsid sleep 300 &'` inside a Claude Bash tool in `@untether_dev_bot`, `/cancel` the run, verify `ps -ef | grep 'sleep 300'` shows no orphans after 15 s.

Related upstream (not fixable from Untether): anthropics/claude-code#43944, cloudflare/workers-sdk#8837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)