### PR TITLE
docs: cross-reference fleet rollout from staging/integration docs

### DIFF
--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -83,6 +83,18 @@ scripts/staging.sh rollback
 systemctl --user restart untether
 ```
 
+## Multi-host fleet rollout
+
+Once integration tests pass on `@untether_dev_bot`, the same rc/stable rolls to all 4 hosts (lba-1 staging, nsd, channelo, mac) in parallel — not just lba-1. The dev/staging separation rules above apply per-host; the fleet scripts wrap them.
+
+```bash
+scripts/run-integration-tests.sh X.Y.ZrcN --manual    # write attestation marker
+scripts/fleet-rollout.sh X.Y.ZrcN                     # parallel install + restart
+scripts/fleet-rollback.sh X.Y.Z-prev --only <host>    # revert one host
+```
+
+The attestation marker at `~/.untether-dev/integration-test-pass-${VERSION}.json` is the safety gate — `fleet-rollout.sh` refuses to run without it. See `.claude/rules/release-discipline.md` → "Fleet rollout (rc and stable)" for the full workflow.
+
 ## After changes
 
 ```bash

--- a/docs/reference/dev-instance.md
+++ b/docs/reference/dev-instance.md
@@ -2,6 +2,8 @@
 
 Untether runs two isolated instances on lba-1: **staging** (PyPI/TestPyPI release) and **dev** (local editable source). They use separate Telegram bots, separate configs, and separate state — zero crosstalk.
 
+> **Fleet context:** lba-1 staging is one of **four production-ish hosts** (lba-1, nsd, channelo, mac). Multi-host upgrades use `scripts/fleet-rollout.sh` — see [release-discipline.md → Fleet rollout](../../.claude/rules/release-discipline.md). This page covers the lba-1 staging/dev pair specifically.
+
 ## How it works
 
 | | Staging | Dev |

--- a/docs/reference/integration-testing.md
+++ b/docs/reference/integration-testing.md
@@ -319,7 +319,10 @@ Integration tests are run by Claude Code via Telegram MCP tools (see "Automated 
 13. Report results: list each test as pass/fail/error with reason
     Distinguish Untether bugs from upstream engine API errors
 
-14. If all pass: commit, tag, release
+14. If all pass: write the attestation marker, then fleet-roll the rc/stable
+    scripts/run-integration-tests.sh X.Y.ZrcN --manual --tiers "tier7,tier1-claude,..." --notes "..."
+    scripts/fleet-rollout.sh X.Y.ZrcN          # parallel across lba-1/nsd/channelo/mac
+    See .claude/rules/release-discipline.md → Fleet rollout for the full gate + escape hatches.
 ```
 
 ### Per release type


### PR DESCRIPTION
## Summary

PR #537 landed `scripts/fleet-rollout.sh` + companions, and updated `CLAUDE.md`, `.claude/rules/release-discipline.md`, and `.claude/skills/release-coordination/SKILL.md` to cover the new 4-host parallel workflow. Three surfaces still pointed at the lba-1-only model. This patch adds one-pointer cross-references on each:

- `docs/reference/dev-instance.md` — note lba-1 staging is one of 4 hosts
- `docs/reference/integration-testing.md` — replace step 14 (\"commit, tag, release\") with the attestation marker + fleet-rollout sequence
- `.claude/rules/dev-workflow.md` — add a \"Multi-host fleet rollout\" section pointing to the scripts and release-discipline.md

No duplication of canonical fleet-rollout content. No behaviour changes. Total: +18 lines.

## Test plan

- [x] Verified each pointer resolves to the canonical doc
- [x] No conflict with PR #537 (which already shipped the canonical content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)