### PR TITLE
chore: staging 0.35.3rc5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.3rc4"
+version = "0.35.3rc5"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.3rc4"
+version = "0.35.3rc5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` and `uv.lock` to `0.35.3rc5`. All 9 v0.35.3 Group 2 issues are now merged on `dev`:

- #404 — secret-scanning alert (PR #439)
- #297 — `/trigger` → `/listen` rename + alias (PR #440)
- #294 — master trigger pause/resume toggle (PR #441)
- #380 — auto-approve scope review for `ControlMcpMessage` / `ControlRewindFiles` (PR #442)
- #438 — `claude_stream_idle_timeout_ms` + Type-A/B classification (PR #443)
- #410 — subscription usage observability + `/usage debug` (PR #444)
- #271 — trigger visibility Tier 2 + Tier 3 (PR #445)
- #333 — Claude post-result idle timeout + `✓ turn complete` UX hint (PR #446)
- #269 — hot-reload `[progress]` settings (PR #447)

Once this lands, the `testpypi-publish` job auto-publishes `untether-0.35.3rc5` to TestPyPI. Integration tests U1–U7 against `@untether_dev_bot` follow before any promotion to `@hetz_lba1_bot` staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)