### PR TITLE
docs: surface #330 per-cron permission_mode in user-facing how-to guides

### DIFF
--- a/docs/how-to/plan-mode.md
+++ b/docs/how-to/plan-mode.md
@@ -133,7 +133,24 @@ Once you approve a plan outline (via "Approve Plan"), subsequent tool calls in t
 
 This applies whether you approve via "Approve Plan" after an outline or by directly approving an ExitPlanMode request. Starting a new session (via `/new` or a new message) restores normal approval behaviour.
 
+## Per-cron override (scheduled runs) {#cron-override}
+
+When a scheduled cron fires into a plan-mode chat, the default behaviour is to inherit the chat's plan mode — which means the cron run pauses for an approval nobody's awake to give. Set `permission_mode = "auto"` on the cron itself to override just that run:
+
+```toml
+[[triggers.crons]]
+id = "daily-summary"
+schedule = "0 8 * * *"
+chat_id = -1001234567890
+engine = "claude"
+prompt = "Post yesterday's key events."
+permission_mode = "auto"
+```
+
+Precedence: cron `permission_mode` > per-chat `/planmode` > engine config default. The rest of the chat's interactive traffic continues to honour plan mode. See [Schedule tasks — Autonomous crons](schedule-tasks.md#autonomous-crons) for the full reference.
+
 ## Related
 
 - [Interactive approval](interactive-approval.md) — how approval buttons and diff previews work
+- [Schedule tasks](schedule-tasks.md#autonomous-crons) — per-cron permission override
 - [Configuration](../reference/config.md) — setting default permission mode in `untether.toml`

--- a/docs/how-to/schedule-tasks.md
+++ b/docs/how-to/schedule-tasks.md
@@ -73,6 +73,24 @@ Common schedules:
 
 Add `run_once = true` to fire a cron exactly once, then auto-disable. Fired state persists to `run_once_fired.json` (sibling of your `untether.toml`), so a reload or restart will **not** re-fire it. Remove the cron from your TOML to clean up.
 
+### Autonomous crons in plan-mode chats (Claude) {#autonomous-crons}
+
+By default a cron inherits the chat's permission mode, so if you've set `/planmode plan` on a Claude chat the scheduled run will pause for your approval too. That's rarely what you want for an 8 AM summariser that runs while you're asleep.
+
+Set `permission_mode = "auto"` on the cron to make that run autonomous without flipping the whole chat:
+
+```toml
+[[triggers.crons]]
+id = "overnight-review"
+schedule = "0 6 * * *"
+chat_id = -1001234567890
+engine = "claude"
+prompt = "Review overnight PRs and reply with a summary."
+permission_mode = "auto"
+```
+
+Precedence (Claude): cron `permission_mode` > per-chat `/planmode` > engine config default. Every autonomous run logs `trigger.cron.permission_mode_override`. Valid values: `default`, `plan`, `auto`, `acceptEdits`, `bypassPermissions`. Claude-only for now; other engines silently ignore the field ([#332](https://github.com/littlebearapps/untether/issues/332) tracks full coverage).
+
 ## Webhook triggers
 
 Webhooks let external services (GitHub, Slack, PagerDuty) trigger agent runs via HTTP POST.

--- a/docs/how-to/webhooks-and-cron.md
+++ b/docs/how-to/webhooks-and-cron.md
@@ -282,6 +282,22 @@ run_once = true
 
 After the cron fires, the `triggers.cron.run_once_completed` log line confirms the removal. Fired state is persisted to `run_once_fired.json` (sibling of `untether.toml`), so the cron is skipped across config reloads and process restarts — the TOML entry is kept for history but won't refire. To re-enable a one-shot, change its `id` or remove both the TOML entry and its record in `run_once_fired.json`.
 
+## Autonomous crons in plan-mode chats (Claude)
+
+A cron normally inherits the chat's permission mode, which means a scheduled run fires into a plan-mode chat and stops for your approval — not useful for a cron that runs at 6 AM. Set `permission_mode = "auto"` on the cron to override:
+
+```toml
+[[triggers.crons]]
+id = "overnight-review"
+schedule = "0 6 * * *"
+chat_id = -1001234567890
+engine = "claude"
+prompt = "Review overnight PRs and reply with a summary."
+permission_mode = "auto"
+```
+
+Precedence (Claude only): cron `permission_mode` > per-chat `/planmode` > engine config default. Every run that actually changes the resolved value logs `trigger.cron.permission_mode_override` for staging observability. Valid values: `default`, `plan`, `auto`, `acceptEdits`, `bypassPermissions`. Other engines (Codex, Gemini, OpenCode, Pi, AMP) silently ignore this field — full coverage is tracked in [#332](https://github.com/littlebearapps/untether/issues/332). See [Schedule tasks — Autonomous crons](schedule-tasks.md#autonomous-crons) for the everyday framing.
+
 ## Delayed runs with `/at`
 
 For ad-hoc one-shot delays, use the `/at` command directly in Telegram — no TOML edit required:


### PR DESCRIPTION
## Summary

#330 shipped in v0.35.2 (merged via PR #334) and is documented in the triggers + config *reference* docs — but nowhere in the how-to guides a user actually opens when setting up a cron. The common mistake pattern is: user sets \`/planmode plan\` on their Claude chat, then schedules a 6 AM cron, and finds the cron run paused on Approve/Deny at 6 AM with nobody awake to tap a button. The docs didn't point at the fix.

This PR adds a concise section to three how-to docs:

- **\`how-to/schedule-tasks.md\`** — new "Autonomous crons in plan-mode chats (Claude)" block with the TOML snippet, precedence order (\`cron permission_mode > /planmode > engine default\`), full list of valid values, and #332 cross-reference for non-Claude engines.
- **\`how-to/webhooks-and-cron.md\`** — same section next to the existing \`run_once\` + \`/at\` sections.
- **\`how-to/plan-mode.md\`** — short "Per-cron override (scheduled runs)" section pointing back to schedule-tasks so plan-mode readers find the scheduler escape hatch.

The #322 stuck-after-tool_result watchdog is already covered in \`how-to/troubleshooting.md\` + \`reference/config.md\` via PR #341, and the staging bot's \`~/.untether/untether.toml\` now has \`detect_stuck_after_tool_result = true\` turned on for dogfooding.

## Test plan

- [x] \`uv run --no-sync zensical build --clean\` — builds clean
- [x] Internal anchor links verified: \`schedule-tasks.md#autonomous-crons\` referenced from both \`webhooks-and-cron.md\` and \`plan-mode.md\`

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)