### PR TITLE
fix: #494 — liveness_stalls counter, cpu_active reliability, approval-aware stall message

### DIFF
--- a/src/untether/runner.py
+++ b/src/untether/runner.py
@@ -317,6 +317,12 @@ class JsonlStreamState:
     )
     stderr_capture: list[str] = field(default_factory=list)
     proc_returncode: int | None = None
+    # #494: subprocess.liveness_stall canary counter. Today `liveness_warned`
+    # in _watchdog_loop latches after the first warning, so this is 0 or 1 per
+    # run. Kept as int for forward-compat if the latch is ever relaxed; surfaced
+    # in session.summary so audits can see liveness fires independently of the
+    # user-facing _total_stall_warn_count.
+    liveness_stalls: int = 0
     # Stuck-after-tool_result detector (#322). Engine-agnostic signal:
     # set when a tool_result-equivalent event arrives, cleared when an
     # assistant-turn-start event arrives. When non-zero and elapsed > threshold,
@@ -1007,6 +1013,20 @@ class JsonlSubprocessRunner(BaseRunner):
             except (ProcessLookupError, PermissionError):
                 break  # process exited
 
+            # #494-B: collect a baseline diag on the first successful poll so
+            # cpu_active has a real comparison snapshot if/when the liveness
+            # watchdog fires. Without this prev_diag stayed None for the
+            # lifetime of the run (`liveness_warned` latches one-shot, so the
+            # post-warning assignment at the bottom never ran), and
+            # is_cpu_active(None, diag) always returned None — which both
+            # confused log readers and treated "unknown" as "definitely idle"
+            # in the auto-kill check at `cpu_active is not True` below. After
+            # this baseline, cpu_active becomes an accurate True/False; the
+            # auto-kill semantics are now "kill only when CPU genuinely went
+            # quiet during the 600s window".
+            if prev_diag is None:
+                prev_diag = collect_proc_diag(pid)
+
             # Liveness stall detection
             if (
                 not liveness_warned
@@ -1016,6 +1036,7 @@ class JsonlSubprocessRunner(BaseRunner):
                 idle = time.monotonic() - stream.last_stdout_at
                 if idle >= self._LIVENESS_TIMEOUT_SECONDS:
                     liveness_warned = True
+                    stream.liveness_stalls += 1
                     diag = collect_proc_diag(pid)
                     cpu_active = is_cpu_active(prev_diag, diag)
                     recent = list(stream.recent_events)[-5:]

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -1475,6 +1475,10 @@ class ProgressEdits:
                 # ring buffer escalation despite CPU activity)
                 mins = int(elapsed // 60)
                 mcp_hung = mcp_server is not None and frozen_escalate
+                # Initialised here (not inside the final else) so the
+                # _genuinely_stuck predicate below can reference it safely
+                # from every branch.
+                _tool_name: str | None = None
                 if mcp_hung:
                     logger.warning(
                         "progress_edits.mcp_tool_hung",
@@ -1517,6 +1521,12 @@ class ProgressEdits:
                         parts = [
                             f"⏳ No progress for {mins} min (CPU active, no new events)"
                         ]
+                elif threshold_reason == "pending_approval":
+                    # #494-C: user is waiting on an approval button; the stall
+                    # warning is expected, not a sign the agent has frozen.
+                    # Distinguish from genuine "no progress" copy so the user
+                    # realises the buttons above are theirs to action.
+                    parts = [f"⏳ Awaiting your approval ({mins} min)"]
                 elif mcp_server is not None:
                     parts = [f"⏳ MCP tool running: {mcp_server} ({mins} min)"]
                 elif threshold_reason == "active_children":
@@ -1533,7 +1543,6 @@ class ProgressEdits:
                     # Extract tool name from last running action for
                     # actionable stall messages ("Bash command still running"
                     # instead of generic "session may be stuck").
-                    _tool_name = None
                     if last_action:
                         for _prefix in ("tool:", "note:", "command:"):
                             if last_action.startswith(_prefix):
@@ -1558,12 +1567,14 @@ class ProgressEdits:
                 if self._stall_warn_count > 1:
                     parts[0] += f" (warned {self._stall_warn_count}x)"
                 # "session may be stuck" — only when genuinely stuck
-                # (no tool identified, cpu not active, not MCP/frozen)
+                # (no tool identified, cpu not active, not MCP/frozen,
+                # not waiting on a user approval button — #494-C)
                 _genuinely_stuck = (
                     not mcp_hung
                     and not frozen_escalate
                     and mcp_server is None
                     and threshold_reason != "active_children"
+                    and threshold_reason != "pending_approval"
                     and not (_tool_name and main_sleeping)
                     and cpu_active is not True
                 )
@@ -2561,6 +2572,8 @@ async def run_runner_with_cancel(
         duration_seconds=round(duration, 1),
         event_count=event_count,
         stall_warnings=edits._total_stall_warn_count,
+        # #494: subprocess-health canary, separate from user-facing stall_warnings
+        liveness_stalls=edits.stream.liveness_stalls if edits.stream else 0,
         peak_idle_seconds=round(edits._peak_idle, 1),
         last_event_type=edits.stream.last_event_type if edits.stream else None,
         cancelled=outcome.cancelled,

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -2377,7 +2377,12 @@ async def test_stall_suppressed_while_waiting_for_approval() -> None:
 
 @pytest.mark.anyio
 async def test_stall_fires_after_approval_threshold() -> None:
-    """Stall monitor fires after the longer approval threshold is exceeded."""
+    """Stall monitor fires after the longer approval threshold is exceeded.
+
+    #494-C: the message must say "Awaiting your approval" rather than the
+    generic "No progress" copy, so the user realises the buttons above are
+    theirs to action and the agent has not hung.
+    """
     transport = FakeTransport()
     presenter = _KeyboardPresenter()
     clock = _FakeClock(start=100.0)
@@ -2413,8 +2418,18 @@ async def test_stall_fires_after_approval_threshold() -> None:
         tg.start_soon(drive)
 
     assert edits._stall_warn_count >= 1
-    stall_msgs = [c for c in transport.send_calls if "No progress" in c["message"].text]
-    assert len(stall_msgs) >= 1
+    # #494-C: message text differentiates from the generic stall copy
+    approval_msgs = [
+        c for c in transport.send_calls if "Awaiting your approval" in c["message"].text
+    ]
+    assert len(approval_msgs) >= 1, (
+        f"Expected at least one 'Awaiting your approval' message, got: "
+        f"{[c['message'].text for c in transport.send_calls]}"
+    )
+    # And it must NOT contain the generic "No progress" copy or the
+    # alarming "session may be stuck" suffix.
+    assert "No progress" not in approval_msgs[0]["message"].text
+    assert "session may be stuck" not in approval_msgs[0]["message"].text
 
 
 @pytest.mark.anyio

--- a/tests/test_exec_runner.py
+++ b/tests/test_exec_runner.py
@@ -1,3 +1,4 @@
+import sys
 from collections.abc import AsyncIterator
 
 import anyio
@@ -664,6 +665,72 @@ async def test_jsonl_stream_state_skips_control_channel_events(tmp_path) -> None
     assert "control_response" in recent_labels
 
 
+@pytest.mark.anyio
+async def test_liveness_stall_increments_counter(tmp_path) -> None:
+    """#494-A: subprocess.liveness_stall increments stream.liveness_stalls so
+    session.summary can surface the subprocess-health canary independently of
+    the user-facing _total_stall_warn_count. Today `liveness_warned` latches
+    after the first warning, so this field will be 0 or 1 per run.
+
+    #494-B: the warning's cpu_active field should be a real bool (True/False)
+    once the baseline prev_diag is populated at watchdog poll start — not None
+    as observed in the rc13 audit.
+    """
+    from structlog.testing import capture_logs
+
+    thread_id = "019b73c4-0c3f-7701-a0bb-aac6b4d8a3bc"
+
+    codex_path = tmp_path / "codex"
+    # Emit one event (sets last_stdout_at > 0), then sleep past the threshold
+    # so the liveness watchdog fires. After the sleep the script exits cleanly
+    # so the test doesn't hang.
+    codex_path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        "import sys\n"
+        "import time\n"
+        "\n"
+        "sys.stdin.read()\n"
+        f"print(json.dumps({{'type': 'thread.started', 'thread_id': '{thread_id}'}}), flush=True)\n"
+        # Sleep long enough for _LIVENESS_TIMEOUT_SECONDS + _WATCHDOG_POLL to fire
+        "time.sleep(1.0)\n",
+        encoding="utf-8",
+    )
+    codex_path.chmod(0o755)
+
+    runner = CodexRunner(codex_cmd=str(codex_path), extra_args=[])
+    # Tight timing so the watchdog fires within the test's runtime
+    runner._LIVENESS_TIMEOUT_SECONDS = 0.2
+    runner._WATCHDOG_POLL_SECONDS = 0.05
+    runner._WATCHDOG_GRACE_SECONDS = 0.5
+
+    with capture_logs() as logs:
+        with anyio.fail_after(5):
+            _ = [evt async for evt in runner.run("hi", None)]
+
+    stream = runner.current_stream
+    assert stream is not None
+    assert stream.liveness_stalls == 1, (
+        f"Expected liveness_stalls=1 after watchdog fired, got {stream.liveness_stalls}"
+    )
+
+    # #494-B: cpu_active should be True/False (a real bool comparing prev to
+    # curr snapshot), not None. Linux-only assertion since /proc is required
+    # for collect_proc_diag to return non-None.
+    if sys.platform.startswith("linux"):
+        liveness_records = [
+            r for r in logs if r.get("event") == "subprocess.liveness_stall"
+        ]
+        assert len(liveness_records) == 1, (
+            f"Expected 1 liveness_stall log record, got {len(liveness_records)}: "
+            f"{liveness_records!r}"
+        )
+        cpu_active = liveness_records[0].get("cpu_active", "MISSING")
+        assert isinstance(cpu_active, bool), (
+            f"Expected cpu_active to be bool, got {cpu_active!r}"
+        )
+
+
 def test_jsonl_stream_state_defaults() -> None:
     """JsonlStreamState initialises with correct defaults."""
     from untether.runner import JsonlStreamState
@@ -676,6 +743,10 @@ def test_jsonl_stream_state_defaults() -> None:
     assert len(stream.recent_events) == 0
     assert stream.stderr_capture == []
     assert stream.proc_returncode is None
+    # #494: liveness_stalls canary counter — separate from user-facing
+    # _total_stall_warn_count so audits can see subprocess-health hits
+    # independently.
+    assert stream.liveness_stalls == 0
 
 
 def test_jsonl_stream_state_recent_events_ring_buffer() -> None:


### PR DESCRIPTION
## Summary

Fixes #494. The rc13 audit observed three related symptoms during 20-min ExitPlanMode approval-wait stalls — they share \`_watchdog_loop\` and the stall-monitor render path, so they're bundled in one PR (with separable concerns called out below).

| | Symptom in rc13 | Sub-fix |
|---|---|---|
| A | \`session.summary.stall_warnings=0\` despite \`subprocess.liveness_stall\` firing | New \`liveness_stalls\` field on session.summary |
| B | \`cpu_active=None\` on liveness_stall warnings | Take baseline \`prev_diag\` snapshot on first poll |
| C | Approval-pending stalls look identical to genuine hangs | New \"⏳ Awaiting your approval\" message branch |

## What changed

### A — \`liveness_stalls\` field on session.summary

\`_total_stall_warn_count\` (runner_bridge.py:1143) is the user-facing-threshold counter; \`subprocess.liveness_stall\` (runner.py:1023) is a separate subprocess-health canary in the watchdog loop. They're architecturally distinct so I added \`JsonlStreamState.liveness_stalls: int\` rather than conflate them. The \`liveness_warned\` latch makes the count 0 or 1 per run today; \`int\` leaves room if the latch is ever relaxed.

### B — \`prev_diag\` baseline so \`cpu_active\` is bool

Old: \`prev_diag\` initialised to None at watchdog poll start, only assigned *after* the one-shot warning fires. \`is_cpu_active(None, diag)\` always returns None.

New: collect a baseline \`prev_diag = collect_proc_diag(pid)\` on the first successful poll. The warning's \`cpu_active\` becomes a real bool comparing two snapshots across the ~600s window.

⚠️ **Semantics change worth a reviewer's eye:** the auto-kill check at \`runner.py:1039\` is \`cpu_active is not True\`. Today \`None\` satisfies that, so auto-kill fires whenever \`tcp_established == 0\`. After this fix, \`cpu_active\` is an accurate bool — still-active processes return True (skip kill); genuinely-idle ones return False (kill, same as before). Auto-kill becomes more accurate, not more aggressive. Verified no test asserts on the None-triggers-kill path (\`grep _stall_auto_kill\` in tests/).

### C — Approval-aware stall message

\`threshold_reason = \"pending_approval\"\` was already computed for threshold selection (runner_bridge.py:1110) but never branched in the message-assembly block — so users saw the same \"No progress / session may be stuck\" copy as genuine hangs. New branch above \`mcp_server is not None\` produces \`⏳ Awaiting your approval ({mins} min)\`, and \`_genuinely_stuck\` now short-circuits on \`pending_approval\` so the alarming \"— session may be stuck.\" suffix is not appended.

Also fixed a latent \`UnboundLocalError\`: \`_tool_name\` was defined inside the final \`else:\` branch but referenced unconditionally in \`_genuinely_stuck\`. Today the predicate short-circuits for every other branch (mcp_hung/frozen_escalate/mcp_server/active_children), but my new pending_approval branch could have hit it. Lifted \`_tool_name: str | None = None\` to the top of the message-assembly block.

## Test plan

- [x] Unit: 255 passed, 2 skipped (\`uv run pytest tests/test_exec_runner.py tests/test_exec_bridge.py tests/test_proc_diag.py -x --no-cov\`)
- [x] New test: \`test_liveness_stall_increments_counter\` drives a real CodexRunner subprocess past \`_LIVENESS_TIMEOUT_SECONDS=0.2\`, asserts \`liveness_stalls==1\` (A) AND \`cpu_active is bool\` via \`structlog.testing.capture_logs\` (B) — gated on Linux for \`/proc\` availability
- [x] Updated test: \`test_stall_fires_after_approval_threshold\` now asserts the message contains \"Awaiting your approval\" and explicitly NOT \"No progress\" / \"session may be stuck\" (C)
- [x] Lint clean: \`uv run ruff format src/ tests/\` + \`uv run ruff check src/ tests/\`
- [x] Lockfile clean: \`uv lock --check\`
- [x] Integration smoke via \`@untether_dev_bot\` codex chat: session.summary now emits \`liveness_stalls=0\` for a normal completion (field wired through). Full watchdog-fire requires either the 60s minimum-configurable \`liveness_timeout\` with a deliberately-idle process or the 30-min \`_STALL_THRESHOLD_APPROVAL\` for the UX branch — the unit test drives the real subprocess with tight timing.

Closes #494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)