### PR TITLE
chore: staging 0.35.3rc7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.3rc6"
+version = "0.35.3rc7"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.3rc6"
+version = "0.35.3rc7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bumps pre-release version `0.35.3rc6 → 0.35.3rc7` so TestPyPI publishes a fresh wheel containing the v0.35.3 follow-up bundle merged in PR #479:

- fix(security): claude runner.start no longer leaks prompt at INFO (#478)
- docs(faq): add docs/faq/index.md for help-centre FAQPage schema (#477)
- ctx: protect docs/faq/index.md from deletion + register in local docs (#477)

The rc6 TestPyPI wheel predates these commits. Without the bump, the publish step skips ("File already exists") and the staging upgrade path keeps installing the older wheel.

Per `release-discipline.md`, pre-release versions don't require a CHANGELOG entry (validate_release.py skips them) and aren't tagged (auto-tag-on-master.yml skips pre-releases). Two-line diff: `pyproject.toml` + `uv.lock`.

## Test plan

- [x] `uv lock` synced cleanly (`Updated untether v0.35.3rc6 -> v0.35.3rc7`)
- [x] `uv run python3 scripts/validate_release.py` — `Pre-release version — skipping changelog validation` (expected)
- [x] CI on this PR will re-run all checks; merging to dev triggers TestPyPI publish on the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)