### PR TITLE
chore: staging 0.35.2rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.2rc1"
+version = "0.35.2rc2"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.2rc1"
+version = "0.35.2rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Version bump to ship #342's `CLAUDE_STREAM_IDLE_TIMEOUT_MS` fix (merged via PR #343) to TestPyPI. No other changes.

rc1 → rc2 delta: [PR #343](https://github.com/littlebearapps/untether/pull/343) only — raises the default from 60000ms to 300000ms to stop the upstream Claude CLI stream watchdog false-triggering on legitimate long-thinking opus/max runs.

## Test plan

- [x] `uv lock` synced
- [x] `ruff format --check` + `ruff check` — clean

Once merged, `testpypi-publish` will push `untether-0.35.2rc2` to TestPyPI and I'll restart the staging bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)