### PR TITLE
chore: staging 0.35.2rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.2rc2"
+version = "0.35.2rc3"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.2rc2"
+version = "0.35.2rc3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bumps version to `0.35.2rc3` for staging on `@hetz_lba1_bot`. Rolls up the six v0.35.2 open-issue merges:

- [#351](https://github.com/littlebearapps/untether/issues/351) xhigh effort level for Claude Code — PR #352
- [#349](https://github.com/littlebearapps/untether/issues/349) surface `rate_limit_event` as visible action — PR #353
- [#350](https://github.com/littlebearapps/untether/issues/350) pre-spawn RAM guard — PR #354
- [#348](https://github.com/littlebearapps/untether/issues/348) `/health` command — PR #355
- [#347](https://github.com/littlebearapps/untether/issues/347) per-session background-task tracking v1 — PR #356
- [#346](https://github.com/littlebearapps/untether/issues/346) gate stuck-after-tool_result detector on live background work — PR #358

Milestone `v0.35.2` is now implementation-complete; merging this unblocks TestPyPI publish for rc3 dogfooding.

## Test plan

- [x] `uv lock --check` clean
- [x] `uv run ruff format --check src/ tests/`
- [ ] CI: format, ruff, pytest 3.12/3.13/3.14, CodeQL, build, lockfile, install-test, testpypi-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)