### PR TITLE
fix: #510 — move ExitPlanMode plan-body prepend onto per-stream path (rc12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.3rc11"
+version = "0.35.3rc12"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -384,35 +384,6 @@ def _apply_preamble(prompt: str) -> str:
     return f"{text}\n\n---\n\n{prompt}"
 
 
-def _prepend_exitplanmode_plan(final_answer: str | None, plan_body: str | None) -> str:
-    """#508 Re-emit ExitPlanMode plan body when the post-approval final
-    answer doesn't already contain it.
-
-    Handles the research-task case: Claude does the work, saves to a file,
-    ExitPlanMode plan body has the substantive findings, user approves,
-    post-approval ``result`` is brief or empty (Claude has nothing left
-    to do). Without this re-emit, the user only sees the brief
-    acknowledgement extracted via the ``last_assistant_text`` fallback —
-    the plan body, which got deleted from Telegram on approve, would
-    otherwise be lost.
-
-    Skip rule: if the plan body is already a substring of
-    ``final_answer`` (the preamble guidance may have caused Claude to
-    repeat the plan content in its post-approval text), do NOT prepend
-    — avoid duplication. Substring-only is the right gate; no length
-    threshold (live repro had answer_len=584, larger than any sensible
-    threshold, but still didn't contain the plan content).
-    """
-    if not plan_body or not plan_body.strip():
-        return final_answer or ""
-    body = plan_body.strip()
-    if body in (final_answer or ""):
-        return final_answer or ""
-    if final_answer:
-        return f"📋 Plan (approved):\n\n{plan_body}\n\n---\n\n{final_answer}"
-    return f"📋 Plan (approved):\n\n{plan_body}"
-
-
 def _resolve_presenter(
     default_presenter: Presenter, channel_id: ChannelId
 ) -> Presenter:
@@ -2984,19 +2955,13 @@ async def handle_message(
         return
     # --- End auto-continue ---
 
+    # #510: ``completed.answer`` already has the #508 ExitPlanMode
+    # plan-body prepend applied at the runner level (claude.py, on the
+    # per-stream path). The previous bridge-side prepend read
+    # ``runner.current_stream`` — a shared singleton on the ClaudeRunner
+    # — and leaked one chat's plan body into another concurrent chat's
+    # final answer.
     final_answer = completed.answer
-
-    # #508 Re-emit ExitPlanMode plan body when the post-approval final
-    # answer doesn't already contain it. See ``_prepend_exitplanmode_plan``
-    # for full rationale and skip rules.
-    _stream = getattr(runner, "current_stream", None)
-    _engine_state = getattr(_stream, "engine_state", None) if _stream else None
-    _plan_body = (
-        getattr(_engine_state, "last_exitplanmode_plan", None)
-        if _engine_state
-        else None
-    )
-    final_answer = _prepend_exitplanmode_plan(final_answer, _plan_body)
 
     # Auto-clear broken session: if a resumed run failed with 0 turns,
     # clear the saved session so the next message starts fresh.

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -875,6 +875,35 @@ def _extract_error(
     return f"{first}\n{diagnostics}"
 
 
+def _prepend_exitplanmode_plan(final_answer: str | None, plan_body: str | None) -> str:
+    """#508 Re-emit ExitPlanMode plan body in the final answer.
+
+    Owned by the runner — called from the per-stream ``StreamResultMessage``
+    translation path using ``state.last_exitplanmode_plan`` (correctly
+    scoped to this run's stream). #510: previously called from
+    ``runner_bridge.handle_message`` against ``runner.current_stream``
+    (singleton attribute on the shared ``ClaudeRunner``), which races
+    across concurrent Claude chats and leaked one chat's plan body into
+    another chat's final answer. Moving the call into the per-stream path
+    in ``claude.py`` closes the leak: ``state`` here is the per-run stream
+    state, not a shared field, so the plan body cannot be sourced from a
+    different session.
+
+    Skip rule: if the plan body is already a substring of
+    ``final_answer`` (the preamble guidance may have caused Claude to
+    repeat the plan content in its post-approval text), do NOT prepend
+    — avoid duplication.
+    """
+    if not plan_body or not plan_body.strip():
+        return final_answer or ""
+    body = plan_body.strip()
+    if body in (final_answer or ""):
+        return final_answer or ""
+    if final_answer:
+        return f"📋 Plan (approved):\n\n{plan_body}\n\n---\n\n{final_answer}"
+    return f"📋 Plan (approved):\n\n{plan_body}"
+
+
 def _maybe_audit_env(state: ClaudeStreamState, session_id: str) -> None:
     """One-shot ``/proc/<pid>/environ`` audit on first system.init (#361).
 
@@ -1181,6 +1210,17 @@ def translate_claude_event(
             result_text = event.result or ""
             if ok and not result_text and state.last_assistant_text:
                 result_text = state.last_assistant_text
+
+            # #510 / #508: re-emit the ExitPlanMode plan body when the
+            # post-approval final answer is brief/empty. Done HERE on the
+            # per-stream path (state is per-run, correctly scoped) rather
+            # than in runner_bridge.handle_message against the shared
+            # runner.current_stream singleton — which raced across
+            # concurrent Claude chats and leaked plan bodies cross-chat.
+            if ok:
+                result_text = _prepend_exitplanmode_plan(
+                    result_text, state.last_exitplanmode_plan
+                )
 
             resume = ResumeToken(engine=ENGINE, value=event.session_id)
             error = None if ok else _extract_error(event, resumed=state.resumed)

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -1204,6 +1204,115 @@ def test_translate_exitplanmode_ignores_empty_plan_body() -> None:
     assert state.last_exitplanmode_plan == "earlier plan body"
 
 
+def test_translate_result_prepends_exitplanmode_plan_into_answer() -> None:
+    """#510: the ExitPlanMode plan body re-emit happens HERE on the per-stream
+    result path (claude.py), not in runner_bridge against the singleton
+    runner.current_stream. Verifies the prepend uses state.last_exitplanmode_plan
+    from the SAME state instance that received the result event.
+    """
+    state = ClaudeStreamState()
+    state.factory._resume = ResumeToken(engine="claude", value="sess-510")
+    state.last_exitplanmode_plan = "- Finding 1\n- Finding 2\n- Recommend X"
+    short_post_approval_result = "Plan approved — see file."
+
+    event = claude_schema.StreamResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=2,
+        session_id="sess-510",
+        result=short_post_approval_result,
+    )
+    events = translate_claude_event(
+        event,
+        title="claude",
+        state=state,
+        factory=state.factory,
+    )
+    completed = [evt for evt in events if isinstance(evt, CompletedEvent)]
+    assert len(completed) == 1
+    answer = completed[0].answer
+    assert "📋 Plan (approved):" in answer
+    assert "- Finding 1" in answer
+    assert short_post_approval_result in answer
+    # Plan body comes before the brief post-approval text
+    assert answer.index("- Finding 1") < answer.index(short_post_approval_result)
+
+
+def test_concurrent_states_do_not_leak_exitplanmode_plan_bodies() -> None:
+    """#510 regression — the live bug. Two concurrent Claude sessions
+    each had their own ClaudeStreamState. Previously the bridge read the
+    plan body from ``runner.current_stream`` (a shared singleton on the
+    runner), which was overwritten when either session re-entered
+    run_impl. The fix routes the prepend through the per-stream
+    translate path, so each state can ONLY ever read its own plan body.
+
+    Models the production incident: chat A captured "PLAN — CHANNELO
+    TUNNEL" on its state, chat B was completing a different task with
+    its own short answer — chat B's CompletedEvent must NOT contain
+    chat A's plan body.
+    """
+    state_a = ClaudeStreamState()
+    state_a.factory._resume = ResumeToken(engine="claude", value="sess-A")
+    state_a.last_exitplanmode_plan = "PLAN — CHANNELO TUNNEL secret content"
+
+    state_b = ClaudeStreamState()
+    state_b.factory._resume = ResumeToken(engine="claude", value="sess-B")
+    # state_b has its own (smaller) plan body — different content
+    state_b.last_exitplanmode_plan = "PLAN — legal-DB handover"
+
+    # Session B completes with a brief post-approval result.
+    event_b = claude_schema.StreamResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=2,
+        session_id="sess-B",
+        result="done",
+    )
+    events_b = translate_claude_event(
+        event_b,
+        title="claude",
+        state=state_b,
+        factory=state_b.factory,
+    )
+    completed_b = next(evt for evt in events_b if isinstance(evt, CompletedEvent))
+
+    # Session B's answer must only contain its own plan body.
+    assert "PLAN — legal-DB handover" in completed_b.answer
+    assert "CHANNELO TUNNEL" not in completed_b.answer
+    assert "secret content" not in completed_b.answer
+
+
+def test_translate_result_error_does_not_prepend_plan(monkeypatch) -> None:
+    """#510: only the OK path prepends. Errored result paths flow into
+    _extract_error and must not also receive a plan-body prepend.
+    """
+    state = ClaudeStreamState()
+    state.factory._resume = ResumeToken(engine="claude", value="sess-510-err")
+    state.last_exitplanmode_plan = "- Should not appear"
+
+    event = claude_schema.StreamResultMessage(
+        subtype="error_during_execution",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=True,
+        num_turns=1,
+        session_id="sess-510-err",
+    )
+    events = translate_claude_event(
+        event,
+        title="claude",
+        state=state,
+        factory=state.factory,
+    )
+    completed = next(evt for evt in events if isinstance(evt, CompletedEvent))
+    assert "📋 Plan (approved):" not in (completed.answer or "")
+    assert "- Should not appear" not in (completed.answer or "")
+
+
 def test_translate_advisor_tool_result_block() -> None:
     """advisor_tool_result shares the tool_result translation path: emits an
     action_completed and pops the matching entry from state.pending_actions.

--- a/tests/test_preamble.py
+++ b/tests/test_preamble.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 from untether.runner_bridge import (
     _DEFAULT_PREAMBLE,
     _apply_preamble,
-    _prepend_exitplanmode_plan,
 )
+from untether.runners.claude import _prepend_exitplanmode_plan
 from untether.settings import PreambleSettings
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.3rc11"
+version = "0.35.3rc12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Fix cross-chat plan-body leak observed on staging v0.35.3rc11 ([#510](https://github.com/littlebearapps/untether/issues/510)). Moves the #508 `_prepend_exitplanmode_plan` call from `runner_bridge.handle_message` (which read the shared `runner.current_stream` singleton and raced across concurrent Claude sessions) into the per-stream `StreamResultMessage` translation path in `claude.py`. The plan body is now constructed inside the runner's own state, so it can never be sourced from a different session.
- Bumps version to `0.35.3rc12`.
- Adds three regression tests (per-stream prepend, concurrent-state isolation, error-path skip).
- Adapts `tests/test_preamble.py` to import `_prepend_exitplanmode_plan` from its new home in `runners.claude`.

## Test plan
- [x] `uv run pytest` — 2647 passed, 2 skipped, 82.37% coverage
- [x] `uv run ruff format src/ tests/` + `uv run ruff check src/` — all clean
- [x] `uv lock --check` — synced
- [x] Live integration on `@untether_dev_bot`: Claude plan-mode research task, approved, final Telegram message arrived with the `📋 Plan (approved):` prefix and full plan body (answer_len=6118). #508 UX preserved.
- [ ] CI green on this PR — required before merge

## Scope notes

This fix targets the demonstrated leak path (#508 plan-body prepend). Three other read sites of `runner.current_stream` remain — `runner_bridge.py:2524`, `:2556`, and the two `executor.py` proxy properties. They read low-signal fields (pid threading, stream identity for `ProgressEdits`) and have not been observed to leak user-visible content. The structural fix for those is tracked as a follow-up under [#510](https://github.com/littlebearapps/untether/issues/510).

Closes the user-visible leak. Will keep the issue open for the broader `current_stream` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)