### PR TITLE
test(security): construct Basic auth header at runtime (#404)

### DIFF
--- a/tests/test_trigger_auth.py
+++ b/tests/test_trigger_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 from typing import Any
@@ -40,7 +41,11 @@ class TestBearerAuth:
 
     def test_malformed_bearer_header(self):
         wh = _make_webhook(auth="bearer", secret="tok_123")
-        headers = {"authorization": "Basic dXNlcjpwYXNz"}
+        # Construct the Basic auth header at runtime so the literal base64
+        # blob doesn't end up in the source tree (#404 — secret-scanning
+        # alert false positive). Test asserts verify_auth REJECTS Basic auth.
+        basic = "Basic " + base64.b64encode(b"user:pass").decode()
+        headers = {"authorization": basic}
         assert verify_auth(wh, headers, b"") is False
 
 


### PR DESCRIPTION
## Summary

- Replace the literal `\"Basic dXNlcjpwYXNz\"` string in `tests/test_trigger_auth.py:test_malformed_bearer_header` with a runtime-constructed header
- This is the optional defensive change suggested in #404 — the corresponding GitHub secret-scanning alert is a true false positive (test fixture asserting that Untether REJECTS Basic auth)
- The alert itself still needs to be manually dismissed in the GitHub Security tab as \"Used in tests / false positive\"

## Test plan
- [x] \`uv run pytest tests/test_trigger_auth.py -x\` — all 16 tests pass
- [x] \`uv run ruff format tests/test_trigger_auth.py && uv run ruff check tests/test_trigger_auth.py\`

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)