### PR TITLE
feat(claude): add extra_args config for upstream CLI flags (#407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # changelog
 
+## v0.35.3 (unreleased)
+
+### changes
+
+- **feat:** `[claude]` config gains `extra_args: list[str]` — user-supplied upstream CLI flags passed through to `claude` verbatim. Mirrors `codex.extra_args` and `pi.extra_args`. Primary motivator is Claude-in-Chrome: Claude Code 2.1.x gates the `mcp__claude-in-chrome__*` tool namespace behind `--chrome` (or `CLAUDE_CODE_ENABLE_CFC=1`), so Untether-spawned sessions never saw those tools in their catalogue. Setting `extra_args = ["--chrome"]` in `~/.untether/untether.toml` now enables Claude-in-Chrome end-to-end without forking Untether or touching the LaunchAgent/systemd env. Flags Untether manages internally (`-p`, `--print`, `--output-format`, `--input-format`, `--resume`/`-r`, `--continue`/`-c`, `--permission-mode`, `--permission-prompt-tool`) are rejected at config-load with a `ConfigError` so duplicate-argv surprises fail fast instead of at runtime. The user-supplied args land on argv after Untether's managed stream-json prelude and before resume / model / effort / allowed-tools / permission flags, so the trailing `-p <prompt>` (or stdin prompt under permission-mode) is never displaced. 8 new unit tests in `tests/test_build_args.py` cover argv ordering, permission-mode argv, multi-flag order preservation, `build_runner` parsing, and reserved-flag rejection (individual flag + `key=value` prefix form) [#407](https://github.com/littlebearapps/untether/issues/407)
+
 ## v0.35.2 (2026-04-20)
 
 ### changes

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -363,6 +363,7 @@ here; plugin engines should document their own keys.
 |-----|------|---------|-------|
 | `model` | string | (unset) | Optional model override. |
 | `allowed_tools` | string[] | `["Bash", "Read", "Edit", "Write"]` | Auto-approve tool rules. |
+| `extra_args` | string[] | `[]` | Extra CLI args passed to `claude` (e.g. `["--chrome"]` to opt into the Claude-in-Chrome extension). Flags Untether manages internally (`-p`, `--print`, `--output-format`, `--input-format`, `--resume`/`-r`, `--continue`/`-c`, `--permission-mode`, `--permission-prompt-tool`) are rejected at config-load. |
 | `dangerously_skip_permissions` | bool | `false` | Skip Claude Code permissions prompts. |
 | `use_api_billing` | bool | `false` | Keep `ANTHROPIC_API_KEY` for API billing. |
 
@@ -371,6 +372,7 @@ here; plugin engines should document their own keys.
     ```sh
     untether config set claude.model "claude-sonnet-4-5-20250929"
     untether config set claude.allowed_tools '["Bash", "Read", "Edit", "Write"]'
+    untether config set claude.extra_args '["--chrome"]'
     untether config set claude.dangerously_skip_permissions false
     untether config set claude.use_api_billing false
     ```
@@ -381,6 +383,7 @@ here; plugin engines should document their own keys.
     [claude]
     model = "claude-sonnet-4-5-20250929"
     allowed_tools = ["Bash", "Read", "Edit", "Write"]
+    extra_args = ["--chrome"]    # e.g. opt into Claude-in-Chrome
     dangerously_skip_permissions = false
     use_api_billing = false
     ```

--- a/docs/reference/runners/claude/runner.md
+++ b/docs/reference/runners/claude/runner.md
@@ -78,6 +78,7 @@ Recommended v1 schema:
     untether config set default_engine "claude"
     untether config set claude.model "claude-sonnet-4-5-20250929"
     untether config set claude.allowed_tools '["Bash", "Read", "Edit", "Write"]'
+    untether config set claude.extra_args '["--chrome"]'
     untether config set claude.dangerously_skip_permissions false
     untether config set claude.use_api_billing false
     ```
@@ -93,6 +94,7 @@ Recommended v1 schema:
     model = "claude-sonnet-4-5-20250929" # optional (Claude Code supports model override in settings too)
     permission_mode = "auto"             # optional: "plan", "auto", or "acceptEdits"
     allowed_tools = ["Bash", "Read", "Edit", "Write"] # optional but strongly recommended for automation
+    extra_args = ["--chrome"]           # optional: extra upstream CLI flags (e.g. --chrome opts into Claude-in-Chrome)
     dangerously_skip_permissions = false # optional (high risk; prefer sandbox use only)
     use_api_billing = false             # optional (keep ANTHROPIC_API_KEY for API billing)
     ```
@@ -102,8 +104,9 @@ Notes:
 * `--allowedTools` exists specifically to auto-approve tools in programmatic runs. ([Claude Code][1])
 * Claude Code tools (Bash/Edit/Write/WebSearch/etc.) and whether permission is required are documented. ([Claude Code][2])
 * If `allowed_tools` is omitted, Untether defaults to `["Bash", "Read", "Edit", "Write"]`.
-* Untether reads `model`, `permission_mode`, `allowed_tools`, `dangerously_skip_permissions`, and `use_api_billing` from `[claude]`.
+* Untether reads `model`, `permission_mode`, `allowed_tools`, `extra_args`, `dangerously_skip_permissions`, and `use_api_billing` from `[claude]`.
 * `permission_mode = "auto"` uses `--permission-mode plan` on the CLI but auto-approves ExitPlanMode requests without showing Telegram buttons. Can also be set per chat via `/planmode auto`.
+* `extra_args` lets you pass additional upstream `claude` CLI flags that Untether doesn't expose directly — for example `["--chrome"]` opts into the Claude-in-Chrome extension (otherwise gated off by Claude Code 2.1.x), or `["--strict-mcp-config"]` / `["--mcp-config", "path"]` for MCP tweaks. Flags Untether manages internally (`-p`, `--print`, `--output-format`, `--input-format`, `--resume`/`-r`, `--continue`/`-c`, `--permission-mode`, `--permission-prompt-tool`) are rejected at config-load with a `ConfigError`. Mirrors `codex.extra_args` and `pi.extra_args`.
 * By default Untether strips `ANTHROPIC_API_KEY` from the subprocess environment so Claude Code uses subscription billing. Set `use_api_billing = true` to keep the key.
 
 ---

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -26,6 +26,7 @@ import anyio
 import msgspec
 
 from ..backends import EngineBackend, EngineConfig
+from ..config import ConfigError
 from ..events import EventFactory
 from ..logging import get_logger
 from ..model import (
@@ -63,6 +64,44 @@ DEFAULT_ALLOWED_TOOLS = ["Bash", "Read", "Edit", "Write"]
 _RESUME_RE = re.compile(
     r"(?im)^\s*`?claude\s+(?:--resume|-r)\s+(?P<token>[^`\s]+)`?\s*$"
 )
+
+# Flags that Untether sets on every spawn (stream-json I/O, resume tokens,
+# permission wiring). A user-supplied copy in `[claude].extra_args` would
+# either duplicate the arg or collide with Untether's expected value, so
+# `build_runner` rejects any entry matching this set or one of the equivalent
+# `key=value` prefixes below. Mirrors `codex._EXEC_ONLY_FLAGS` (#407).
+_RESERVED_FLAGS: frozenset[str] = frozenset(
+    {
+        "-p",
+        "--print",
+        "--output-format",
+        "--input-format",
+        "--resume",
+        "-r",
+        "--continue",
+        "-c",
+        "--permission-mode",
+        "--permission-prompt-tool",
+    }
+)
+_RESERVED_PREFIXES: tuple[str, ...] = (
+    "--output-format=",
+    "--input-format=",
+    "--resume=",
+    "--permission-mode=",
+    "--permission-prompt-tool=",
+)
+
+
+def _find_reserved_flag(extra_args: list[str]) -> str | None:
+    for arg in extra_args:
+        if arg in _RESERVED_FLAGS:
+            return arg
+        for prefix in _RESERVED_PREFIXES:
+            if arg.startswith(prefix):
+                return arg
+    return None
+
 
 # Phase 2: Global registry for active ClaudeRunner instances
 # Keyed by session_id, stores (runner_instance, timestamp)
@@ -1381,6 +1420,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     model: str | None = None
     permission_mode: str | None = None
     allowed_tools: list[str] | None = None
+    extra_args: list[str] = field(default_factory=list)
     dangerously_skip_permissions: bool = False
     use_api_billing: bool = False
     session_title: str = "claude"
@@ -1550,6 +1590,12 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 "stream-json",
                 "--verbose",
             ]
+
+        # User-supplied CLI flags (e.g. `--chrome` to opt into Claude-in-Chrome).
+        # Must sit after the Untether-managed I/O prelude but before
+        # resume / model / effort / allowed-tools / permission so the final
+        # prompt position (after `--`) is never displaced (#407).
+        args.extend(self.extra_args)
 
         if resume is not None:
             if resume.is_continue:
@@ -2309,7 +2355,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             self._pty_master_fd = None
 
 
-def build_runner(config: EngineConfig, _config_path: Path) -> Runner:
+def build_runner(config: EngineConfig, config_path: Path) -> Runner:
     claude_cmd = shutil.which("claude") or "claude"
 
     model = config.get("model")
@@ -2322,11 +2368,41 @@ def build_runner(config: EngineConfig, _config_path: Path) -> Runner:
     permission_mode = config.get("permission_mode")
     title = str(model) if model is not None else "claude"
 
+    extra_args_value = config.get("extra_args")
+    if extra_args_value is None:
+        extra_args: list[str] = []
+    elif isinstance(extra_args_value, list) and all(
+        isinstance(item, str) for item in extra_args_value
+    ):
+        extra_args = list(extra_args_value)
+    else:
+        logger.warning(
+            "claude.config.invalid",
+            error="extra_args must be a list of strings",
+            config_path=str(config_path),
+        )
+        raise ConfigError(
+            f"Invalid `claude.extra_args` in {config_path}; expected a list of strings."
+        )
+
+    reserved_flag = _find_reserved_flag(extra_args)
+    if reserved_flag:
+        logger.warning(
+            "claude.config.invalid",
+            error=f"reserved flag {reserved_flag!r} is managed by Untether",
+            config_path=str(config_path),
+        )
+        raise ConfigError(
+            f"Invalid `claude.extra_args` in {config_path}; flag {reserved_flag!r} "
+            f"is managed by Untether and cannot be overridden."
+        )
+
     return ClaudeRunner(
         claude_cmd=claude_cmd,
         model=model,
         permission_mode=permission_mode,
         allowed_tools=allowed_tools,
+        extra_args=extra_args,
         dangerously_skip_permissions=dangerously_skip_permissions,
         use_api_billing=use_api_billing,
         session_title=title,

--- a/tests/test_build_args.py
+++ b/tests/test_build_args.py
@@ -94,6 +94,136 @@ class TestClaudeBuildArgs:
         # Should be comma-separated list
         assert "Bash" in args[idx + 1]
 
+    def test_extra_args_default_empty(self) -> None:
+        """`extra_args=[]` produces byte-identical argv to the pre-#407
+        behaviour — no extra tokens introduced."""
+        runner_none = self._runner()
+        runner_empty = self._runner(extra_args=[])
+        from untether.runners.claude import ClaudeStreamState
+
+        state = ClaudeStreamState()
+        args_none = runner_none.build_args("hello", None, state=state)
+        args_empty = runner_empty.build_args("hello", None, state=state)
+        assert args_none == args_empty
+
+    def test_extra_args_chrome(self) -> None:
+        """`extra_args=['--chrome']` lands on argv after the managed
+        prelude and before resume/model/allowed-tools, and does not
+        displace the `-p <prompt>` suffix (#407)."""
+        runner = self._runner(extra_args=["--chrome"])
+        from untether.runners.claude import ClaudeStreamState
+
+        state = ClaudeStreamState()
+        token = ResumeToken(engine="claude", value="sess123")
+        args = runner.build_args("hello", token, state=state)
+        assert "--chrome" in args
+        chrome_idx = args.index("--chrome")
+        verbose_idx = args.index("--verbose")
+        resume_idx = args.index("--resume")
+        assert verbose_idx < chrome_idx < resume_idx
+        # Prompt still last after `--`
+        assert args[-2] == "--"
+        assert args[-1] == "hello"
+
+    def test_extra_args_chrome_permission_mode(self) -> None:
+        """`extra_args` survives the permission-mode argv path (no -p,
+        prompt sent via stdin)."""
+        runner = self._runner(extra_args=["--chrome"])
+        from untether.runners.claude import ClaudeStreamState
+
+        state = ClaudeStreamState()
+        opts = RunOptions(permission_mode="plan")
+        with patch("untether.runners.claude.get_run_options", return_value=opts):
+            args = runner.build_args("hello", None, state=state)
+        assert "--chrome" in args
+        assert "--permission-mode" in args
+        chrome_idx = args.index("--chrome")
+        perm_idx = args.index("--permission-mode")
+        assert chrome_idx < perm_idx
+        # permission-mode path sends prompt via stdin, no trailing `-- hello`
+        assert "--" not in args
+        assert "hello" not in args
+
+    def test_extra_args_multiple(self) -> None:
+        """Order between multiple user-supplied flags is preserved."""
+        runner = self._runner(extra_args=["--chrome", "--strict-mcp-config"])
+        from untether.runners.claude import ClaudeStreamState
+
+        state = ClaudeStreamState()
+        args = runner.build_args("hello", None, state=state)
+        chrome_idx = args.index("--chrome")
+        strict_idx = args.index("--strict-mcp-config")
+        assert chrome_idx < strict_idx
+
+
+class TestClaudeBuildRunner:
+    """Coverage for extra_args parsing + reserved-flag validation in
+    `build_runner` (#407)."""
+
+    def _call(self, config: dict[str, Any]):
+        from pathlib import Path
+
+        from untether.runners.claude import build_runner
+
+        return build_runner(config, Path("/tmp/untether.toml"))
+
+    def test_extra_args_missing_yields_empty(self) -> None:
+        runner = self._call({})
+        assert runner.extra_args == []
+
+    def test_extra_args_list_of_strings(self) -> None:
+        runner = self._call({"extra_args": ["--chrome"]})
+        assert runner.extra_args == ["--chrome"]
+
+    def test_extra_args_non_list_raises(self) -> None:
+        import pytest
+
+        from untether.config import ConfigError
+
+        with pytest.raises(ConfigError, match="list of strings"):
+            self._call({"extra_args": "--chrome"})
+
+    def test_extra_args_non_string_element_raises(self) -> None:
+        import pytest
+
+        from untether.config import ConfigError
+
+        with pytest.raises(ConfigError, match="list of strings"):
+            self._call({"extra_args": ["--chrome", 42]})
+
+    def test_reserved_flag_rejected(self) -> None:
+        import pytest
+
+        from untether.config import ConfigError
+
+        for reserved in (
+            "-p",
+            "--print",
+            "--output-format",
+            "--input-format",
+            "--resume",
+            "--continue",
+            "--permission-mode",
+            "--permission-prompt-tool",
+        ):
+            with pytest.raises(ConfigError, match="managed by Untether"):
+                self._call({"extra_args": [reserved]})
+
+    def test_reserved_prefix_rejected(self) -> None:
+        import pytest
+
+        from untether.config import ConfigError
+
+        with pytest.raises(ConfigError, match="managed by Untether"):
+            self._call({"extra_args": ["--output-format=text"]})
+
+    def test_non_reserved_flag_accepted(self) -> None:
+        # Sanity: `--chrome`, `--no-chrome`, `--mcp-config`, and other
+        # upstream flags Untether doesn't manage must pass through.
+        for flag in ("--chrome", "--no-chrome", "--mcp-config"):
+            runner = self._call({"extra_args": [flag]})
+            assert flag in runner.extra_args
+
 
 # ---------------------------------------------------------------------------
 # Codex


### PR DESCRIPTION
## Summary

Adds `[claude] extra_args: list[str]` to `untether.toml` so users can pass upstream `claude` CLI flags (like `--chrome`) without forking Untether. Primary motivator: Claude Code 2.1.x gates the `mcp__claude-in-chrome__*` tool namespace behind `--chrome` / `CLAUDE_CODE_ENABLE_CFC=1`, so Untether-spawned sessions never saw those tools. Setting `extra_args = ["--chrome"]` fixes it end-to-end.

Mirrors `codex.extra_args` and `pi.extra_args`.

- Untether-managed flags (`-p`, `--print`, `--output-format`, `--input-format`, `--resume`/`-r`, `--continue`/`-c`, `--permission-mode`, `--permission-prompt-tool`) are rejected at config-load with a `ConfigError` so duplicate-argv surprises fail fast.
- User args land on argv **after** the managed stream-json prelude and **before** resume/model/effort/allowed-tools/permission flags — the trailing `-p <prompt>` (or stdin prompt under permission-mode) position is never displaced.

Closes #407.

## Test plan

- [x] `uv run pytest tests/test_build_args.py tests/test_claude_runner.py tests/test_claude_control.py` (216 passed)
- [x] `uv run ruff check src/` + `uv run ruff format --check src/ tests/`
- [x] `python3 scripts/validate_release.py`
- [ ] **Empirical verification (Nathan)**: run `claude --chrome -p "list your tools" --output-format stream-json --input-format stream-json --verbose < /dev/null` on Mac to confirm `--chrome` works in stream-json mode before staging. Binary analysis found no stream-json-specific gate on the `--chrome` code path, but SSH to the Mac can't run it because claude.ai OAuth lives in the login Keychain.
- [ ] After merge + dev install: `extra_args = ["--chrome"]` in `~/.untether-dev/untether.toml`, restart `untether-dev`, prompt via `@untether_dev_bot`, confirm `mcp__claude-in-chrome__*` appears in the tool catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)