### PR TITLE
chore: staging 0.35.3rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.3rc2"
+version = "0.35.3rc3"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.3rc2"
+version = "0.35.3rc3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bump rc2 → rc3 so TestPyPI publishes a fresh staging wheel that includes everything merged to `dev` since rc2:

- **#435** — #409 user-extensible env allowlist + `BWS_ACCESS_TOKEN` default

Cumulative content (vs rc1, which was just #407):
- #431 — Group 1A security hygiene (8 issues)
- #432 — #379 cost tracker race (`threading.Lock`)
- #433 — #378 voice key SecretStr
- #435 — #409 env allowlist + BWS

Per release-discipline.md, no CHANGELOG entries on rc PRs.

## Test plan

- [x] `uv lock` synced (`untether v0.35.3rc2 → v0.35.3rc3`)
- [x] CI matrix expected green (no source change beyond version)
- [ ] After merge: TestPyPI publish should succeed at `0.35.3rc3` (new version, no `skip-existing`)
- [ ] After publish: `scripts/staging.sh install 0.35.3rc3` on `@hetz_lba1_bot` for full Group 1 dogfood

🤖 Generated with [Claude Code](https://claude.com/claude-code)