### PR TITLE
fix(security): voice_transcription_api_key → SecretStr (#378)

### DIFF
--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -121,7 +121,10 @@ class TelegramTransportSettings(BaseModel):
     voice_max_bytes: StrictInt = 10 * 1024 * 1024
     voice_transcription_model: NonEmptyStr = "gpt-4o-mini-transcribe"
     voice_transcription_base_url: NonEmptyStr | None = None
-    voice_transcription_api_key: NonEmptyStr | None = None
+    # #378: SecretStr (parity with bot_token from #196) — masks repr()/str()/
+    # tracebacks/structlog. Access the raw value via .get_secret_value() at the
+    # transport boundary (telegram/loop.py before passing to OpenAI SDK).
+    voice_transcription_api_key: SecretStr | None = None
     voice_show_transcription: bool = True
     session_mode: Literal["stateless", "chat"] = "stateless"
     show_resume_line: bool = True
@@ -142,6 +145,19 @@ class TelegramTransportSettings(BaseModel):
         if not token:
             raise ValueError("bot_token must not be empty")
         return SecretStr(token)
+
+    @field_validator("voice_transcription_api_key", mode="after")
+    @classmethod
+    def _validate_voice_key_not_empty(cls, v: SecretStr | None) -> SecretStr | None:
+        """#378: preserve the pre-SecretStr `NonEmptyStr | None` contract.
+        Empty / whitespace-only strings round-trip to None so downstream code
+        can use a simple `is not None` (or truthy) check at the call site."""
+        if v is None:
+            return None
+        key = v.get_secret_value().strip()
+        if not key:
+            return None
+        return SecretStr(key)
 
 
 class TransportsSettings(BaseModel):

--- a/src/untether/telegram/bridge.py
+++ b/src/untether/telegram/bridge.py
@@ -4,6 +4,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, cast
 
+from pydantic import SecretStr
+
 from ..context import RunContext
 from ..logging import get_logger
 from ..markdown import MarkdownFormatter, MarkdownParts
@@ -159,7 +161,8 @@ class TelegramBridgeConfig:
     voice_max_bytes: int = 10 * 1024 * 1024
     voice_transcription_model: str = "gpt-4o-mini-transcribe"
     voice_transcription_base_url: str | None = None
-    voice_transcription_api_key: str | None = None
+    # #378: SecretStr ferries the key without leaking it through repr/log.
+    voice_transcription_api_key: SecretStr | None = None
     voice_show_transcription: bool = True
     forward_coalesce_s: float = 1.0
     media_group_debounce_s: float = 1.0

--- a/src/untether/telegram/loop.py
+++ b/src/untether/telegram/loop.py
@@ -2205,7 +2205,11 @@ async def run_main_loop(
                         max_bytes=cfg.voice_max_bytes,
                         reply=reply,
                         base_url=cfg.voice_transcription_base_url,
-                        api_key=cfg.voice_transcription_api_key,
+                        api_key=(
+                            cfg.voice_transcription_api_key.get_secret_value()
+                            if cfg.voice_transcription_api_key is not None
+                            else None
+                        ),
                     )
                     if text is None:
                         return

--- a/tests/test_bridge_config_reload.py
+++ b/tests/test_bridge_config_reload.py
@@ -76,7 +76,10 @@ class TestUpdateFrom:
         assert cfg.voice_max_bytes == 1 * 1024 * 1024
         assert cfg.voice_transcription_model == "whisper-1"
         assert cfg.voice_transcription_base_url == "https://x/v1"
-        assert cfg.voice_transcription_api_key == "sk-new"
+        # #378: SecretStr — compare via .get_secret_value() since equality
+        # against a bare str returns False.
+        assert cfg.voice_transcription_api_key is not None
+        assert cfg.voice_transcription_api_key.get_secret_value() == "sk-new"
         assert cfg.voice_show_transcription is False
         assert cfg.show_resume_line is False
         assert cfg.forward_coalesce_s == 3.5
@@ -123,7 +126,9 @@ class TestUpdateFrom:
     def test_update_from_clears_voice_api_key(self, cfg: TelegramBridgeConfig):
         """Removing voice_transcription_api_key from config resets it to None."""
         cfg.update_from(_settings(voice_transcription_api_key="sk-before"))
-        assert cfg.voice_transcription_api_key == "sk-before"
+        # #378: SecretStr — equality is by SecretStr identity, not raw string.
+        assert cfg.voice_transcription_api_key is not None
+        assert cfg.voice_transcription_api_key.get_secret_value() == "sk-before"
         cfg.update_from(_settings())  # no voice_transcription_api_key
         assert cfg.voice_transcription_api_key is None
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -191,6 +191,56 @@ def test_bot_token_none_rejected(tmp_path: Path) -> None:
         validate_settings_data(data, config_path=config_path)
 
 
+def test_voice_transcription_api_key_is_secret_str(tmp_path: Path) -> None:
+    """#378: voice_transcription_api_key must be SecretStr — masks repr()/str()
+    and only yields the raw value via .get_secret_value()."""
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        "[transports.telegram]\n"
+        'bot_token = "tok"\n'
+        "chat_id = 123\n"
+        "voice_transcription = true\n"
+        'voice_transcription_api_key = "sk-supersecret-1234567890ABCDEF"\n',
+        encoding="utf-8",
+    )
+    settings, _ = load_settings(config_path)
+    key = settings.transports.telegram.voice_transcription_api_key
+    assert key is not None
+    assert key.get_secret_value() == "sk-supersecret-1234567890ABCDEF"
+    # Masking: str() and repr() must not leak the value.
+    assert "supersecret" not in str(key)
+    assert "supersecret" not in repr(key)
+
+
+def test_voice_transcription_api_key_empty_string_normalised_to_none(
+    tmp_path: Path,
+) -> None:
+    """#378: empty/whitespace-only API key round-trips to None so downstream
+    truthy / `is not None` checks behave the same as with the prior
+    `NonEmptyStr | None` field type."""
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        "[transports.telegram]\n"
+        'bot_token = "tok"\n'
+        "chat_id = 123\n"
+        'voice_transcription_api_key = "   "\n',
+        encoding="utf-8",
+    )
+    settings, _ = load_settings(config_path)
+    assert settings.transports.telegram.voice_transcription_api_key is None
+
+
+def test_voice_transcription_api_key_default_none(tmp_path: Path) -> None:
+    """#378: default is still None when key is omitted."""
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        '[transports.telegram]\nbot_token = "tok"\nchat_id = 123\n',
+        encoding="utf-8",
+    )
+    settings, _ = load_settings(config_path)
+    assert settings.transports.telegram.voice_transcription_api_key is None
+
+
 def test_require_telegram_rejects_non_telegram_transport(tmp_path: Path) -> None:
     config_path = tmp_path / "untether.toml"
     settings = UntetherSettings.model_validate(

--- a/tests/test_telegram_backend.py
+++ b/tests/test_telegram_backend.py
@@ -306,7 +306,9 @@ def test_telegram_backend_build_and_run_wires_config(
     assert cfg.voice_max_bytes == 1234
     assert cfg.voice_transcription_model == "whisper-1"
     assert cfg.voice_transcription_base_url == "http://localhost:8000/v1"
-    assert cfg.voice_transcription_api_key == "local"
+    # #378: voice_transcription_api_key is now SecretStr — compare via .get_secret_value()
+    assert cfg.voice_transcription_api_key is not None
+    assert cfg.voice_transcription_api_key.get_secret_value() == "local"
     assert cfg.voice_show_transcription is False
     assert cfg.allowed_user_ids == (7, 8)
     assert cfg.files.enabled is True


### PR DESCRIPTION
## Summary

Closes #378. Brings `voice_transcription_api_key` into parity with `bot_token` (closed #196) — wraps it in Pydantic `SecretStr` so the value is masked in `repr()`/`str()`/tracebacks/structlog, and the raw key is only accessible via `.get_secret_value()` at the transport boundary.

## Changes

- **`src/untether/settings.py`**: field type `NonEmptyStr | None` → `SecretStr | None`. New `_validate_voice_key_not_empty` validator preserves the prior no-empty-string contract by round-tripping `""` / whitespace-only values to `None`.
- **`src/untether/telegram/bridge.py`**: `TelegramBridgeConfig.voice_transcription_api_key` annotation → `SecretStr | None`; added `from pydantic import SecretStr`. `update_from()` unchanged (assigns SecretStr to SecretStr — no logic change).
- **`src/untether/telegram/loop.py:2208`**: sole unwrap point — call `.get_secret_value()` only when non-None before passing to `transcribe_voice`. The OpenAI SDK still wants raw `str | None`.
- **`src/untether/telegram/voice.py`**: unchanged; boundary stays at the loop caller.

## Tests

- `tests/test_settings.py` — new `test_voice_transcription_api_key_is_secret_str` (round-trip + `repr/str` masking), `..._empty_string_normalised_to_none` (whitespace → `None`), `..._default_none` (omitted → `None`).
- `tests/test_bridge_config_reload.py` — hot-reload tests updated to use `.get_secret_value()` for value comparison; `test_update_from_clears_voice_api_key` now asserts SecretStr round-trip + None reset.
- `tests/test_telegram_backend.py` — `build_and_run` assertion updated for SecretStr.

## Test plan

- [x] `uv run pytest tests/test_settings.py tests/test_bridge_config_reload.py tests/test_telegram_backend.py tests/test_cli_helpers.py tests/test_telegram_voice.py --no-cov -x` → 95 passed
- [x] `uv run pytest --no-cov` → 2413 passed, 2 skipped
- [x] `uv run ruff check src/ tests/` → clean
- [x] `uv run ruff format --check src/ tests/` → clean
- [ ] Integration via `@untether_dev_bot` after merge: Tier 3 voice transcription path. Send a voice message; confirm transcription still works. `journalctl --user -u untether-dev` shows no plaintext `sk-...` in logs.

## Notes

- Group 1B sub-batch 2 of 3. PR #432 is sub-batch 1 (#379 cost-tracker race). #377 (startup-block) saved for after Group 1C per the approved plan order.
- Independent of #432 — no merge ordering required.
- No CHANGELOG entry — per `release-discipline.md` §"Staging / rc versions".

🤖 Generated with [Claude Code](https://claude.com/claude-code)