### PR TITLE
feat(security): user-extensible env allowlist + BWS default (#409)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Untether adds interactive permission control, plan mode support, and several UX 
 - **Trigger visibility (Tier 1)** — `/ping` shows per-chat trigger summary (`⏰ triggers: 1 cron (id, 9:00 AM daily (Melbourne))`); run footer shows `⏰ cron:<id>` / `⚡ webhook:<id>` for trigger-initiated runs; new `describe_cron()` utility renders common patterns in plain English
 - **Graceful restart improvements (Tier 1)** — persists Telegram `update_id` to `last_update_id.json` so restarts don't drop/duplicate messages; `Type=notify` systemd integration via stdlib `sd_notify` (`READY=1` + `STOPPING=1`); `RestartSec=2`
 - **`diff_preview` plan bypass (#283)** — after user approves a plan outline via "Pause & Outline Plan", the `_discuss_approved` flag short-circuits diff preview for subsequent Edit/Write tools so no second approval is needed
+- **User-extensible env allowlist (#409)** — `[security] env_extra_allow` and `env_extra_prefix_allow` (in `untether.toml`) extend the engine-subprocess env allowlist with per-deployment names so users can thread credential-manager tokens (1Password, Doppler, Vault, Infisical, …) without forking `utils/env_policy.py`. Names are validated against `[A-Z_][A-Z0-9_]*`. Honoured by the Claude and Pi runners and by the `env_audit` probe. `BWS_ACCESS_TOKEN` was promoted into the built-in defaults at the same time. One `env_policy.user_extension` INFO log per process
 
 See `.claude/skills/claude-stream-json/` and `.claude/rules/control-channel.md` for implementation details.
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -324,11 +324,15 @@ Runtime security knobs. Defaults are safe — operators only flip these when inv
     ```toml
     [security]
     env_audit = true
+    env_extra_allow = ["OP_SERVICE_ACCOUNT_TOKEN", "DOPPLER_TOKEN"]
+    env_extra_prefix_allow = ["VAULT_", "INFISICAL_"]
     ```
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
 | `env_audit` | bool | `true` | One-shot `/proc/<claude_pid>/environ` sample on first `system.init` ([#361](https://github.com/littlebearapps/untether/issues/361)). Emits `claude.env_audit.leaked_var` WARNING per non-allowlisted name observed (dedup per session per name). Reuses `utils/env_policy.is_allowed`. Linux-only — silently no-ops elsewhere or when /proc is unreadable. Set `false` to opt out (e.g. on hardened hosts where `/proc/<pid>/environ` reads are sensitive). The companion `env -i` wrap on Claude exec ([#361](https://github.com/littlebearapps/untether/issues/361)) is always on and not configurable. |
+| `env_extra_allow` | list[str] | `[]` | Per-deployment exact-match additions to the engine-subprocess env allowlist ([#409](https://github.com/littlebearapps/untether/issues/409)). Use for credential-manager tokens that aren't in the global defaults — e.g. `["OP_SERVICE_ACCOUNT_TOKEN", "DOPPLER_TOKEN", "INFISICAL_TOKEN"]`. Each entry must match `[A-Z_][A-Z0-9_]*` (uppercase, digits, underscore; cannot start with a digit). Empty / whitespace / lowercase entries are rejected at config-load time. Currently honoured by the Claude and Pi runners. The audit (`env_audit`) honours these too, so user-allowed names aren't false-flagged as leaks. Untether emits one `env_policy.user_extension` INFO log per process at first runner spawn so the addition is visible in journalctl. |
+| `env_extra_prefix_allow` | list[str] | `[]` | Like `env_extra_allow` but for name *prefixes* — convenient for credential-manager families where many vars share a prefix. Examples: `["VAULT_"]` admits `VAULT_TOKEN`, `VAULT_ADDR`, `VAULT_NAMESPACE`. Each entry must match the same env-var name shape as `env_extra_allow`. |
 
 ## Engine-specific config tables
 

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -103,6 +103,28 @@ def _find_reserved_flag(extra_args: list[str]) -> str | None:
     return None
 
 
+def _load_env_extras() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """#409: read [security] env_extra_allow / env_extra_prefix_allow.
+
+    Best-effort — config errors must never block a run, so we swallow
+    them and fall back to the built-in defaults. Returns
+    ``(extra_exact, extra_prefix)``.
+    """
+    from ..settings import load_settings_if_exists
+
+    try:
+        result = load_settings_if_exists()
+        if result is None:
+            return ((), ())
+        settings, _ = result
+        return (
+            tuple(settings.security.env_extra_allow),
+            tuple(settings.security.env_extra_prefix_allow),
+        )
+    except Exception:  # noqa: BLE001 — never let config errors block a run
+        return ((), ())
+
+
 # Phase 2: Global registry for active ClaudeRunner instances
 # Keyed by session_id, stores (runner_instance, timestamp)
 _ACTIVE_RUNNERS: dict[str, tuple[ClaudeRunner, float]] = {}
@@ -589,7 +611,15 @@ def _maybe_audit_env(state: ClaudeStreamState, session_id: str) -> None:
     if not enabled:
         return
 
-    leaked = audit_proc_env(state.pid, expected_extras=("UNTETHER_SESSION",))
+    # #409: pass user extras through so the audit doesn't flag names the
+    # operator explicitly opted into via [security] env_extra_allow.
+    user_exact, user_prefix = _load_env_extras()
+    leaked = audit_proc_env(
+        state.pid,
+        expected_extras=("UNTETHER_SESSION",),
+        user_extra_exact=user_exact,
+        user_extra_prefix=user_prefix,
+    )
     for name in leaked:
         if name in state.audited_leaks:
             continue
@@ -1677,9 +1707,13 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         # MCP namespaces, etc.) flow through. See env_policy.py for the
         # canonical list + how to extend it when a new MCP or engine needs
         # an unfamiliar variable.
-        from ..utils.env_policy import filtered_env
+        from ..utils.env_policy import filtered_env, log_user_extensions_once
 
-        env = filtered_env()
+        # #409: thread per-deployment extras from
+        # [security] env_extra_allow / env_extra_prefix_allow.
+        extra_exact, extra_prefix = _load_env_extras()
+        log_user_extensions_once(extra_exact, extra_prefix)
+        env = filtered_env(extra_allow=extra_exact, extra_prefix=extra_prefix)
         # Let Claude Code hooks detect Untether sessions (e.g. PitchDocs
         # context-guard skips blocking Stop hooks in Telegram).
         env["UNTETHER_SESSION"] = "1"

--- a/src/untether/runners/pi.py
+++ b/src/untether/runners/pi.py
@@ -49,6 +49,28 @@ _RESUME_RE = re.compile(r"(?im)^\s*`?pi\s+--session\s+(?P<token>.+?)`?\s*$")
 _SESSION_ID_PREFIX_LEN = 8
 
 
+def _load_env_extras() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """#409: read [security] env_extra_allow / env_extra_prefix_allow.
+
+    Best-effort — config errors must never block a run, so we swallow
+    them and fall back to the built-in defaults. Returns
+    ``(extra_exact, extra_prefix)``.
+    """
+    from ..settings import load_settings_if_exists
+
+    try:
+        result = load_settings_if_exists()
+        if result is None:
+            return ((), ())
+        settings, _ = result
+        return (
+            tuple(settings.security.env_extra_allow),
+            tuple(settings.security.env_extra_prefix_allow),
+        )
+    except Exception:  # noqa: BLE001 — never let config errors block a run
+        return ((), ())
+
+
 @dataclass(slots=True)
 class PiStreamState:
     resume: ResumeToken
@@ -456,10 +478,13 @@ class PiRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     def env(self, *, state: PiStreamState) -> dict[str, str] | None:
         # #198: allowlist filter — Pi subprocess no longer inherits the
         # parent's full environment. See `utils/env_policy.py` for the
-        # canonical list + extension notes.
-        from ..utils.env_policy import filtered_env
+        # canonical list + extension notes. #409: thread per-deployment
+        # extras from [security] env_extra_allow / env_extra_prefix_allow.
+        from ..utils.env_policy import filtered_env, log_user_extensions_once
 
-        env = filtered_env()
+        extra_exact, extra_prefix = _load_env_extras()
+        log_user_extensions_once(extra_exact, extra_prefix)
+        env = filtered_env(extra_allow=extra_exact, extra_prefix=extra_prefix)
         env.setdefault("NO_COLOR", "1")
         env.setdefault("CI", "1")
         return env

--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Literal
@@ -285,18 +286,57 @@ class ProgressSettings(BaseModel):
     group_chat_rps: float = Field(default=20.0 / 60.0, gt=0, le=10)
 
 
+_ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+
 class SecuritySettings(BaseModel):
-    """Runtime security knobs (#361).
+    """Runtime security knobs (#361, #409).
 
     ``env_audit`` enables a one-shot ``/proc/<pid>/environ`` sample on
     Claude session start. Disallowed names emit a structured warning so
     the operator can see when host env leaks past
     :func:`utils.env_policy.filtered_env`.
+
+    ``env_extra_allow`` / ``env_extra_prefix_allow`` (#409) extend the
+    built-in subprocess-env allowlist with per-deployment names so users
+    can thread credential-manager tokens (1Password, Doppler, Vault,
+    Infisical, …) without forking ``utils/env_policy.py``.
     """
 
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
     env_audit: bool = True
+    # #409: user-extensible engine-subprocess env allowlist. Each entry
+    # must look like a POSIX env var name (uppercase, digits, underscore;
+    # must not start with a digit). Empty/whitespace strings are rejected
+    # so a stray TOML edit doesn't silently widen the allowlist.
+    env_extra_allow: list[str] = Field(default_factory=list)
+    env_extra_prefix_allow: list[str] = Field(default_factory=list)
+
+    @field_validator("env_extra_allow", "env_extra_prefix_allow", mode="after")
+    @classmethod
+    def _validate_env_names(cls, v: list[str]) -> list[str]:
+        """Each entry must look like a POSIX env-var name.
+
+        Trailing wildcards / glob chars are NOT supported — prefix matches
+        already cover families (``VAULT_*`` is configured as ``"VAULT_"``).
+        """
+        cleaned: list[str] = []
+        for entry in v:
+            if not isinstance(entry, str):
+                raise ValueError(
+                    f"env allowlist entries must be strings (got {type(entry).__name__})"
+                )
+            stripped = entry.strip()
+            if not stripped:
+                raise ValueError("env allowlist entries must not be empty")
+            if not _ENV_NAME_RE.match(stripped):
+                raise ValueError(
+                    f"invalid env name {entry!r} — must match [A-Z_][A-Z0-9_]* "
+                    "(uppercase letters, digits, underscores; cannot start with a digit)"
+                )
+            cleaned.append(stripped)
+        return cleaned
 
 
 class UntetherSettings(BaseSettings):

--- a/src/untether/utils/env_audit.py
+++ b/src/untether/utils/env_audit.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Iterable
 
-from .env_policy import is_allowed
+from .env_policy import is_allowed_with_extras
 
 
 def read_proc_environ(pid: int) -> dict[str, str] | None:
@@ -47,6 +47,8 @@ def audit_proc_env(
     pid: int,
     *,
     expected_extras: Iterable[str] = (),
+    user_extra_exact: Iterable[str] = (),
+    user_extra_prefix: Iterable[str] = (),
 ) -> list[str]:
     """Return sorted names present in ``/proc/<pid>/environ`` that aren't
     in the env_policy allowlist.
@@ -57,13 +59,24 @@ def audit_proc_env(
     ``expected_extras`` lets the caller permit per-engine vars that
     aren't in the global allowlist (e.g. a runner sets a specific
     ``X_INTERNAL_TOKEN`` itself).
+
+    ``user_extra_exact`` / ``user_extra_prefix`` (#409) thread per-
+    deployment user extras through so audit doesn't false-flag names the
+    user opted into via ``[security] env_extra_allow``.
     """
     env = read_proc_environ(pid)
     if not env:
         return []
-    allowed_extras = frozenset(expected_extras)
+    runner_extras = frozenset(expected_extras)
     return sorted(
-        name for name in env if not is_allowed(name) and name not in allowed_extras
+        name
+        for name in env
+        if name not in runner_extras
+        and not is_allowed_with_extras(
+            name,
+            extra_exact=user_extra_exact,
+            extra_prefix=user_extra_prefix,
+        )
     )
 
 

--- a/src/untether/utils/env_policy.py
+++ b/src/untether/utils/env_policy.py
@@ -1,4 +1,4 @@
-"""Allowlist-based env filter for engine subprocesses (#198).
+"""Allowlist-based env filter for engine subprocesses (#198, #409).
 
 Background
 ----------
@@ -29,17 +29,34 @@ integration validation — see #332 for the follow-up milestone.
 Extending the allowlist
 -----------------------
 
-If a new engine or MCP needs a variable that isn't allowlisted, it
-hangs at init with no useful error. Add the variable below, ship a
-test in ``tests/test_env_policy.py``, and run the integration suite.
+There are two ways to extend the allowlist:
+
+1. **Built-in defaults** (this module). Add the variable to
+   ``_EXACT_ALLOW`` or ``_PREFIX_ALLOW``, ship a test in
+   ``tests/test_env_policy.py``, and run the integration suite. Use
+   this for vars that *every* user is likely to need.
+
+2. **Per-deployment config** (#409). Set
+   ``[security] env_extra_allow = [...]`` and
+   ``env_extra_prefix_allow = [...]`` in ``untether.toml``. The
+   runners pass these through to :func:`filtered_env` so the user
+   doesn't need to fork or vendor-patch this module to thread a
+   credential-manager token (``OP_SERVICE_ACCOUNT_TOKEN``,
+   ``DOPPLER_TOKEN``, ``VAULT_*``, etc.) to engine subprocesses.
+
 The set of NAMESPACE prefixes is deliberately narrow — add another
-prefix only when there's a clear family of vars (e.g. all ``XDG_*``).
+default prefix only when there's a clear family of vars (e.g. all
+``XDG_*``). User-defined extras are filtered to the same name shape.
 """
 
 from __future__ import annotations
 
 import os
 from collections.abc import Iterable, Mapping
+
+from ..logging import get_logger
+
+logger = get_logger(__name__)
 
 # Exact-match allowlist. One entry per variable.
 _EXACT_ALLOW: frozenset[str] = frozenset(
@@ -118,6 +135,10 @@ _EXACT_ALLOW: frozenset[str] = frozenset(
         # Cloudflare — for MCP servers accessing CF APIs.
         "CLOUDFLARE_API_TOKEN",
         "CLOUDFLARE_ACCOUNT_ID",
+        # Bitwarden Secrets Manager — used by MCP bash wrappers that
+        # call `kc_get` / `bws secret` to materialise per-project
+        # credentials (Trello, Jina, Pal, etc.). See issue #409.
+        "BWS_ACCESS_TOKEN",
         # Untether-set markers — Claude hooks look for UNTETHER_SESSION.
         "UNTETHER_SESSION",
         # direnv-provided workspace context.
@@ -157,6 +178,26 @@ def is_allowed(name: str) -> bool:
     return any(name.startswith(prefix) for prefix in _PREFIX_ALLOW)
 
 
+def is_allowed_with_extras(
+    name: str,
+    *,
+    extra_exact: Iterable[str] = (),
+    extra_prefix: Iterable[str] = (),
+) -> bool:
+    """Like :func:`is_allowed` but also honours per-deployment user extras (#409).
+
+    ``extra_exact`` and ``extra_prefix`` come from
+    ``[security] env_extra_allow`` / ``env_extra_prefix_allow`` in
+    ``untether.toml``. The audit module passes them through so live-
+    process audits don't false-flag user-allowed names as leaks.
+    """
+    if is_allowed(name):
+        return True
+    if name in frozenset(extra_exact):
+        return True
+    return any(name.startswith(prefix) for prefix in extra_prefix)
+
+
 # Back-compat alias for any external importers that depended on the
 # previously-private name. Safe to remove once we've audited all consumers.
 _is_allowed = is_allowed
@@ -166,6 +207,7 @@ def filtered_env(
     source: Mapping[str, str] | None = None,
     *,
     extra_allow: Iterable[str] = (),
+    extra_prefix: Iterable[str] = (),
 ) -> dict[str, str]:
     """Return a filtered copy of `source` containing only allowlisted keys.
 
@@ -176,6 +218,10 @@ def filtered_env(
     extra_allow : Iterable[str]
         Additional exact variable names to allow for this call (e.g.
         per-engine / per-site keys that don't belong in the global set).
+    extra_prefix : Iterable[str]
+        Additional name prefixes to allow (#409 — surfaces
+        ``[security] env_extra_prefix_allow`` so users can pass through
+        credential-manager families like ``VAULT_*``).
 
     Returns
     -------
@@ -184,8 +230,61 @@ def filtered_env(
     """
     if source is None:
         source = os.environ
-    extras = frozenset(extra_allow)
-    return {k: v for k, v in source.items() if is_allowed(k) or k in extras}
+    extras_exact = frozenset(extra_allow)
+    extras_prefix = tuple(extra_prefix)
+    return {
+        k: v
+        for k, v in source.items()
+        if is_allowed_with_extras(
+            k, extra_exact=extras_exact, extra_prefix=extras_prefix
+        )
+    }
 
 
-__all__ = ["filtered_env", "is_allowed"]
+# Module-level latch so we emit `env_policy.user_extension` at most once
+# per process even if multiple runners (Claude + Pi) call it. Reset is
+# only useful in tests; expose the underlying flag via _RESET_LOG_LATCH.
+_extension_logged = False
+
+
+def log_user_extensions_once(
+    extra_exact: Iterable[str] = (),
+    extra_prefix: Iterable[str] = (),
+) -> None:
+    """Emit a single INFO log naming user-supplied env-policy extras (#409).
+
+    Idempotent — re-invocations after the first non-empty call are
+    no-ops so journalctl shows one record per process per restart, not
+    one per spawned subprocess.
+    """
+    global _extension_logged
+    if _extension_logged:
+        return
+    exact = sorted(set(extra_exact))
+    prefix = sorted(set(extra_prefix))
+    if not exact and not prefix:
+        return
+    logger.info(
+        "env_policy.user_extension",
+        extra_exact=exact,
+        extra_prefix=prefix,
+        hint=(
+            "user-extended subprocess env allowlist via "
+            "[security] env_extra_allow / env_extra_prefix_allow"
+        ),
+    )
+    _extension_logged = True
+
+
+def _reset_log_latch_for_tests() -> None:
+    """Clear the once-per-process log latch. Tests only."""
+    global _extension_logged
+    _extension_logged = False
+
+
+__all__ = [
+    "filtered_env",
+    "is_allowed",
+    "is_allowed_with_extras",
+    "log_user_extensions_once",
+]

--- a/tests/test_env_audit.py
+++ b/tests/test_env_audit.py
@@ -66,13 +66,14 @@ class TestAuditProcEnv:
             "PATH": "/usr/bin",
             "HOME": "/home/u",
             "ANTHROPIC_API_KEY": "sk-ant-",
-            "BWS_ACCESS_TOKEN": "0.f3a-...",
+            "BWS_ACCESS_TOKEN": "0.f3a-...",  # #409: now in default allowlist
             "STRIPE_SECRET_KEY": "sk-live-...",
+            "DROP_ME": "leak",
         }
         monkeypatch.setattr(env_audit, "read_proc_environ", lambda pid: fake_env)
 
         result = audit_proc_env(12345)
-        assert result == ["BWS_ACCESS_TOKEN", "STRIPE_SECRET_KEY"]
+        assert result == ["DROP_ME", "STRIPE_SECRET_KEY"]
 
     def test_empty_when_all_allowed(self, monkeypatch):
         fake_env = {"PATH": "/usr/bin", "HOME": "/home/u"}
@@ -82,15 +83,40 @@ class TestAuditProcEnv:
     def test_respects_expected_extras(self, monkeypatch):
         fake_env = {
             "PATH": "/usr/bin",
-            "BWS_ACCESS_TOKEN": "x",
+            "STRIPE_SECRET_KEY": "x",
             "CUSTOM_RUNNER_ENV": "y",
         }
         monkeypatch.setattr(env_audit, "read_proc_environ", lambda pid: fake_env)
 
         # CUSTOM_RUNNER_ENV is permitted by the caller as an extra; only
-        # BWS_ACCESS_TOKEN should be reported.
+        # STRIPE_SECRET_KEY should be reported.
         result = audit_proc_env(12345, expected_extras=("CUSTOM_RUNNER_ENV",))
-        assert result == ["BWS_ACCESS_TOKEN"]
+        assert result == ["STRIPE_SECRET_KEY"]
+
+    def test_respects_user_extra_exact(self, monkeypatch):
+        """#409: user-allowed exact names must not be flagged as leaks."""
+        fake_env = {
+            "PATH": "/usr/bin",
+            "OP_SERVICE_ACCOUNT_TOKEN": "1p-...",
+            "STRIPE_SECRET_KEY": "leak",
+        }
+        monkeypatch.setattr(env_audit, "read_proc_environ", lambda pid: fake_env)
+
+        result = audit_proc_env(12345, user_extra_exact=("OP_SERVICE_ACCOUNT_TOKEN",))
+        assert result == ["STRIPE_SECRET_KEY"]
+
+    def test_respects_user_extra_prefix(self, monkeypatch):
+        """#409: user-allowed prefix names must not be flagged as leaks."""
+        fake_env = {
+            "PATH": "/usr/bin",
+            "VAULT_TOKEN": "v",
+            "VAULT_ADDR": "https://vault",
+            "STRIPE_SECRET_KEY": "leak",
+        }
+        monkeypatch.setattr(env_audit, "read_proc_environ", lambda pid: fake_env)
+
+        result = audit_proc_env(12345, user_extra_prefix=("VAULT_",))
+        assert result == ["STRIPE_SECRET_KEY"]
 
     def test_unreadable_returns_empty(self, monkeypatch):
         monkeypatch.setattr(env_audit, "read_proc_environ", lambda pid: None)

--- a/tests/test_env_policy.py
+++ b/tests/test_env_policy.py
@@ -1,8 +1,15 @@
-"""Tests for `utils/env_policy.py` — the engine-subprocess env allowlist (#198)."""
+"""Tests for `utils/env_policy.py` — the engine-subprocess env allowlist (#198, #409)."""
 
 from __future__ import annotations
 
-from untether.utils.env_policy import _is_allowed, filtered_env, is_allowed
+from untether.utils.env_policy import (
+    _is_allowed,
+    _reset_log_latch_for_tests,
+    filtered_env,
+    is_allowed,
+    is_allowed_with_extras,
+    log_user_extensions_once,
+)
 
 
 class TestIsAllowed:
@@ -12,13 +19,13 @@ class TestIsAllowed:
         assert is_allowed("PATH") is True
         assert is_allowed("ANTHROPIC_API_KEY") is True
         assert is_allowed("UNTETHER_SESSION") is True
+        assert is_allowed("BWS_ACCESS_TOKEN") is True
 
     def test_prefix_allow_returns_true(self):
         assert is_allowed("CLAUDE_CODE_FOO") is True
         assert is_allowed("MCP_SERVER_BAR") is True
 
     def test_disallowed_returns_false(self):
-        assert is_allowed("BWS_ACCESS_TOKEN") is False
         assert is_allowed("AWS_SECRET_ACCESS_KEY") is False
         assert is_allowed("STRIPE_SECRET_KEY") is False
 
@@ -149,3 +156,107 @@ class TestMixedInput:
         out = filtered_env()
         assert out.get("ANTHROPIC_API_KEY") == "probe-value"
         assert "DEFINITELY_NOT_ALLOWED_XYZ" not in out
+
+
+class TestUserExtensions:
+    """#409: per-deployment user extras via [security] env_extra_allow /
+    env_extra_prefix_allow surface here as `extra_allow` / `extra_prefix`
+    parameters to filtered_env."""
+
+    def test_is_allowed_with_extras_falls_back_to_default(self):
+        # No extras: behaves identically to is_allowed().
+        assert is_allowed_with_extras("PATH") is True
+        assert is_allowed_with_extras("AWS_SECRET_ACCESS_KEY") is False
+
+    def test_is_allowed_with_extras_admits_user_exact(self):
+        assert (
+            is_allowed_with_extras(
+                "OP_SERVICE_ACCOUNT_TOKEN",
+                extra_exact=["OP_SERVICE_ACCOUNT_TOKEN"],
+            )
+            is True
+        )
+        # Names not in the user exacts still get rejected.
+        assert (
+            is_allowed_with_extras(
+                "OTHER_TOKEN", extra_exact=["OP_SERVICE_ACCOUNT_TOKEN"]
+            )
+            is False
+        )
+
+    def test_is_allowed_with_extras_admits_user_prefix(self):
+        assert is_allowed_with_extras("VAULT_TOKEN", extra_prefix=["VAULT_"]) is True
+        assert is_allowed_with_extras("VAULT_ADDR", extra_prefix=["VAULT_"]) is True
+        assert (
+            is_allowed_with_extras("STRIPE_VAULT_KEY", extra_prefix=["VAULT_"]) is False
+        )
+
+    def test_filtered_env_admits_extra_prefix(self):
+        src = {
+            "VAULT_TOKEN": "v-tok",
+            "VAULT_ADDR": "https://vault",
+            "STRIPE_SECRET_KEY": "sk_live_x",
+            "PATH": "/usr/bin",
+        }
+        out = filtered_env(src, extra_prefix=["VAULT_"])
+        assert out == {
+            "VAULT_TOKEN": "v-tok",
+            "VAULT_ADDR": "https://vault",
+            "PATH": "/usr/bin",
+        }
+
+    def test_filtered_env_combines_extra_allow_and_extra_prefix(self):
+        src = {
+            "DOPPLER_TOKEN": "d-tok",
+            "VAULT_TOKEN": "v-tok",
+            "STRIPE_SECRET_KEY": "leak",
+        }
+        out = filtered_env(
+            src,
+            extra_allow=["DOPPLER_TOKEN"],
+            extra_prefix=["VAULT_"],
+        )
+        assert out == {"DOPPLER_TOKEN": "d-tok", "VAULT_TOKEN": "v-tok"}
+
+    def test_default_still_blocks_random_env_vars(self):
+        """Without user extras, prior denial behaviour is preserved."""
+        src = {"AWS_SECRET_ACCESS_KEY": "leak", "STRIPE_SECRET_KEY": "leak"}
+        assert filtered_env(src) == {}
+
+
+class TestUserExtensionLogging:
+    """#409: log_user_extensions_once emits one structured INFO per process."""
+
+    def setup_method(self):
+        _reset_log_latch_for_tests()
+
+    def teardown_method(self):
+        _reset_log_latch_for_tests()
+
+    def test_logs_once_when_extras_provided(self):
+        from structlog.testing import capture_logs
+
+        with capture_logs() as logs:
+            log_user_extensions_once(
+                extra_exact=["OP_SERVICE_ACCOUNT_TOKEN"],
+                extra_prefix=["VAULT_"],
+            )
+            log_user_extensions_once(
+                extra_exact=["OP_SERVICE_ACCOUNT_TOKEN"],
+                extra_prefix=["VAULT_"],
+            )
+
+        ext_events = [r for r in logs if r.get("event") == "env_policy.user_extension"]
+        assert len(ext_events) == 1
+        assert ext_events[0]["extra_exact"] == ["OP_SERVICE_ACCOUNT_TOKEN"]
+        assert ext_events[0]["extra_prefix"] == ["VAULT_"]
+
+    def test_no_log_when_no_extras(self):
+        from structlog.testing import capture_logs
+
+        with capture_logs() as logs:
+            log_user_extensions_once()
+            log_user_extensions_once(extra_exact=[], extra_prefix=[])
+
+        ext_events = [r for r in logs if r.get("event") == "env_policy.user_extension"]
+        assert ext_events == []

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -241,6 +241,112 @@ def test_voice_transcription_api_key_default_none(tmp_path: Path) -> None:
     assert settings.transports.telegram.voice_transcription_api_key is None
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# #409 — env allowlist user-extensible config (SecuritySettings extras)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def test_env_extra_allow_round_trip(tmp_path: Path) -> None:
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        '[transports.telegram]\nbot_token = "tok"\nchat_id = 123\n\n'
+        "[security]\n"
+        'env_extra_allow = ["OP_SERVICE_ACCOUNT_TOKEN", "DOPPLER_TOKEN"]\n'
+        'env_extra_prefix_allow = ["VAULT_", "INFISICAL_"]\n',
+        encoding="utf-8",
+    )
+    settings, _ = load_settings(config_path)
+    assert settings.security.env_extra_allow == [
+        "OP_SERVICE_ACCOUNT_TOKEN",
+        "DOPPLER_TOKEN",
+    ]
+    assert settings.security.env_extra_prefix_allow == ["VAULT_", "INFISICAL_"]
+
+
+def test_env_extra_allow_default_empty(tmp_path: Path) -> None:
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        '[transports.telegram]\nbot_token = "tok"\nchat_id = 123\n',
+        encoding="utf-8",
+    )
+    settings, _ = load_settings(config_path)
+    assert settings.security.env_extra_allow == []
+    assert settings.security.env_extra_prefix_allow == []
+
+
+def test_env_extra_allow_rejects_empty_string(tmp_path: Path) -> None:
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        '[transports.telegram]\nbot_token = "tok"\nchat_id = 123\n\n'
+        "[security]\n"
+        'env_extra_allow = [""]\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="env_extra_allow"):
+        load_settings(config_path)
+
+
+def test_env_extra_allow_rejects_whitespace_only(tmp_path: Path) -> None:
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        '[transports.telegram]\nbot_token = "tok"\nchat_id = 123\n\n'
+        "[security]\n"
+        'env_extra_allow = ["   "]\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="env_extra_allow"):
+        load_settings(config_path)
+
+
+def test_env_extra_allow_rejects_lowercase(tmp_path: Path) -> None:
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        '[transports.telegram]\nbot_token = "tok"\nchat_id = 123\n\n'
+        "[security]\n"
+        'env_extra_allow = ["my_token"]\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="env_extra_allow"):
+        load_settings(config_path)
+
+
+def test_env_extra_allow_rejects_leading_digit(tmp_path: Path) -> None:
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        '[transports.telegram]\nbot_token = "tok"\nchat_id = 123\n\n'
+        "[security]\n"
+        'env_extra_allow = ["1_BAD"]\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="env_extra_allow"):
+        load_settings(config_path)
+
+
+def test_env_extra_allow_rejects_spaces(tmp_path: Path) -> None:
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        '[transports.telegram]\nbot_token = "tok"\nchat_id = 123\n\n'
+        "[security]\n"
+        'env_extra_allow = ["TOK EN"]\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="env_extra_allow"):
+        load_settings(config_path)
+
+
+def test_env_extra_prefix_allow_validates_names(tmp_path: Path) -> None:
+    """Prefix entries must match the same env-var name shape."""
+    config_path = tmp_path / "untether.toml"
+    config_path.write_text(
+        '[transports.telegram]\nbot_token = "tok"\nchat_id = 123\n\n'
+        "[security]\n"
+        'env_extra_prefix_allow = ["bad-prefix"]\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="env_extra_prefix_allow"):
+        load_settings(config_path)
+
+
 def test_require_telegram_rejects_non_telegram_transport(tmp_path: Path) -> None:
     config_path = tmp_path / "untether.toml"
     settings = UntetherSettings.model_validate(


### PR DESCRIPTION
## Summary

Closes #409. Adds two new `[security]` config keys so self-installed Untether users can thread credential-manager tokens (1Password, Doppler, Vault, Infisical, …) into engine subprocesses without forking `utils/env_policy.py`. Also promotes `BWS_ACCESS_TOKEN` into the built-in default allowlist (Bitwarden Secrets Manager — common enough to ship by default).

## Public surface

```toml
[security]
env_extra_allow = ["OP_SERVICE_ACCOUNT_TOKEN", "DOPPLER_TOKEN"]
env_extra_prefix_allow = ["VAULT_", "INFISICAL_"]
```

Names must match `[A-Z_][A-Z0-9_]*` (Pydantic validator rejects `""`, `"   "`, lowercase, leading-digit, spaces). Honoured by the **Claude** and **Pi** runners (the same engines that opted in to `filtered_env` for #198) and by the **`env_audit`** probe (so user-allowed names aren't false-flagged as `claude.env_audit.leaked_var`).

One `env_policy.user_extension` INFO log per process at first runner spawn — visible in `journalctl --user -u untether-dev` so the operator sees the addition is in effect.

## Changes

- **`src/untether/utils/env_policy.py`**: new `is_allowed_with_extras()`, extended `filtered_env(extra_prefix=)`, new `log_user_extensions_once()` with per-process latch.
- **`src/untether/settings.py`**: `SecuritySettings.env_extra_allow` + `env_extra_prefix_allow` with shared `_validate_env_names` validator; new `_ENV_NAME_RE` constant.
- **`src/untether/runners/claude.py`**, **`src/untether/runners/pi.py`**: new `_load_env_extras()` helper (best-effort settings load — never blocks a run on a config error, mirrors the existing `env_audit` pattern); threads extras through `filtered_env()` + `log_user_extensions_once()`.
- **`src/untether/utils/env_audit.py`** `audit_proc_env()`: new `user_extra_exact=` / `user_extra_prefix=` parameters so user-allowed names don't show up as leaks.
- **`utils/env_policy.py`** built-in defaults: `BWS_ACCESS_TOKEN` promoted into `_EXACT_ALLOW` (the half of #409 that originally lived as an uncommitted patch on `feature/walking-mode-monitor`).
- **Docs**: `docs/reference/config.md` `[security]` table rows for both new keys with examples; CLAUDE.md features list entry.

## Test plan

- [x] `uv run pytest tests/test_env_policy.py tests/test_env_audit.py tests/test_settings.py --no-cov -x` → 83 passed
- [x] `uv run pytest --no-cov` → 2432 passed, 2 skipped (+19 new tests vs prior baseline)
- [x] `uv run ruff check src/ tests/` → clean
- [x] `uv run ruff format --check src/ tests/` → clean
- [ ] Integration via `@untether_dev_bot` after merge: set `[security] env_extra_allow = ["OP_SERVICE_ACCOUNT_TOKEN"]` in `~/.untether-dev/untether.toml`, restart `untether-dev`, send a `/claude` task that runs `env | grep OP_`; confirm the value reaches the subprocess and `journalctl --user -u untether-dev` shows `env_policy.user_extension` once.

## Notes

- This is Group 1C of three sub-batches (1A hygiene #431, 1B high-pri security #432/#433, 1C #409) per the approved v0.35.3 plan.
- **#377 (allowed_user_ids startup-block)** still pending — final Group 1 PR per the plan's merge order (most install-time-edge-case-prone, ship last).
- No CHANGELOG entry — per `release-discipline.md` §"Staging / rc versions".

🤖 Generated with [Claude Code](https://claude.com/claude-code)