### PR TITLE
fix: raise CLAUDE_STREAM_IDLE_TIMEOUT_MS default to 300s (#342)

### DIFF
--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -1316,7 +1316,14 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         # by Claude Code 2.1.110+ for the sdk-cli stdio path. Use setdefault
         # so user overrides (shell rc, per-project env) always win. See #322.
         env.setdefault("CLAUDE_ENABLE_STREAM_WATCHDOG", "1")
-        env.setdefault("CLAUDE_STREAM_IDLE_TIMEOUT_MS", "60000")
+        # #342: opus on `max` reasoning can legitimately idle its SSE stream
+        # for 60-120s while chain-of-thought expands between output deltas; a
+        # 60s watchdog trips and aborts the run mid-reasoning ("API Error:
+        # Stream idle timeout - partial response received"). 300000ms (5 min)
+        # matches the undici idle-body timeout that motivated #322 *and*
+        # Untether's own `stuck_after_tool_result_timeout` default, so the
+        # upstream CLI watchdog and our detector fire in the same window.
+        env.setdefault("CLAUDE_STREAM_IDLE_TIMEOUT_MS", "300000")
         env.setdefault("MCP_TOOL_TIMEOUT", "120000")
         env.setdefault("MAX_MCP_OUTPUT_TOKENS", "12000")
         if self.use_api_billing is not True:

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -439,6 +439,35 @@ def test_env_sets_untether_session() -> None:
     assert env_api["UNTETHER_SESSION"] == "1"
 
 
+def test_env_stream_idle_timeout_default_is_300s(monkeypatch) -> None:
+    """#342: the default CLAUDE_STREAM_IDLE_TIMEOUT_MS must be 300000ms (5 min).
+
+    60000ms (the value shipped in #322 / PR #323) tripped the upstream
+    stream watchdog mid-reasoning on opus/max runs, aborting the run with
+    "API Error: Stream idle timeout". 300000ms matches the undici idle-body
+    timeout that motivated #322 and Untether's own
+    stuck_after_tool_result_timeout default, so legitimate long-thinking
+    windows no longer false-positive.
+    """
+    # Clear any shell-set value so we measure setdefault behaviour.
+    monkeypatch.delenv("CLAUDE_STREAM_IDLE_TIMEOUT_MS", raising=False)
+    runner = ClaudeRunner(claude_cmd="claude")
+    env = runner.env(state=None)
+    assert env is not None
+    assert env["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] == "300000"
+    # Watchdog stays on; only the idle threshold changed.
+    assert env["CLAUDE_ENABLE_STREAM_WATCHDOG"] == "1"
+
+
+def test_env_stream_idle_timeout_user_override_wins(monkeypatch) -> None:
+    """Shell-set CLAUDE_STREAM_IDLE_TIMEOUT_MS wins over the Untether default."""
+    monkeypatch.setenv("CLAUDE_STREAM_IDLE_TIMEOUT_MS", "600000")
+    runner = ClaudeRunner(claude_cmd="claude")
+    env = runner.env(state=None)
+    assert env is not None
+    assert env["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] == "600000"
+
+
 def test_rate_limit_event_returns_empty() -> None:
     """rate_limit_event should decode and translate to no Untether events."""
     event = _decode_event({"type": "rate_limit_event"})


### PR DESCRIPTION
## Summary

Fixes [#342](https://github.com/littlebearapps/untether/issues/342). PR #323's reinforcement of the stuck-after-tool_result detector (#322) set `CLAUDE_STREAM_IDLE_TIMEOUT_MS=60000` as a defensive default. That is too aggressive for opus on `max` reasoning — legitimate chain-of-thought expansion produces 60-120s SSE-idle windows, which trip the upstream CLI watchdog and abort the run with `API Error: Stream idle timeout - partial response received`.

Caught on staging (`v0.35.2rc1`) mid-reasoning: 11 turns in, $1.47 spent, `peak_idle_seconds=91.4`. See the issue for the full reproducer.

Raises the default to `300000` (5 min) which matches:
- **undici's idle-body timeout** — the original motivation for #322
- **Untether's own `stuck_after_tool_result_timeout`** default in `[watchdog]`

So the upstream CLI watchdog and our detector now fire in the same window instead of the upstream one undercutting us by 5×. User overrides via shell rc / systemd drop-in still win (`setdefault`).

## Changes

- `src/untether/runners/claude.py` — raise the setdefault from `60000` to `300000` with a comment explaining the failure mode.
- `tests/test_claude_runner.py` — two new tests: `test_env_stream_idle_timeout_default_is_300s` locks the 300000ms default and `test_env_stream_idle_timeout_user_override_wins` confirms shell-set values still win.

## Test plan

- [x] `uv run pytest -q` — 2289 passed, 1 skipped, 82% coverage
- [x] `uv run ruff format --check` + `ruff check` — clean
- [x] Two new unit tests pass
- [ ] Post-merge: restart staging with rc2 (or hotfix rc1) and validate an `opus · max` long-thinking run completes past the 60s mark

🤖 Generated with [Claude Code](https://claude.com/claude-code)