### PR TITLE
fix: #502 — skip control-channel events from last_event_type

### DIFF
--- a/src/untether/runner.py
+++ b/src/untether/runner.py
@@ -146,6 +146,13 @@ _CODEX_TOOL_ITEM_TYPES = frozenset(
 )
 _OPENCODE_TOOL_STATUSES = frozenset({"completed", "error"})
 
+# #502: control-channel traffic is stdin/stdout permission-flow (Claude
+# control_request → Untether stdin control_response, and parent-initiated
+# requests like mcp_status). Skip when computing last_event_type so the
+# session.summary reflects the last *stream* event, not the last frame
+# the parser saw. recent_events still records them for diagnostics.
+_CONTROL_CHANNEL_EVENT_TYPES = frozenset({"control_request", "control_response"})
+
 
 def _classify_jsonl_event(raw: Any) -> str:
     """Return "tool_result" | "assistant" | "other" for a decoded JSONL event.
@@ -807,8 +814,12 @@ class JsonlSubprocessRunner(BaseRunner):
                 itype = item.get("type")
                 if isinstance(itype, str) and itype:
                     etool = itype
-            stream.last_event_type = etype
-            stream.last_event_tool = etool
+            # #502: skip control-channel events when updating last_event_type
+            # so session.summary reflects the last stream event, not stdin/stdout
+            # permission-flow traffic. recent_events still records them.
+            if etype not in _CONTROL_CHANNEL_EVENT_TYPES:
+                stream.last_event_type = etype
+                stream.last_event_tool = etool
             label = f"tool:{etool}" if etool else etype
             stream.recent_events.append((now, label))
             # Stuck-after-tool_result tracking (#322). The latch persists across

--- a/tests/test_exec_runner.py
+++ b/tests/test_exec_runner.py
@@ -625,6 +625,45 @@ async def test_jsonl_stream_state_tracks_events(tmp_path) -> None:
     assert isinstance(started.meta["pid"], int)
 
 
+@pytest.mark.anyio
+async def test_jsonl_stream_state_skips_control_channel_events(tmp_path) -> None:
+    """#502: control_request / control_response events on stdout must not
+    overwrite ``stream.last_event_type``. They are permission-flow traffic,
+    not stream-result events, so the session.summary should reflect the
+    last actual stream event. ``recent_events`` still records them for
+    diagnostics."""
+    thread_id = "019b73c4-0c3f-7701-a0bb-aac6b4d8a3bc"
+
+    codex_path = tmp_path / "codex"
+    codex_path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        "import sys\n"
+        "\n"
+        "sys.stdin.read()\n"
+        f"print(json.dumps({{'type': 'thread.started', 'thread_id': '{thread_id}'}}), flush=True)\n"
+        # A real stream event — should be reflected in last_event_type
+        "print(json.dumps({'type': 'item.completed', 'item': {'id': 'item_0', 'type': 'agent_message', 'text': 'ok'}}), flush=True)\n"
+        # Control-channel chatter — must NOT overwrite last_event_type
+        "print(json.dumps({'type': 'control_request', 'request_id': 'req_1', 'request': {'subtype': 'mcp_status'}}), flush=True)\n"
+        "print(json.dumps({'type': 'control_response', 'request_id': 'req_1', 'response': {'subtype': 'success'}}), flush=True)\n",
+        encoding="utf-8",
+    )
+    codex_path.chmod(0o755)
+
+    runner = CodexRunner(codex_cmd=str(codex_path), extra_args=[])
+    _ = [evt async for evt in runner.run("hi", None)]
+
+    stream = runner.current_stream
+    assert stream is not None
+    # last_event_type reflects the last *stream* event, not the control chatter
+    assert stream.last_event_type == "item.completed"
+    # But the control events ARE still recorded in recent_events for diagnostics
+    recent_labels = [label for (_ts, label) in stream.recent_events]
+    assert "control_request" in recent_labels
+    assert "control_response" in recent_labels
+
+
 def test_jsonl_stream_state_defaults() -> None:
     """JsonlStreamState initialises with correct defaults."""
     from untether.runner import JsonlStreamState


### PR DESCRIPTION
## Summary

Fixes #502. `session.summary` was recording `last_event_type=control_request` (pass 1 evidence) and `last_event_type=control_response` (pass 2 evidence) on ok=True completed runs. Root cause is in `src/untether/runner.py` where \`stream.last_event_type\` was written unconditionally from the raw JSONL \`type\` field, including the permission-flow stdin/stdout traffic (Claude → Untether \`control_request\`, and the parent-initiated \`mcp_status\` response on stdout per #365).

## What changed

- \`src/untether/runner.py\` — skip updating \`stream.last_event_type\` / \`last_event_tool\` when \`etype in {\"control_request\", \"control_response\"}\`. \`recent_events\` still records control entries for the stall-diagnostic timeline (which is what surfaced the bug in the rc13 audit).
- \`tests/test_exec_runner.py\` — new test \`test_jsonl_stream_state_skips_control_channel_events\`: emits an event sequence with control_request/control_response interleaved, asserts \`stream.last_event_type\` reflects the last *stream* event and that \`recent_events\` still contains the control labels.

## Why this is the surgical fix

The auto-continue gate at \`runner_bridge.py:282\` (\`if last_event_type != \"user\"\`) detects Claude Code's silent-termination bug (upstream #34142, #30333) by checking the *raw* \`type\` value. Switching \`last_event_type\` to the classified kind (\`tool_result\`/\`assistant\`/\`other\`) would have broken auto-continue. Filtering only the control-channel events leaves auto-continue unchanged.

## Test plan

- [x] Unit: new regression test passes (\`uv run pytest tests/test_exec_runner.py::test_jsonl_stream_state_skips_control_channel_events -xvs\`)
- [x] Regression: \`uv run pytest tests/test_exec_runner.py tests/test_exec_bridge.py -x --no-cov\` → 219 passed, 1 skipped
- [x] Lint clean: \`uv run ruff format src/ tests/\` + \`uv run ruff check src/ tests/\`
- [x] Lockfile clean: \`uv lock --check\`
- [x] **Integration test on @untether_dev_bot (Tier 1 + C1):** sent a plan-mode prompt → ExitPlanMode prompt appeared → pressed ✅ Approve → run completed:

  Before (rc13):
  \`session.summary ... last_event_type=control_request ok=True\`
  \`session.summary ... last_event_type=control_response ok=True\`

  After (this PR):
  \`session.summary ... duration_seconds=270.1 engine=claude event_count=14 last_event_type=result ok=True peak_idle_seconds=210.4\`

Closes #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)