### PR TITLE
docs: #517 — note cumulative session cost is not capped, recommend max_cost_per_day

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -263,6 +263,18 @@ Per-chat override: `/verbose on` and `/verbose off` override the config default 
 
 Budget alerts always appear regardless of `[footer]` settings.
 
+!!! note "Cumulative session cost is not capped"
+    Sessions can stack many runs via `/continue`, follow-up prompts, or
+    a long back-and-forth dogfooding chat. A single session has been
+    observed to cumulate over US$100 across 5 sub-runs even though each
+    individual run was well under `max_cost_per_run`
+    ([#517](https://github.com/littlebearapps/untether/issues/517)). If
+    you need a ceiling that spans sessions, set `max_cost_per_day` —
+    Untether tracks daily cost across all sessions and triggers
+    `cost_budget.exceeded` once the day's spend crosses it. A
+    `max_cost_per_session` knob is not currently provided; file a
+    feature request if your workflow needs one.
+
 ## `watchdog`
 
 === "toml"


### PR DESCRIPTION
## Summary

Resolves #517 as **docs-only**, per the rc13 audit handover plan's recommendation.

The audit observed a single Claude session burn ~\$102 across 5 sub-runs on \`legal-librarian-local\` ([\$26, \$33, \$18, \$9, \$9] over ~90 min). Each individual sub-run was well under any reasonable \`max_cost_per_run\`, so neither the per-run nor per-day budget triggered — the session simply stacked many smaller runs via \`/continue\` and follow-up prompts.

This is **not a bug** — sessions stacking sub-runs is by design (\`/continue\` UX, dogfooding back-and-forth). But the config docs implied \`max_cost_per_run\` + \`max_cost_per_day\` were the only ceilings without spelling out the stacking caveat. This PR adds a Note callout under \`[cost_budget]\` that:

- Explicitly states sessions can stack many runs
- Cites the audit-observed \$100+ session
- Recommends \`max_cost_per_day\` for cross-session ceilings
- Notes \`max_cost_per_session\` is not provided (file a feature request)

## What I considered, then chose not to do

- **Add \`max_cost_per_session\`** — non-trivial: requires per-session_id cost accumulation across resumes, plumbing through \`runner_bridge\`, new \`CostAlert\` scope. \~100-150 lines. The audit's pattern was Nathan actively dogfooding (attended), not unattended runaway spend; \`max_cost_per_day\` is the right tool for that. Better as a separate feature request when an unattended scenario actually needs it.
- **Adjust Trello-MCP batching** — out of scope (upstream Claude / MCP server, not Untether).

## Test plan

- [x] Markdown renders cleanly in mkdocs (visual check — no syntax errors)
- [x] No code change — no test impact

Closes #517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)