### PR TITLE
docs: refresh v0.35.2 user docs — 6 files, factual fixes + new sections

### DIFF
--- a/docs/how-to/cost-budgets.md
+++ b/docs/how-to/cost-budgets.md
@@ -47,7 +47,7 @@ After each run completes, Untether checks the reported cost against your budgets
 3. **Warning threshold**: at `warn_at_pct` (default 70%) of either budget, you get an early warning
 
 !!! note "Token-only engines"
-    Engines that don't report USD costs (Codex, Pi, Gemini CLI, Amp) show token counts in the footer instead (e.g. `💰 26.0k in / 71 out`). Budget alerts only apply to engines that report USD costs.
+    Engines that don't report USD costs (Codex, Pi, and OpenCode on its free tier) show token counts in the footer instead (e.g. `💰 26.0k in / 71 out`). Gemini CLI and AMP surface `total_cost_usd` when their CLI reports one; on the free tier they render tokens only. Budget alerts apply only to the USD-reporting path.
 
 ### Alert levels
 

--- a/docs/how-to/schedule-tasks.md
+++ b/docs/how-to/schedule-tasks.md
@@ -71,7 +71,7 @@ Common schedules:
 | `*/30 * * * *` | Every 30 minutes |
 | `0 */4 * * *` | Every 4 hours |
 
-Add `run_once = true` to fire a cron exactly once, then auto-disable. It re-activates on config reload or restart — useful for one-off tasks that shouldn't repeat.
+Add `run_once = true` to fire a cron exactly once, then auto-disable. Fired state persists to `run_once_fired.json` (sibling of your `untether.toml`), so a reload or restart will **not** re-fire it. Remove the cron from your TOML to clean up.
 
 ## Webhook triggers
 

--- a/docs/how-to/security.md
+++ b/docs/how-to/security.md
@@ -53,6 +53,12 @@ export UNTETHER_CONFIG_PATH=/path/to/untether.toml
 !!! tip "Automatic log redaction"
     Untether automatically redacts bot tokens, OpenAI API keys (`sk-...`), and GitHub tokens (`ghp_`, `ghs_`, `github_pat_`) from all structured log output. Even if a token appears in engine output or error messages, it is replaced with `[REDACTED]` before being written to logs.
 
+## Engine subprocess env allowlist
+
+Claude and Pi engine subprocesses do **not** inherit Untether's full environment. Only allowlisted variables (OS essentials, AI/cloud provider keys, Claude/MCP/Node/Python/UV/NPM namespaces, git/ssh auth) pass through — random third-party tokens that happen to live in your shell (`AWS_*`, `STRIPE_*`, `DATABASE_URL`, personal app tokens, etc.) are **not** available to the engine or its MCP servers. This reduces the blast radius of any tool call or MCP that exfiltrates process env.
+
+If a new engine or MCP genuinely needs a variable that isn't allowlisted (symptom: hangs at init, silent `KeyError` in logs), add it to `_EXACT_ALLOW` / `_PREFIX_ALLOW` in `src/untether/utils/env_policy.py`. Other engines (Codex, Gemini, OpenCode, AMP) still inherit the full parent env — extending the allowlist to them is tracked in [#332](https://github.com/littlebearapps/untether/issues/332).
+
 ## File transfer deny globs
 
 File transfer includes a deny list that blocks access to sensitive paths. The defaults are:

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -136,6 +136,21 @@ The stall watchdog monitors engine subprocesses for periods of inactivity (no JS
 
 **Tuning:** All thresholds are configurable via `[watchdog]` in `untether.toml`. Use `tool_timeout` to increase the initial threshold for local tools (default 10 min), and `mcp_tool_timeout` for MCP tools (default 15 min). See the [config reference](../reference/config.md#watchdog).
 
+## Claude Code hangs after an MCP tool_result
+
+**Symptoms:** Claude Code goes silent immediately after an MCP tool returns — the `tool_result` arrives in the JSONL stream but the assistant never responds. Ring buffer fills with `user`/`tool_result` events and stays there. Often hits Cloudflare's remote MCP servers via `mcp-remote`.
+
+Root cause is upstream — [claude-code#39700](https://github.com/anthropics/claude-code/issues/39700) combined with undici's idle-body timeout in `mcp-remote` ([geelen/mcp-remote#226](https://github.com/geelen/mcp-remote/issues/226)) — but Untether ships an opt-in detector plus a tiered workaround ([#322](https://github.com/littlebearapps/untether/issues/322)).
+
+Enable in `~/.untether/untether.toml`:
+
+```toml
+[watchdog]
+detect_stuck_after_tool_result = true
+```
+
+On detection (default 5 min after `tool_result` arrives with no assistant follow-up), Untether logs `progress_edits.stuck_after_tool_result`, SIGTERMs any `mcp-remote` / `@modelcontextprotocol` adapter children to force the SSE reader to error out, and finally cancels the run if the engine stays silent for another 60 seconds. Tune via `stuck_after_tool_result_timeout` and `stuck_after_tool_result_recovery_delay`. See the [config reference](../reference/config.md#watchdog).
+
 ## Claude Code exits without finishing (auto-continue)
 
 **Symptoms:** Claude Code exits after receiving tool results without processing them. You see "⚠️ Auto-continuing" in the chat, or the session ends prematurely with no final answer.
@@ -230,10 +245,11 @@ Run `untether doctor` to validate voice configuration.
 
 1. Check that triggers are enabled: `[triggers] enabled = true`
 2. Verify the server is running: `curl http://127.0.0.1:9876/health` (adjust host/port)
-3. Check auth — if using HMAC, the sending service must sign requests with the same secret
-4. Check `event_filter` — if set, only matching event types are processed
-5. Check firewall rules if the webhook server is behind NAT
-6. Look at `debug.log` for incoming request logs
+3. **Port already in use?** As of [#320](https://github.com/littlebearapps/untether/issues/320), a port conflict degrades gracefully — the rest of the bot (polling, commands, crons) stays up, but webhook delivery is disabled. Look for `triggers.server.bind_failed` in the log (`journalctl --user -u untether \| grep bind_failed`); the entry includes the occupied port and a `fix` suggestion. Free the port or set `[triggers.server] port = <N>` in `untether.toml`.
+4. Check auth — if using HMAC, the sending service must sign requests with the same secret
+5. Check `event_filter` — if set, only matching event types are processed
+6. Check firewall rules if the webhook server is behind NAT
+7. Look at `debug.log` for incoming request logs
 
 ## Config change didn't take effect
 
@@ -241,8 +257,8 @@ Run `untether doctor` to validate voice configuration.
 
 1. **Check `watch_config`:** Hot-reload requires `watch_config = true` in the top-level config. Without it, changes only apply on restart.
 2. **Hot-reloadable settings** apply immediately: `voice_transcription`, `[files]`, `allowed_user_ids`, `show_resume_line`, trigger crons/webhooks/auth/timezones.
-3. **Restart-only settings** require `/restart` or `systemctl restart`: `bot_token`, `chat_id`, `session_mode`, `topics.enabled`, `message_overflow`, `triggers.server.host`/`port`.
-4. Check the log for `config.reload.applied` (success) or `config.reload.transport_config_changed restart_required=True` (restart needed).
+3. **Restart-only settings** require `/restart` or `systemctl restart`: `bot_token`, `chat_id`, `session_mode`, `topics.enabled`, `message_overflow`, `triggers.server.host`/`port`. Editing one of these in a running bot triggers a Telegram 🔄 warning to every project chat plus any `allowed_user_ids` admin DM ([#318](https://github.com/littlebearapps/untether/issues/318)) so you won't silently keep running on the stale value.
+4. Check the log for `config.reload.applied` (success), `config.reload.transport_config_changed restart_required=True` (restart needed), or `config.reload.restart_notify.sent` (Telegram warning broadcast).
 
 ## /at delay not firing
 

--- a/docs/how-to/webhooks-and-cron.md
+++ b/docs/how-to/webhooks-and-cron.md
@@ -270,7 +270,7 @@ accessible immediately, and removed webhooks start returning 404.
 
 ## One-shot crons with `run_once`
 
-Set `run_once = true` on a cron to fire once then auto-disable. The cron stays in the TOML but is skipped until the next reload or restart:
+Set `run_once = true` on a cron to fire once then auto-disable:
 
 ```toml
 [[triggers.crons]]
@@ -280,7 +280,7 @@ prompt = "Check today's deployment status"
 run_once = true
 ```
 
-After the cron fires, the `triggers.cron.run_once_completed` log line confirms the removal. To re-enable, save the TOML again (triggers a reload) or restart the service.
+After the cron fires, the `triggers.cron.run_once_completed` log line confirms the removal. Fired state is persisted to `run_once_fired.json` (sibling of `untether.toml`), so the cron is skipped across config reloads and process restarts — the TOML entry is kept for history but won't refire. To re-enable a one-shot, change its `id` or remove both the TOML entry and its record in `run_once_fired.json`.
 
 ## Delayed runs with `/at`
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -268,6 +268,10 @@ Budget alerts always appear regardless of `[footer]` settings.
     stall_repeat_seconds = 180.0
     tool_timeout = 600.0
     mcp_tool_timeout = 900.0
+    detect_stuck_after_tool_result = false
+    stuck_after_tool_result_timeout = 300.0
+    stuck_after_tool_result_recovery_enabled = true
+    stuck_after_tool_result_recovery_delay = 60.0
     ```
 
 | Key | Type | Default | Notes |
@@ -277,6 +281,10 @@ Budget alerts always appear regardless of `[footer]` settings.
 | `stall_repeat_seconds` | float | `180.0` | Interval between repeat stall warnings in Telegram (30–600). |
 | `tool_timeout` | float | `600.0` | Stall threshold (seconds) for running local tool calls like Bash, Read, Write (60–7200). Increase for long builds or benchmarks. |
 | `mcp_tool_timeout` | float | `900.0` | Stall threshold (seconds) for running MCP tool calls (60–7200). MCP tools are network-bound and may legitimately run for 10–20+ minutes. |
+| `detect_stuck_after_tool_result` | bool | `false` | Enable the stuck-after-tool_result detector ([#322](https://github.com/littlebearapps/untether/issues/322)) — fires when a `tool_result` arrives and the engine goes silent for `stuck_after_tool_result_timeout` seconds while CPU-active (matches the upstream Claude-code / `mcp-remote` / undici wedge). Opt-in this release; will default `true` once the recovery path has more staging soak time. |
+| `stuck_after_tool_result_timeout` | float | `300.0` | Seconds of silence after a `tool_result` before the detector fires (60–1800). Matches undici's default idle-body timeout. |
+| `stuck_after_tool_result_recovery_enabled` | bool | `true` | When the detector fires, attempt tiered recovery: Tier 2 SIGTERMs `mcp-remote`/`@modelcontextprotocol` adapter children (forces the SSE reader to error out and unblocks the parent engine); Tier 3 cancels the run via `cancel_event`. Set `false` to log only. Has no effect if `detect_stuck_after_tool_result = false`. |
+| `stuck_after_tool_result_recovery_delay` | float | `60.0` | Seconds between Tier 2 MCP-adapter SIGTERM and Tier 3 cancel escalation (10–600). |
 
 The stall monitor in `ProgressEdits` fires at 5 min (300s) idle, 10 min for local tools, 15 min for MCP tools, and 30 min for pending approvals. When a local tool is running and the child process is CPU-active, the first stall warning fires but repeat warnings are suppressed — they resume if CPU goes idle (indicating a genuinely stuck tool). The liveness watchdog in the subprocess layer fires at `liveness_timeout` with `/proc` diagnostics. When `stall_auto_kill` is enabled, auto-kill requires a triple safety gate: timeout exceeded + zero TCP connections + CPU ticks not increasing between snapshots.
 


### PR DESCRIPTION
## Summary

Sixth-pass doc cleanup to close drift introduced by v0.35.2 features whose user-facing notes didn't land with the original PRs. All edits describe already-shipped behaviour.

### Factual corrections
- **`how-to/cost-budgets.md`** — Gemini CLI and AMP are no longer in the "don't report USD costs" list (#316 added `total_cost_usd` extraction for both). Noted the free-tier fallback.
- **`how-to/schedule-tasks.md`** + **`how-to/webhooks-and-cron.md`** — the pre-#317 claim that `run_once` crons re-activate on reload/restart is gone. Now points at `run_once_fired.json` persistence.

### New sections for already-shipped features
- **`how-to/security.md`** — "Engine subprocess env allowlist" section covering #198.
- **`how-to/troubleshooting.md`**:
  - "Claude Code hangs after an MCP tool_result" section for #322's opt-in detector + tiered recovery
  - "Webhook not receiving events" gains a `triggers.server.bind_failed` diagnostic step (#320)
  - "Config change didn't take effect" describes the #318 🔄 Telegram warning broadcast

### New config documentation
- **`reference/config.md`** — four new `[watchdog]` fields from #322.

## Test plan

- [x] `uv run --no-sync zensical build --clean` — builds clean locally
- [x] No code or test changes; pytest/ruff not re-run for pure-docs diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)