### PR TITLE
fix: plain Approve on diff_preview tools populates plan-bypass (#369) [rc6]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.2rc5"
+version = "0.35.2rc6"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -102,10 +102,16 @@ _DISCUSS_COOLDOWN: dict[str, tuple[float, int]] = {}
 # When Claude Code next calls ExitPlanMode, it will be auto-approved.
 _DISCUSS_APPROVED: set[str] = set()
 
-# Plan exit approved: session_ids where ExitPlanMode was manually approved.
-# After plan approval, diff_preview tools (Edit/Write/Bash) auto-approve instead
-# of requiring per-tool manual approval — the user already reviewed the plan (#283).
+# Plan-bypass set: session_ids where the user has approved at least one
+# plan-gated tool (ExitPlanMode, Edit, Write, or Bash). After the first
+# approval, subsequent diff_preview tools auto-approve instead of re-prompting
+# — the user has already reviewed code for this session (#283, #369).
 _PLAN_EXIT_APPROVED: set[str] = set()
+
+# Tools guarded by the diff_preview approval gate. Mirrors the tools an
+# approved plan unlocks: approving any of these populates _PLAN_EXIT_APPROVED
+# for the session so subsequent diff_preview tools auto-approve (#369).
+_DIFF_PREVIEW_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "Bash"})
 
 # Sessions where "Pause & Outline Plan" was clicked and we're waiting for outline text.
 # StreamTextBlock handler checks this to emit visible note events in the progress message.
@@ -820,9 +826,9 @@ def translate_claude_event(
                 state.auto_approve_queue.append(request_id)
                 return []
 
-            # Auto-approve tool requests that don't need user interaction
+            # Auto-approve tool requests that don't need user interaction.
+            # _DIFF_PREVIEW_TOOLS is module-scoped — see top of file.
             _TOOLS_REQUIRING_APPROVAL = {"ExitPlanMode", "AskUserQuestion"}
-            _DIFF_PREVIEW_TOOLS = frozenset({"Edit", "Write", "Bash"})
             if isinstance(request, claude_schema.ControlCanUseToolRequest):
                 tool_name = getattr(request, "tool_name", "unknown")
                 if tool_name not in _TOOLS_REQUIRING_APPROVAL:
@@ -1413,10 +1419,15 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             if request_id in _REQUEST_TO_INPUT:
                 inner["updatedInput"] = _REQUEST_TO_INPUT.pop(request_id)
             tool_name = _REQUEST_TO_TOOL_NAME.pop(request_id, None)
-            # After plan approval, bypass diff_preview gate for subsequent
-            # tools — user already reviewed the plan (#283)
+            # After approving any plan-gated tool, bypass the diff_preview
+            # gate for subsequent tools in the same session — the user has
+            # already reviewed code, repeating the prompt per-tool is
+            # redundant (#283 for ExitPlanMode; #369 extended to diff_preview
+            # tools so plan-mode sessions that skip ExitPlanMode also bypass).
             session_id_for_plan = _REQUEST_TO_SESSION.get(request_id)
-            if tool_name == "ExitPlanMode" and session_id_for_plan:
+            if session_id_for_plan and (
+                tool_name == "ExitPlanMode" or tool_name in _DIFF_PREVIEW_TOOLS
+            ):
                 _PLAN_EXIT_APPROVED.add(session_id_for_plan)
         else:
             inner = {"behavior": "deny", "message": deny_message or "User denied"}

--- a/tests/test_claude_control.py
+++ b/tests/test_claude_control.py
@@ -1713,6 +1713,68 @@ def test_plan_exit_approved_cleaned_up_on_session_end() -> None:
     assert session_id not in _PLAN_EXIT_APPROVED
 
 
+# ---------------------------------------------------------------------------
+# #369 — plain Approve on diff_preview tools must populate _PLAN_EXIT_APPROVED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool_name", ["Edit", "Write", "Bash", "ExitPlanMode"])
+@pytest.mark.anyio
+async def test_approve_populates_plan_exit_approved_for_diff_tools(
+    tool_name: str,
+) -> None:
+    """Plain Approve on any diff_preview tool or ExitPlanMode populates
+    _PLAN_EXIT_APPROVED so subsequent Edits auto-approve (#369)."""
+    runner = ClaudeRunner(claude_cmd="claude")
+    session_id = f"sess-369-{tool_name}"
+    request_id = f"req-369-{tool_name}"
+
+    _ACTIVE_RUNNERS[session_id] = (runner, 0.0)
+    _SESSION_STDIN[session_id] = AsyncMock()
+    _REQUEST_TO_SESSION[request_id] = session_id
+    _REQUEST_TO_INPUT[request_id] = {}
+    _REQUEST_TO_TOOL_NAME[request_id] = tool_name
+
+    ok = await runner.write_control_response(request_id, approved=True)
+    assert ok is True
+    assert session_id in _PLAN_EXIT_APPROVED
+
+
+@pytest.mark.anyio
+async def test_deny_does_not_populate_plan_exit_approved() -> None:
+    """Deny click must NOT populate _PLAN_EXIT_APPROVED (#369)."""
+    runner = ClaudeRunner(claude_cmd="claude")
+    session_id = "sess-369-deny"
+    request_id = "req-369-deny"
+
+    _ACTIVE_RUNNERS[session_id] = (runner, 0.0)
+    _SESSION_STDIN[session_id] = AsyncMock()
+    _REQUEST_TO_SESSION[request_id] = session_id
+    _REQUEST_TO_INPUT[request_id] = {}
+    _REQUEST_TO_TOOL_NAME[request_id] = "Edit"
+
+    await runner.write_control_response(request_id, approved=False, deny_message="nope")
+    assert session_id not in _PLAN_EXIT_APPROVED
+
+
+@pytest.mark.anyio
+async def test_approve_non_diff_tool_does_not_populate() -> None:
+    """Approving a non-diff non-ExitPlanMode tool must NOT populate the
+    bypass set (e.g., AskUserQuestion answers don't imply code review) (#369)."""
+    runner = ClaudeRunner(claude_cmd="claude")
+    session_id = "sess-369-aq"
+    request_id = "req-369-aq"
+
+    _ACTIVE_RUNNERS[session_id] = (runner, 0.0)
+    _SESSION_STDIN[session_id] = AsyncMock()
+    _REQUEST_TO_SESSION[request_id] = session_id
+    _REQUEST_TO_INPUT[request_id] = {}
+    _REQUEST_TO_TOOL_NAME[request_id] = "AskUserQuestion"
+
+    await runner.write_control_response(request_id, approved=True)
+    assert session_id not in _PLAN_EXIT_APPROVED
+
+
 def test_diff_preview_edit_shows_diff_text() -> None:
     """When diff_preview=True, Edit approval message contains diff text."""
     from untether.runners.run_options import EngineRunOptions, apply_run_options

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.2rc5"
+version = "0.35.2rc6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes #369 — under `--permission-mode plan --permission-prompt-tool stdio`, every Edit/Write/Bash re-prompted for approval because `_PLAN_EXIT_APPROVED` was only populated on ExitPlanMode approval. Resumed sessions where Claude skipped ExitPlanMode (plan already approved in a prior turn) hit the diff_preview gate per tool — ~1 Edit per click, workflow broken for multi-file fixes.

Extends the #283 bypass pattern: plain Approve on any diff_preview tool (Edit/Write/Bash) now populates `_PLAN_EXIT_APPROVED`, matching the existing ExitPlanMode path.

Version: **0.35.2rc6** (TestPyPI only via dev branch — no master merge).

## Changes

- `src/untether/runners/claude.py`: promote `_DIFF_PREVIEW_TOOLS` to module scope; extend `write_control_response` bypass condition
- `tests/test_claude_control.py`: +6 regression tests (parametrized approve + deny + non-diff-tool negative)
- `pyproject.toml`: 0.35.2rc5 → 0.35.2rc6
- `uv.lock`: resync

## Test plan

- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest` — 2372 passed, 1 skipped, coverage 82.06% (threshold 80%)
- [x] `uv lock --check` — clean
- [x] **Phase 1 live** on `@untether_dev_bot` Claude chat (`-5284581592`): fresh session, plan mode on, ExitPlanMode → 3 Writes + 3 Edits after 1 Approve click — 1× `control_response.sent` + 6× `control_response.auto_approved` in journalctl
- [x] **Phase 2 live — exact #369 repro**: resumed session skips ExitPlanMode, first Edit hits diff_preview gate, Approve → 2 subsequent Edits auto-approve — 1× sent + 2× auto_approved
- [x] **Discuss flow regression (#283)**: Pause & Outline Plan → outline → Approve Plan → 3 Writes auto-approve — no regression
- [x] **Tier 7 command smoke**: `/ping`, `/usage`, `/verbose`, `/config` all responding cleanly
- [x] Logs clean — no unexpected warnings/errors during the run

## Follow-up

#370 — research: migrate plan-exit bypass to parent-initiated `set_permission_mode` control_request. Filed against v0.35.5 milestone. The current `_PLAN_EXIT_APPROVED` pattern is a protocol-dishonest silent-auto-approve shortcut; a true mirror of vanilla Claude Code CLI would send `set_permission_mode` to transition the CLI itself out of plan mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)