### PR TITLE
fix(security): guard daily cost tracker with threading.Lock (#379)

### DIFF
--- a/src/untether/cost_tracker.py
+++ b/src/untether/cost_tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from dataclasses import dataclass
 
@@ -9,8 +10,13 @@ from .logging import get_logger
 
 logger = get_logger(__name__)
 
-# Daily cost accumulator: (date_str, total_cost)
+# Daily cost accumulator: (date_str, total_cost).
+# #379: guarded by `_daily_cost_lock` so concurrent finalize_run calls can't
+# race the read-modify-write and silently lose a run's cost. The critical
+# section is a single tuple assignment (sub-microsecond), so a `threading.Lock`
+# is fine — both async tasks (cooperative) and threaded callers are safe.
 _daily_cost: tuple[str, float] = ("", 0.0)
+_daily_cost_lock = threading.Lock()
 
 
 @dataclass(slots=True)
@@ -38,18 +44,21 @@ def record_run_cost(cost: float) -> None:
     """Record the cost of a completed run for daily tracking."""
     global _daily_cost
     today = _today()
-    date, total = _daily_cost
-    _daily_cost = (today, cost) if date != today else (today, total + cost)
+    with _daily_cost_lock:
+        date, total = _daily_cost
+        _daily_cost = (today, cost) if date != today else (today, total + cost)
+        daily_total = _daily_cost[1]
     logger.debug(
         "cost_tracker.recorded",
         cost=cost,
-        daily_total=_daily_cost[1],
+        daily_total=daily_total,
     )
 
 
 def get_daily_cost() -> float:
     """Get today's accumulated cost."""
-    date, total = _daily_cost
+    with _daily_cost_lock:
+        date, total = _daily_cost
     if date != _today():
         return 0.0
     return total

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -96,3 +96,31 @@ class TestFormatCostAlert:
     def test_formats_message(self):
         alert = CostAlert(level="warning", message="test message")
         assert format_cost_alert(alert) == "test message"
+
+
+class TestConcurrentRecord:
+    """#379: read-modify-write under concurrent callers must not lose updates."""
+
+    def setup_method(self):
+        _reset_daily()
+
+    def test_concurrent_record_run_cost_atomic(self):
+        from concurrent.futures import ThreadPoolExecutor
+
+        n_calls = 200
+        unit_cost = 0.01
+
+        with ThreadPoolExecutor(max_workers=16) as pool:
+            futures = [pool.submit(record_run_cost, unit_cost) for _ in range(n_calls)]
+            for future in futures:
+                future.result()
+
+        # If the read-modify-write were unguarded, concurrent threads racing
+        # the (today, total + cost) assignment would lose updates and the
+        # observed total would be < n * unit. The lock makes this impossible.
+        expected = round(n_calls * unit_cost, 2)
+        observed = round(get_daily_cost(), 2)
+        assert observed == expected, (
+            f"lost cost updates under concurrency: "
+            f"expected ${expected:.2f}, got ${observed:.2f}"
+        )


### PR DESCRIPTION
## Summary

Closes #379. Fixes a read-modify-write race in `cost_tracker._daily_cost` that could let concurrent `record_run_cost` calls silently lose updates and defeat the per-day budget gate.

**Why `threading.Lock` over `anyio.Lock`:** verified via grep — there is exactly 1 production caller (`runner_bridge.py:550`, sync) and 6 sync test callers. The critical section is a single tuple assignment (sub-microsecond), so a `threading.Lock` covers both async (cooperative) and threaded concurrency models without rippling an async signature change through the callers and test suite.

## Changes

- `src/untether/cost_tracker.py` — added `_daily_cost_lock = threading.Lock()`; wrapped the RMW block in `record_run_cost` and the read in `get_daily_cost` with `with _daily_cost_lock:`. Functions remain synchronous.

## Test plan

- [x] `uv run pytest tests/test_cost_tracker.py --no-cov -v` → 13 passed (12 existing + 1 new `test_concurrent_record_run_cost_atomic` using `ThreadPoolExecutor` with 16 workers × 200 calls)
- [x] `uv run pytest --no-cov` → 2411 passed, 2 skipped
- [x] `uv run ruff check src/ tests/` → clean
- [x] `uv run ruff format --check src/ tests/` → clean
- [ ] Integration via `@untether_dev_bot` after merge: Tier 6 stress — send 5 concurrent prompts via `/claude`, verify `/usage` daily total equals sum of per-run costs

## Notes

- Group 1B sub-batch 1 of 3 (#379 cost-tracker race, #378 voice-key SecretStr, #377 startup-block) per the approved v0.35.3 plan.
- No CHANGELOG entry — per `release-discipline.md` §"Staging / rc versions", entries batch into the stable bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)