### PR TITLE
docs(v0.35.3): comprehensive polish — fill gaps after rc1–rc9

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The wizard offers three **workflow modes** — pick the one that fits:
 - 📎 **File transfer** — upload files to your repo with `/file put`, download with `/file get`; agents can also deliver files automatically by writing to `.untether-outbox/` during a run — sent as Telegram documents on completion
 - 🛡️ **Graceful recovery** — orphan progress messages cleaned up on restart; stall detection with CPU-aware diagnostics; auto-continue for Claude Code sessions that exit prematurely
 - ⏰ **Scheduled tasks** — cron expressions with timezone support, webhook triggers, one-shot delays (`/at 30m <prompt>`), `run_once` crons, master pause/resume toggle, and hot-reload configuration (no restart required). `/ping` shows per-chat trigger summary; trigger-initiated runs show provenance in the footer (`⏰ cron:<id>` / `⚡ webhook:<id>` / `⏰ at:<token>`); `/stats` reports per-engine triggered-vs-manual breakdown
+- 🔁 **Autonomous loops (Claude only)** — opt-in observation of Claude Code's `/loop` and `ScheduleWakeup`; Untether re-fires iterations after the subprocess exits so loops keep running between turns. Off by default; enable per chat via `/config → 🔁 Loop mode`. Cost guarded by `[cost_budget]`, runaway-safety capped by `[loop]` (max iterations, total duration, expiry)
 - 💬 **Forum topics** — map Telegram topics to projects and branches
 - 📤 **Session export** — `/export` for markdown or JSON transcripts
 - 🗂️ **File browser** — `/browse` to navigate project files with inline buttons

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,25 @@ Include:
 - Bot token management — token security is the operator's responsibility
 - Issues requiring physical access to the host machine
 
+## Security improvements in v0.35.3
+
+v0.35.3 ships a follow-on hardening bundle on top of v0.35.2. Upgrade notes:
+
+- **BREAKING — empty `allowed_user_ids` rejected at startup** ([#377](https://github.com/littlebearapps/untether/issues/377)). Previously the empty default meant any Telegram user who knew the bot username could send commands. Untether now refuses to start with `ConfigError: [transports.telegram] allowed_user_ids is empty …`. Operators who genuinely need an open bot (demos, hackathons, dev) must opt in explicitly with `allow_any_user = true`, which is logged INFO every boot (`security.allow_any_user`). See [Security how-to](docs/how-to/security.md).
+- **AMP `dangerously_allow_all` default flipped to `false`** ([#206](https://github.com/littlebearapps/untether/issues/206)). AMP runs no longer skip its built-in permission system unless the operator opts in.
+- **Pi session directory locked to `0o700`** ([#207](https://github.com/littlebearapps/untether/issues/207)). Other users on shared hosts can no longer read Pi session JSONL.
+- **`voice_transcription_api_key` is now `SecretStr`** ([#378](https://github.com/littlebearapps/untether/issues/378)) — parity with `bot_token`. Masked in repr/str/tracebacks and structlog serialisation.
+- **Prompt content removed from INFO logs** ([#205](https://github.com/littlebearapps/untether/issues/205), [#478](https://github.com/littlebearapps/untether/issues/478)) — `runner.start` no longer carries `prompt[:100]`. A debug-only `runner.start_prompt` event is available when explicitly enabled.
+- **`/file get` TOCTOU window closed** ([#211](https://github.com/littlebearapps/untether/issues/211)) — single-open + bounded read in a worker thread.
+- **stderr sanitisation regex extended** ([#208](https://github.com/littlebearapps/untether/issues/208)) — covers macOS (`/Users/…`, `/private/var/…`), container roots (`/app/`, `/workspace/`), and other absolute paths beyond `/home/<user>/`.
+- **OpenAI project-key redaction** ([#213](https://github.com/littlebearapps/untether/issues/213)) — structlog redaction now covers `sk-proj-…` keys (the generic `sk-…` regex didn't match the project-key char set).
+- **Daily cost tracker race fixed** ([#379](https://github.com/littlebearapps/untether/issues/379)) — the unguarded read-modify-write that could lose a run's cost (and bypass the per-day budget cap) is now wrapped in a lock.
+- **Pygments bumped 2.19.2 → 2.20.0** ([#402](https://github.com/littlebearapps/untether/issues/402)) — clears CVE-2026-4539 (ReDoS in `AdlLexer`).
+- **Auto-approve scope re-audit** ([#380](https://github.com/littlebearapps/untether/issues/380)) — `ControlRewindFilesRequest` and `ControlMcpMessageRequest` re-verified safe under the upstream Claude Code 2.1.x trust model. Regression-lock tests fail loudly if the auto-approve path starts inspecting payloads. Audit memo at `docs/audits/2026-04-27-380-auto-approve-scope-review.md`.
+- **User-extensible env allowlist** ([#409](https://github.com/littlebearapps/untether/issues/409)) — `[security] env_extra_allow` and `env_extra_prefix_allow` let operators thread credential-manager tokens (1Password, Doppler, Vault, Infisical) into engine subprocesses without forking. `BWS_ACCESS_TOKEN` is now in the built-in defaults.
+
+See [CHANGELOG v0.35.3](https://github.com/littlebearapps/untether/blob/master/CHANGELOG.md#v0353) for the full entry list.
+
 ## Security improvements in v0.35.2
 
 v0.35.2 ships a security hardening bundle. Upgrade notes:

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -46,7 +46,7 @@ flowchart TB
     subgraph Triggers["Triggers Layer"]
         trigger_server[triggers/server.py<br/>webhook HTTP server<br/>multipart, rate limit]
         trigger_cron[triggers/cron.py<br/>cron scheduler<br/>timezone, run_once]
-        trigger_manager[triggers/manager.py<br/>TriggerManager<br/>hot-reload]
+        trigger_manager[triggers/manager.py<br/>TriggerManager<br/>hot-reload + pause/resume]
         trigger_dispatch[triggers/dispatcher.py<br/>dispatch to run_job]
         trigger_actions[triggers/actions.py<br/>file_write, http_forward, notify_only]
         trigger_fetch[triggers/fetch.py<br/>cron data-fetch]
@@ -422,6 +422,6 @@ flowchart TD
 | **Bridge** | `telegram/bridge.py`, `runner_bridge.py` | Message handling, execution coordination |
 | **Runner** | `runner.py`, `runners/*.py`, `schemas/*.py` | Agent CLI subprocess, JSONL parsing, event translation |
 | **Transport** | `transport.py`, `presenter.py`, `telegram/client.py` | Telegram API, message rendering |
-| **Triggers** | `triggers/server.py`, `triggers/cron.py`, `triggers/manager.py`, `triggers/dispatcher.py`, `triggers/actions.py`, `triggers/fetch.py`, `triggers/ssrf.py`, `triggers/auth.py`, `triggers/rate_limit.py`, `triggers/describe.py`, `triggers/templating.py` | Webhook server (multipart, rate limit), cron scheduler (timezone, data-fetch, `run_once`), `TriggerManager` for hot-reload, non-agent actions (`file_write`/`http_forward`/`notify_only`), SSRF protection, HMAC/bearer auth, human-friendly cron description |
+| **Triggers** | `triggers/server.py`, `triggers/cron.py`, `triggers/manager.py`, `triggers/dispatcher.py`, `triggers/actions.py`, `triggers/fetch.py`, `triggers/ssrf.py`, `triggers/auth.py`, `triggers/rate_limit.py`, `triggers/describe.py`, `triggers/history.py`, `triggers/templating.py` | Webhook server (multipart, rate limit, `503 triggers paused`), cron scheduler (timezone, data-fetch, `run_once`), `TriggerManager` for hot-reload + master pause/resume toggle, fire-history persistence for `/stats` triggered/manual breakdown, non-agent actions (`file_write`/`http_forward`/`notify_only`), SSRF protection, HMAC/bearer auth, human-friendly cron description |
 | **Domain** | `model.py`, `progress.py`, `events.py` | Event types, action tracking |
 | **Utils** | `worktrees.py`, `utils/*.py`, `markdown.py` | Git worktrees, formatting, paths |

--- a/docs/explanation/module-map.md
+++ b/docs/explanation/module-map.md
@@ -19,6 +19,8 @@ This page is a high-level map of Untether’s internal modules: what they do and
 | `transport_runtime.py` | Facade used by transports and commands to resolve messages and runners without importing internal router/project types. |
 | `cost_tracker.py` | Per-run and daily cost tracking with budget alerts and auto-cancel. |
 | `shutdown.py` | Graceful shutdown state and drain logic. |
+| `telegram/at_scheduler.py` | One-shot delayed runs from `/at <duration>`; in-memory state, drained on shutdown. |
+| `telegram/loop_scheduler.py` | Loop mode firing for Claude's `/loop` and `ScheduleWakeup`; persists `active_loops.json` so loops survive restart. Mirrors `at_scheduler` API. |
 
 ## Domain model and events
 
@@ -66,6 +68,17 @@ This page is a high-level map of Untether’s internal modules: what they do and
 |--------|----------------|
 | `runners/*` | Engine runner implementations (Claude Code, Codex, OpenCode, Pi, Gemini CLI, Amp). |
 | `schemas/*` | msgspec schemas / decoders for engine JSONL streams. |
+
+## Triggers
+
+| Module | Responsibility |
+|--------|----------------|
+| `triggers/manager.py` | Mutable holder for crons + webhooks; hot-reload on TOML change; master `pause()` / `resume()` / `is_paused` toggle. |
+| `triggers/server.py` | Webhook HTTP server (aiohttp); returns `503 triggers paused` while master pause is active; `/health` reflects paused state. |
+| `triggers/dispatcher.py` | Routes webhook/cron fires to `run_job()` or non-agent action handlers. |
+| `triggers/cron.py` | Cron expression parser, timezone-aware scheduler loop. |
+| `triggers/history.py` | Persistent JSON history of cron/webhook fire times for `/stats` triggered/manual breakdown. |
+| `triggers/describe.py` | Human-friendly cron rendering for `/ping`, `/config → 📡 Triggers`. |
 
 ## Configuration and persistence
 

--- a/docs/how-to/inline-settings.md
+++ b/docs/how-to/inline-settings.md
@@ -119,6 +119,21 @@ Lists are scoped to the current chat (`crons_for_chat()` / `webhooks_for_chat()`
 
 See [Schedule tasks](schedule-tasks.md#pausing-all-triggers) for the pause flow end-to-end.
 
+### Loop mode page {#loop-mode}
+
+When the active engine is Claude Code, the home page gains a `🔁 Loop mode` button that opens the Loop sub-page ([#289](https://github.com/littlebearapps/untether/issues/289)). Loop mode is **off by default** — turning it on enables Untether's observation of Claude's session-scoped scheduling tools (`CronCreate`, `ScheduleWakeup`) so iterations keep firing after the subprocess exits.
+
+The page shows:
+
+* **State** — `Loop mode: on` / `off` for the current chat (per-chat override over the global `[loop] enabled` default).
+* **Cost + quota warning** — explicit reminder before turning ON: every loop fire counts against `[cost_budget]`, and the runaway caps in `[loop]` (`max_iterations`, `max_total_duration_hours`, `expiry_days`) are the safety net.
+* **💰 Set a budget** — deep-link to the `Cost & Usage` page (`config:cu`) for one-tap budget setup.
+* **Toggle row** — `[On] [Off] [Clear]` with ✓ on the active option.
+
+`/cancel` and `/new` both drop pending loop iterations for the current session and write a do-not-resume sentinel so a subsequent `loop_scheduler` resume can't replay them. `/continue` is unaffected (it doesn't trigger loop replay).
+
+Loop mode is **Claude-only** (`LOOP_SUPPORTED_ENGINES = frozenset({"claude"})`); the button is hidden for other engines. See [Schedule tasks → Loop mode](schedule-tasks.md#loop-mode) for the full architecture and cost guidance.
+
 ### Cost & Usage page
 
 The Cost & Usage sub-page merges cost display and budget controls into a unified page with toggle rows:

--- a/docs/how-to/operations.md
+++ b/docs/how-to/operations.md
@@ -187,8 +187,9 @@ When enabled, Untether watches the config file for changes and reloads most sett
 - Trigger system: `triggers.enabled`, crons, webhooks, auth, rate limits, timezones
 - Telegram bridge: `voice_transcription`, `[files]`, `allowed_user_ids`, `allow_any_user`, `show_resume_line`, timing
 - `[security]` keys: `env_extra_allow`, `env_extra_prefix_allow` (re-read on next runner spawn)
-- `[progress]` keys: `max_actions`, `verbosity`, `min_render_interval`, `group_chat_rps` ([#269](https://github.com/littlebearapps/untether/issues/269))
-- `[watchdog]` keys: `tool_timeout`, `mcp_tool_timeout`, `claude_stream_idle_timeout_ms`, `post_result_idle_timeout`, `post_result_idle_enabled` (re-read per run)
+- `[progress]` keys: `max_actions`, `verbosity`, `min_render_interval`, `group_chat_rps`, `heartbeat_interval` ([#269](https://github.com/littlebearapps/untether/issues/269), [#481](https://github.com/littlebearapps/untether/issues/481))
+- `[watchdog]` keys: `tool_timeout`, `mcp_tool_timeout`, `claude_stream_idle_timeout_ms`, `post_result_idle_timeout`, `post_result_idle_enabled`, `bash_grace_seconds` (re-read per run)
+- Trigger pause/resume: in-memory only, toggled via `/config → 📡 Triggers` ([#294](https://github.com/littlebearapps/untether/issues/294)) — restart auto-resumes
 - `[footer]` and `[cost]` settings (re-read per call)
 - Engine defaults, budget, cost/usage display flags
 

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -228,6 +228,8 @@ post_result_idle_timeout = 60   # 1 minute
 
 If a button-click `control_response` is mid-flight when the deadline arrives, the timer re-arms instead of closing — preventing orphaned approvals. Look for `claude.post_result_idle.deferred` and `claude.post_result_idle.closing_stdin` in the logs to confirm the watchdog's behaviour.
 
+When the watchdog actually closes stdin, Untether also sends one (and only one) Telegram closing message: `✓ turn complete · session closed after Nm idle`. While the watchdog is running, stall warnings are suppressed (`progress_edits.stall_post_result_suppressed`) so you don't get noise during the legitimate idle window — genuinely-frozen post-result sessions still warn via the frozen-ring escalation.
+
 ## Messages too long or truncated
 
 **Symptoms:** The bot's response is cut off or split across multiple messages.

--- a/docs/how-to/verbose-progress.md
+++ b/docs/how-to/verbose-progress.md
@@ -79,6 +79,22 @@ Control how many actions appear in the progress message. Actions beyond this lim
 
 Set to `0` to hide the action list entirely, or increase it to see more history.
 
+!!! tip "Hot-reload"
+    `[progress]` settings (`verbosity`, `max_actions`, `heartbeat_interval`, `min_render_interval`, `group_chat_rps`) hot-reload — editing them in `untether.toml` applies on the next run without restart ([#269](https://github.com/littlebearapps/untether/issues/269)).
+
+## Long-running tool tail (heartbeat)
+
+Long-running tool calls (Bash, BashOutput, ScheduleWakeup, Monitor, KillShell, …) get an automatic elapsed-time tail on the progress message after ~60 s — `▸ Bash · 3m 47s · npm run build` — so a glancing user can answer "is it alive? what's it doing? for how long?" without waiting for the next JSONL event ([#481](https://github.com/littlebearapps/untether/issues/481)). The tail appears regardless of `/verbose` state.
+
+In **verbose** mode the tool's `format_verbose_detail` line additionally renders:
+
+- `BashOutput` — the last line of `result_preview` (so 10-min Cloudflare deploy polls show `→ Deploy Production: in_progress` instead of a static `▸ BashOutput`)
+- `ScheduleWakeup` — countdown + reason: `→ fires in 4m 12s · "build check"`
+- `Monitor` — countdown remaining
+- `KillShell` — target shell id
+
+Tune the heartbeat tick via `[progress] heartbeat_interval` (5–120 s, default 30 s) — every tick walks the open-action set and forces a re-render whenever any action is older than 60 s. Strict "rolling stdout sub-line every 5 s" cannot be achieved without upstream Claude Code changes; the BashOutput-polling path is the proxy and refreshes at each polling cycle (~15 s in practice).
+
 ## Per-chat override
 
 The `/verbose` toggle overrides the global config for the current chat. This override persists until you clear it or restart Untether.

--- a/docs/how-to/webhooks-and-cron.md
+++ b/docs/how-to/webhooks-and-cron.md
@@ -242,7 +242,18 @@ Each webhook and cron can specify where the Telegram notification appears:
     max_body_bytes = 1048576  # 1 MB max payload
     ```
 
-The server includes a health endpoint at `GET /health` for uptime monitoring.
+The server includes a health endpoint at `GET /health` for uptime monitoring. While the master pause toggle is active (see [Pause and resume all triggers](#pause-and-resume-all-triggers)) it returns `{"status": "paused", "paused": true}` so external monitors can distinguish "paused but up" from "down".
+
+## Pause and resume all triggers
+
+Untether ships a master pause toggle ([#294](https://github.com/littlebearapps/untether/issues/294)) that gates **both** crons and webhooks at once — useful when deploying, debugging, or muting overnight without editing config:
+
+* **`/config` home page** shows a one-button toggle row at the bottom whenever triggers are configured.
+* **`/config` → `📡 Triggers`** opens a dedicated page with state, per-chat counts, and a Pause/Resume button. It also lists per-chat crons and webhooks with last-fired times.
+* While paused: cron loop skips ticks, webhooks return `503 triggers paused` with `Retry-After: 60`, `/health` returns `paused: true`, and `/ping` shows `⏸ triggers paused: … (suspended)`.
+* `run_once` crons are not consumed during the pause and fire on the next matching tick after resume.
+
+Pause is **in-memory only** — restart auto-resumes (the safe default). For a durable shutoff, set `[triggers] enabled = false` in `untether.toml` instead.
 
 ## Hot-reload configuration
 

--- a/docs/reference/commands-and-directives.md
+++ b/docs/reference/commands-and-directives.md
@@ -66,6 +66,8 @@ Notes:
 - In topics, `/ctx` binds the topic context.
 - `/new` cancels running tasks and clears sessions but does **not** clear a bound context.
 - `/continue` uses the engine's native "continue" flag: `--continue` (Claude, OpenCode, Pi), `resume --last` (Codex), or `--resume latest` (Gemini).
+- Long-running tools (Bash, BashOutput, ScheduleWakeup, Monitor, …) surface a heartbeat-driven elapsed-time tail (`▸ Bash · 3m 47s · npm run build`) on the progress message after ~60s, regardless of `/verbose` state ([#481](https://github.com/littlebearapps/untether/issues/481)). Tune via `[progress] heartbeat_interval`.
+- Loop mode (Claude only): there is no `/loop` Telegram command — it's a Claude Code feature. Untether observes Claude's `ScheduleWakeup` and `CronCreate` tool calls and re-fires iterations after the subprocess exits. Off by default; opt in per chat via `/config` → 🔁 **Loop mode**. Cost protection lives in `[cost_budget]`, runaway-safety caps in `[loop]` ([#289](https://github.com/littlebearapps/untether/issues/289)).
 
 ## CLI
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -226,14 +226,19 @@ Controls progress message rendering during agent runs.
     [progress]
     verbosity = "verbose"
     max_actions = 8
+    heartbeat_interval = 30
     ```
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
 | `verbosity` | `"compact"` \| `"verbose"` | `"compact"` | `compact` shows status + title only. `verbose` adds tool detail lines (file paths, commands, patterns). |
 | `max_actions` | int (0–50) | `5` | Maximum action lines shown in the progress message. |
+| `heartbeat_interval` | int (5–120) | `30` | Heartbeat tick that re-renders progress messages so long-running tools surface an elapsed-time tail (e.g. `▸ Bash · 3m 47s · npm run build`) without waiting for the next JSONL event ([#481](https://github.com/littlebearapps/untether/issues/481)). |
 
 Per-chat override: `/verbose on` and `/verbose off` override the config default for the current chat without editing the TOML file. `/verbose clear` removes the override.
+
+!!! tip "Hot-reload"
+    Editing `[progress]` in `untether.toml` applies on the next run without restart ([#269](https://github.com/littlebearapps/untether/issues/269)). The default presenter and per-chat `/verbose` overrides both pick up the new values.
 
 ## `cost_budget`
 
@@ -278,6 +283,9 @@ Budget alerts always appear regardless of `[footer]` settings.
     prespawn_ram_warn_mb = 2000
     prespawn_ram_block_mb = 500
     claude_stream_idle_timeout_ms = 300_000
+    post_result_idle_enabled = true
+    post_result_idle_timeout = 600.0
+    bash_grace_seconds = 60.0
     ```
 
 | Key | Type | Default | Notes |
@@ -296,6 +304,9 @@ Budget alerts always appear regardless of `[footer]` settings.
 | `prespawn_ram_warn_mb` | int | `2000` | Pre-spawn RAM guard ([#350](https://github.com/littlebearapps/untether/issues/350)) — emit `subprocess.prespawn.ram_warning` when free RAM is below this threshold (MB) at engine spawn. `0` disables the warn tier. |
 | `prespawn_ram_block_mb` | int | `500` | Refuse to spawn the engine subprocess (yields `CompletedEvent(ok=False, error="🛑 Insufficient RAM…")`) when free RAM is below this threshold (MB). `0` disables the block tier; `0` for both fully disables the guard. Must be strictly less than `prespawn_ram_warn_mb` when both are set. |
 | `claude_stream_idle_timeout_ms` | int | `300_000` | Sets `CLAUDE_STREAM_IDLE_TIMEOUT_MS` in the Claude Code subprocess env via `setdefault` ([#438](https://github.com/littlebearapps/untether/issues/438)). Range 30 s – 30 min. Long-form opus 4.7 1M plan-mode generations can legitimately idle the SSE stream past 5 min; deployments hitting upstream Anthropic API stalls (Type A — mid-generation) can raise this to `600_000` or `900_000` to ride out longer silences. Type-B failures (cold-start zero-byte, `num_turns ≤ 1 && duration_api_ms == 0`) are upstream API outages — raising this won't help; the failure error message now classifies both modes inline. Shell-set `CLAUDE_STREAM_IDLE_TIMEOUT_MS` still wins. |
+| `post_result_idle_enabled` | bool | `true` | Claude post-result idle watchdog ([#333](https://github.com/littlebearapps/untether/issues/333)) — closes Claude's stdin cleanly after `post_result_idle_timeout` of silence following a `result` event so multi-turn sessions don't sit alive (and billable) for the full upstream ~36 min idle window. Set `false` to disable (Claude will sit idle until the upstream CLI exits on its own). The clean exit is auto-continue safe — `last_event_type=result` is excluded from the auto-continue gate. |
+| `post_result_idle_timeout` | float | `600.0` | Seconds the watchdog waits after a `result` event before closing stdin (30–3600). The first `result` also emits a `✓ turn complete` footer hint so users know the turn is done; when the watchdog actually fires it sends one Telegram message: `✓ turn complete · session closed after Nm idle`. Re-arms (instead of closing) if a control_request or AskUserQuestion is mid-flight, so a button click in flight is never orphaned. |
+| `bash_grace_seconds` | float | `60.0` | Stall-warning grace window for Bash / BashOutput / KillShell tools ([#481](https://github.com/littlebearapps/untether/issues/481)). Range 5–300. While the most-recent action is one of these and within this window of its start, stall warnings (and the `_STALL_MAX_WARNINGS` auto-cancel arm) are suppressed — long builds and deploys are an expected wait, not a hung session. |
 
 The stall monitor in `ProgressEdits` fires at 5 min (300s) idle, 10 min for local tools, 15 min for MCP tools, and 30 min for pending approvals. When a local tool is running and the child process is CPU-active, the first stall warning fires but repeat warnings are suppressed — they resume if CPU goes idle (indicating a genuinely stuck tool). The liveness watchdog in the subprocess layer fires at `liveness_timeout` with `/proc` diagnostics. When `stall_auto_kill` is enabled, auto-kill requires a triple safety gate: timeout exceeded + zero TCP connections + CPU ticks not increasing between snapshots.
 
@@ -475,11 +486,13 @@ here; plugin engines should document their own keys.
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
 | `model` | string | (unset) | Optional model override, passed as `--model`. |
+| `skip_trust` | bool | `true` | Pass `--skip-trust` so headless runs work outside `~/.gemini/trustedFolders.json` ([#471](https://github.com/littlebearapps/untether/issues/471)). Gemini CLI rejects runs from any directory not in the trust list — even with `--approval-mode yolo` — and there is no interactive prompt path in headless usage. Set `false` to enforce Gemini's project-local extension/MCP trust gate. |
 
 === "untether config"
 
     ```sh
     untether config set gemini.model "gemini-2.5-pro"
+    untether config set gemini.skip_trust true
     ```
 
 === "toml"
@@ -487,6 +500,7 @@ here; plugin engines should document their own keys.
     ```toml
     [gemini]
     model = "gemini-2.5-pro"
+    skip_trust = true
     ```
 
 !!! note "Approval mode"

--- a/docs/reference/runners/amp/untether-events.md
+++ b/docs/reference/runners/amp/untether-events.md
@@ -185,7 +185,7 @@ Returns `None` if no usage data was accumulated.
     ```sh
     untether config set amp.model "claude-sonnet-4-6"
     untether config set amp.mode "smart"
-    untether config set amp.dangerously_allow_all true
+    untether config set amp.dangerously_allow_all false
     ```
 
 === "toml"
@@ -194,5 +194,5 @@ Returns `None` if no usage data was accumulated.
     [amp]
     model = "claude-sonnet-4-6"       # optional
     mode = "smart"                     # optional: deep|free|rush|smart
-    dangerously_allow_all = true       # default: true
+    dangerously_allow_all = false      # default: false (flipped in v0.35.3 — #206)
     ```

--- a/docs/reference/runners/claude/stream-json-cheatsheet.md
+++ b/docs/reference/runners/claude/stream-json-cheatsheet.md
@@ -136,6 +136,20 @@ Fields:
 {"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls -la"}}
 ```
 
+#### `ScheduleWakeup` (session-scoped scheduling)
+
+Claude Code 2.1.x emits `ScheduleWakeup` `tool_use` blocks when the model parks itself for a delay (`/loop`'s no-interval dynamic mode and similar). Untether observes these for [Loop mode](../../../how-to/inline-settings.md#loop-mode) and the long-running tool tail.
+
+```json
+{"type":"tool_use","id":"toolu_3","name":"ScheduleWakeup","input":{"delaySeconds":300,"reason":"build check","prompt":"check if the build finished"}}
+```
+
+* `delaySeconds` (int, 60–3600) — wall-clock delay before wakeup. Untether reads this field for countdown rendering ([#481](https://github.com/littlebearapps/untether/issues/481) fixed; pre-rc7 reads `delay_ms`/`timeout_ms` were always 0.0 in production).
+* `reason` (string) — short human label rendered in verbose mode (`→ fires in 4m 12s · "build check"`).
+* `prompt` (string) — the prompt the model wants to fire on wakeup (loop iteration body).
+
+`CronCreate` follows the same shape with a `cron` field (5-field expression) instead of `delaySeconds`. The Loop observer parses `cron` (not `cron_expression`) and `id` (not `taskId`/`cronId`); upstream 8-character cron IDs bind via `\bjob ([0-9a-f]{8})\b` from the assistant text.
+
 ### Tool result
 String content:
 ```json

--- a/docs/reference/runners/claude/untether-events.md
+++ b/docs/reference/runners/claude/untether-events.md
@@ -151,6 +151,10 @@ The terminal event looks like:
 - Emit exactly one `completed` event; ignore any trailing JSON lines afterward.
   No idle-timeout completion is used.
 
+#### Supplementary `started` event after `result` (`✓ turn complete`)
+
+Every successful `result` (i.e. `is_error=false`) MAY also emit a supplementary `started` event carrying late-arriving meta — `meta={"complete": "✓ turn complete"}` ([#333](https://github.com/littlebearapps/untether/issues/333)). This is the supported pattern for late-arriving meta documented in `runner-development.md`: `ProgressTracker.note_event` merges meta idempotently so the marker shows up in the footer (`format_meta_line`) alongside model / effort / permission / trigger without duplicating the StartedEvent. Errored results do **not** emit the marker — no false "complete" tag on a failure.
+
 #### Permission denials
 
 > **Not yet implemented.** The upstream Claude Code CLI may include

--- a/docs/reference/runners/pi/runner.md
+++ b/docs/reference/runners/pi/runner.md
@@ -85,6 +85,7 @@ Notes:
 * `extra_args` lets you pass new Pi flags without changing Untether.
 * Session files are stored under Pi's default session dir:
   `~/.pi/agent/sessions/--<cwd>--` (with path separators replaced by `-`).
+* The Pi runner explicitly creates the session dir with `0o700` (rwx------) and chmods any pre-existing dir to the same mode ([#207](https://github.com/littlebearapps/untether/issues/207)) so other users on a shared host can't read Pi session JSONL.
 
 ---
 

--- a/docs/reference/specification.md
+++ b/docs/reference/specification.md
@@ -1,4 +1,4 @@
-# Untether Specification v0.35.1 [2026-04-15]
+# Untether Specification v0.35.3 [2026-05-08]
 
 This document is **normative**. The words **MUST**, **SHOULD**, and **MAY** express requirements.
 

--- a/docs/reference/triggers/triggers.md
+++ b/docs/reference/triggers/triggers.md
@@ -494,7 +494,7 @@ the filesystem context.
 
 ## Trigger visibility
 
-!!! info "New in v0.35.1"
+!!! info "Tier 1 in v0.35.1, Tier 2/3 expanded in v0.35.3"
 
 ### Per-chat `/ping` indicator
 
@@ -511,11 +511,17 @@ If multiple triggers target the chat, the indicator shows counts instead of the 
 ⏰ triggers: 2 crons, 1 webhook
 ```
 
+While master pause is active (see [Pause/Resume](#pause-and-resume)), `/ping` switches to:
+
+```
+⏸ triggers paused: 2 crons, 1 webhook (suspended)
+```
+
 The indicator is per-chat — only triggers whose `chat_id` matches the current chat appear. Triggers that omit `chat_id` (and therefore fall back to the transport's default `chat_id`) show for that chat only.
 
 ### Meta footer
 
-Runs initiated by a cron or webhook show provenance in the meta footer alongside model and mode:
+Runs initiated by a cron, webhook, or `/at` show provenance in the meta footer alongside model and mode:
 
 ```
 🏷 opus 4.6 · plan · ⏰ cron:daily-review
@@ -523,6 +529,28 @@ Runs initiated by a cron or webhook show provenance in the meta footer alongside
 
 - `⏰ cron:<id>` for cron-initiated runs
 - `⚡ webhook:<id>` for webhook-initiated runs
+- `⏰ at:<token>` for `/at <duration>` one-shot delayed runs ([#271](https://github.com/littlebearapps/untether/issues/271) follow-up)
+
+### `/config` → 📡 Triggers page (Tier 2)
+
+`/config` → **📡 Triggers** (`config:tg`) lists every cron and webhook configured for the current chat ([#271](https://github.com/littlebearapps/untether/issues/271) Tier 2):
+
+- **Crons**: human-readable `describe_cron(schedule, timezone)`, project, engine, last-fired relative time
+- **Webhooks**: path, auth scheme, project, engine, last-fired
+
+Lists are scoped to the current chat (using `crons_for_chat` / `webhooks_for_chat` with the bridge `default_chat_id` fallback), capped at 10 entries with a `…and N more (see untether.toml)` overflow marker.
+
+The same page hosts the master [Pause/Resume](#pause-and-resume) toggle.
+
+### `/stats` triggered/manual breakdown (Tier 3)
+
+`/stats` appends `(N triggered, M manual)` to per-engine lines and the totals row when at least one count is nonzero ([#271](https://github.com/littlebearapps/untether/issues/271) Tier 3):
+
+```
+claude: 12 runs (8 triggered, 4 manual)
+```
+
+Triggered counts include cron, webhook, and `/at` fires. Backed by a new persistent JSON history store at `<config_path>.with_name("triggers_history.json")` recording wall time after every successful cron/webhook/action dispatch. Recording is best-effort — a transient disk failure logs `triggers.history.write_failed` and swallows so it can't break the cron loop or webhook server. Renaming a trigger ID in TOML leaves a stale entry that operators can manually delete (no auto-prune to avoid losing data on transient TOML errors).
 
 ### Human-friendly cron descriptions
 
@@ -562,7 +590,35 @@ The webhook server exposes a `GET /health` endpoint that returns:
 {"status": "ok", "webhooks": 2}
 ```
 
+While master pause is active (see [Pause/Resume](#pause-and-resume)) the same endpoint returns:
+
+```json
+{"status": "paused", "paused": true, "webhooks": 2}
+```
+
+External monitors can use the `paused` field to distinguish "paused but up" from "down" — the bot is healthy and reachable, just not dispatching trigger work.
+
 Use this for uptime monitoring or reverse proxy health checks.
+
+## Pause and resume
+
+`TriggerManager` exposes a master pause toggle ([#294](https://github.com/littlebearapps/untether/issues/294)) that gates **both** crons and webhooks at once:
+
+- **Cron loop**: skips its tick while paused. `run_once` crons are not consumed during the pause and fire on the next matching tick after resume.
+- **Webhook server**: returns `503 triggers paused` with `Retry-After: 60` instead of dispatching. Auth, rate-limit, and event-filter checks still run before the 503 so an unauthenticated probe still gets `401`, not `503`.
+- **`/health`**: surfaces `{"status": "paused", "paused": true}`.
+- **`/ping`**: switches to `⏸ triggers paused: … (suspended)`.
+
+### Toggling
+
+Pause/resume is wired into `/config` two ways:
+
+1. **Home-page button row** — appears at the bottom of the `/config` home page only when triggers are configured. One-tap toggle.
+2. **Dedicated 📡 Triggers page** (`config:tg`) — shows current state and counts, with a Pause/Resume button at the top. The same page lists per-chat crons and webhooks.
+
+### Persistence
+
+Pause is **in-memory only** — restart auto-resumes (the safe default). If you need a durable shutoff, set `[triggers] enabled = false` in `untether.toml`, which survives restarts. Pause is for "stop firing for the next half hour while I deploy" not "permanently disable triggers".
 
 ## Testing webhooks
 
@@ -599,6 +655,7 @@ Expected responses:
 | `404 Not Found` | No webhook configured for this path. |
 | `413 Payload Too Large` | Body exceeds `max_body_bytes`. |
 | `429 Too Many Requests` | Rate limit exceeded. |
+| `503 triggers paused` | Master [Pause](#pause-and-resume) toggle is active. Includes `Retry-After: 60`. |
 
 ## Troubleshooting
 

--- a/docs/tutorials/install.md
+++ b/docs/tutorials/install.md
@@ -79,6 +79,9 @@ npm install -g @google/gemini-cli
 
 Gemini CLI uses Google AI Studio or Vertex AI for authentication. Run `gemini` and sign in with your Google account. Supports plan mode, sandboxing, and automatic model routing (Pro for planning, Flash for implementation).
 
+!!! tip "Headless trust"
+    Untether runs Gemini with `--skip-trust` by default (v0.35.3+, [#471](https://github.com/littlebearapps/untether/issues/471)) so projects outside `~/.gemini/trustedFolders.json` work in headless mode. Set `[gemini] skip_trust = false` in `untether.toml` if you'd rather enforce Gemini's project-local trust gate.
+
 ### AMP
 
 ```sh


### PR DESCRIPTION
## Summary

Audited all 27 v0.35.3 issues (rc1–rc9) against every user-facing doc and applied succinct gap fills. **Docs-only — no code or tests changed.** No version bump needed: `0.35.3rc9` stays as-is on TestPyPI; this PR re-pushes dev with the same version, and the TestPyPI publish job's `skip-existing: true` flag means nothing republishes.

### Reference docs

- **`config.md`** — added `[progress] heartbeat_interval` (#481), `[watchdog] post_result_idle_timeout` / `post_result_idle_enabled` (#333) + `bash_grace_seconds` (#481), `[gemini] skip_trust` (#471), and a hot-reload tip on `[progress]`
- **`commands-and-directives.md`** — heartbeat-tail note + Loop-mode pointer (no `/loop` command — it's a Claude feature)
- **`triggers/triggers.md`** — `/config:tg` page, `/stats` triggered/manual breakdown, `/at` footer (`⏰ at:<token>`), `503 paused` response, `/health` paused state, full **Pause and resume** section
- **`specification.md`** — version stamp `v0.35.1` → `v0.35.3`
- **`runners/claude/stream-json-cheatsheet.md`** — `ScheduleWakeup` event shape (`delaySeconds`, `reason`, `prompt`) + `CronCreate` Loop-observer notes (#289, #481)
- **`runners/claude/untether-events.md`** — supplementary `StartedEvent` with `meta={"complete": "✓ turn complete"}` after successful `result`
- **`runners/amp/untether-events.md`** — example flipped to `dangerously_allow_all = false` (default since #206)
- **`runners/pi/runner.md`** — `0o700` session dir mode (#207)

### How-to

- **`inline-settings.md`** — new `🔁 Loop mode` page section
- **`verbose-progress.md`** — long-running tool tail (heartbeat), `BashOutput`/`ScheduleWakeup`/`Monitor` verbose detail, hot-reload tip
- **`webhooks-and-cron.md`** — full **Pause and resume** section, `/health` paused state, `503 triggers paused`
- **`troubleshooting.md`** — post-result closing message + stall suppression note
- **`operations.md`** — hot-reload list now covers `heartbeat_interval` + `bash_grace_seconds` + trigger pause/resume
- **`tutorials/install.md`** — Gemini `--skip-trust` headless tip

### Explanation

- **`architecture.md`** — TriggerManager pause/resume, `triggers/history.py`
- **`module-map.md`** — `at_scheduler.py`, `loop_scheduler.py`, full **Triggers** module section

### Top-level

- **`README.md`** — 🔁 Autonomous loops feature row
- **`SECURITY.md`** — v0.35.3 hardening bundle subsection covering #377, #206, #207, #378, #205/#478, #211, #208, #213, #379, #402, #380, #409

## Out of scope

- **#483 (FAQ filename rename)** is deliberately NOT in this PR. The rename `docs/faq/index.md` → `docs/faq/faq.md` is blocked by the FAQ-protect hook from #477, and the hook itself is self-protected by `release-guard-protect.sh`. Human-led follow-up will land #483 separately.

## Test plan

- [x] `python3 -c` sanity check on every edited file (line count + pipe count) — all parse cleanly
- [ ] CI: format, ruff, ty (informational), pytest 3.12/3.13/3.14, build, lockfile, pip-audit, bandit, docs (Zensical)
- [ ] After merge: confirm dev's marketing-site docs sync picks up the doc updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)