### PR TITLE
chore: staging 0.35.3rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.3rc1"
+version = "0.35.3rc2"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.3rc1"
+version = "0.35.3rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bump rc1 → rc2 so TestPyPI publishes a fresh staging wheel that includes everything merged to `dev` since rc1 (#412):

- **#431** — Group 1A security hygiene (#205, #206, #207, #208, #211, #213, #402, #403)
- **#432** — #379 daily cost tracker race (`threading.Lock` guard)
- **#433** — #378 `voice_transcription_api_key` → `SecretStr`

rc1 only carried #407 (Claude `extra_args`). rc2 supersedes it.

## Test plan

- [x] `uv run pytest --no-cov` → 2413 passed, 2 skipped (against the merged `dev` state)
- [x] `uv run ruff check src/ tests/` + `ruff format --check` clean
- [x] `uv lock` synced (`untether v0.35.3rc1 → v0.35.3rc2`)
- [x] `release-validation` skips per-rc — no CHANGELOG entry needed (`release-discipline.md` §"Staging / rc versions")
- [ ] After merge: TestPyPI publish should succeed (new version, no `skip-existing` conflict)
- [ ] After publish: `scripts/staging.sh install 0.35.3rc2` on `@hetz_lba1_bot` for staged dogfood

🤖 Generated with [Claude Code](https://claude.com/claude-code)