### PR TITLE
chore: staging 0.35.3rc14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.3rc13"
+version = "0.35.3rc14"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.3rc13"
+version = "0.35.3rc14"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Stage `0.35.3rc14` to TestPyPI. Bundles four PRs merged this cycle on `dev`:

- **#519** fix: skip control-channel events from `last_event_type` (closes #502)
- **#520** fix: `liveness_stalls` counter, `cpu_active` reliability, approval-aware stall message (closes #494)
- **#521** fix: derive `retry_after_s` from reset timestamps, log full `RateLimitInfo` (closes #518)
- **#522** docs: cumulative session cost not capped, recommend `max_cost_per_day` (closes #517)

No CHANGELOG update — rc versions are skipped by `validate_release.py`.

## Test plan

- [ ] CI green
- [ ] TestPyPI publish succeeds (Publish to TestPyPI job)
- [ ] `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple untether==0.35.3rc14` resolves cleanly
- [ ] After merge: stage to `@hetz_lba1_bot` via `scripts/staging.sh install 0.35.3rc14` and run integration tier per the changed-areas in `docs/reference/integration-testing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)