### PR TITLE
chore: staging 0.35.3rc15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.3rc14"
+version = "0.35.3rc15"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.3rc14"
+version = "0.35.3rc15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` from `0.35.3rc14` → `0.35.3rc15` so CI publishes the post-rc14 dev-branch changes to TestPyPI.

### Included since rc14
- #539 deps: bump urllib3 2.6.3 → 2.7.0 to clear pip-audit CVEs
- #538 docs: cross-reference fleet rollout from staging/integration docs
- #541 fix: #497 debounce `catalog.refresh_sent` to prevent storms
- #542 docs(changelog): complete v0.35.3 entries (#404 #498 #501 #502 #522 #530)

Pre-release version (`rcN`) — `validate_release.py` skips CHANGELOG requirements for rcs; stable `v0.35.3` changelog already covers the included fixes via PR #542.

## Test plan
- [ ] CI passes (format, ruff, ty, pytest 3.12/3.13/3.14, build, lockfile, install-test, pip-audit, bandit)
- [ ] `Publish to TestPyPI` job runs on merge to dev and uploads `0.35.3rc15` wheel + sdist
- [ ] After merge, run integration tests against `@untether_dev_bot` (Tier 7 + Tier 1) then write attestation marker
- [ ] `scripts/fleet-rollout.sh 0.35.3rc15` to all 4 hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)