### PR TITLE
fix(telegram): #550 — clear AskUserQuestion inline keyboard on final answer

### DIFF
--- a/src/untether/telegram/commands/ask_question.py
+++ b/src/untether/telegram/commands/ask_question.py
@@ -138,6 +138,29 @@ class AskQuestionCommand:
                 # All questions answered — send structured response
                 success = await answer_ask_question_with_options(flow.request_id)
                 if success:
+                    # Strip the inline keyboard from the final question message
+                    # so the user can no longer click buttons that would fire
+                    # `ask_question.flow_missing` warnings. We use a short
+                    # completion text because `flow.current_index` is now past
+                    # the end of `flow.questions` (so `format_question_message`
+                    # would IndexError) and `MessageRef` does not carry the
+                    # original text.
+                    cleared = RenderedMessage(
+                        text="✅ All questions answered",
+                        extra={
+                            "parse_mode": "HTML",
+                            "reply_markup": {"inline_keyboard": []},
+                        },
+                    )
+                    try:
+                        await ctx.executor.edit(ctx.message, cleared)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "ask_question.keyboard_clear_failed",
+                            request_id=flow.request_id,
+                            error=str(exc),
+                        )
+
                     answer_lines = []
                     for question, answer in flow.answers.items():
                         answer_lines.append(f"Q: {question}\nA: {answer}")
@@ -146,6 +169,7 @@ class AskQuestionCommand:
                         text=f"Answers sent:\n\n{answers_summary}",
                         notify=True,
                     )
+                # Preserve buttons on failure so the user can retry.
                 return CommandResult(
                     text="Failed to send answers — session may have ended",
                     notify=True,

--- a/tests/test_ask_user_question.py
+++ b/tests/test_ask_user_question.py
@@ -811,3 +811,189 @@ async def test_send_next_ask_question_message_no_thread() -> None:
 
     _, _, options = transport.sent[0]
     assert options.thread_id is None
+
+
+# ---------------------------------------------------------------------------
+# #550 — AskQuestionCommand.handle clears inline keyboard on final answer
+# ---------------------------------------------------------------------------
+
+
+def _make_command_ctx(args_text: str):
+    """Build a minimal CommandContext-like mock for AskQuestionCommand.handle tests."""
+    from unittest.mock import MagicMock
+
+    ctx = MagicMock()
+    ctx.args_text = args_text
+    ctx.executor = AsyncMock()
+    ctx.executor.edit = AsyncMock(return_value=None)
+    ctx.message = MagicMock()
+    return ctx
+
+
+@pytest.mark.anyio
+async def test_550_final_answer_clears_inline_keyboard(monkeypatch) -> None:
+    """#550: After the user answers the last question in a multi-Q flow, the
+    inline keyboard on the question message must be stripped via executor.edit."""
+    from untether.telegram.commands import ask_question as cmd_mod
+    from untether.transport import RenderedMessage
+
+    flow = AskQuestionState(
+        request_id="req-550-a",
+        channel_id=CHAT_A,
+        questions=[
+            {"question": "First?", "options": [{"label": "A"}, {"label": "B"}]},
+            {"question": "Second?", "options": [{"label": "C"}, {"label": "D"}]},
+        ],
+        current_index=1,  # already answered Q1, about to answer Q2
+        answers={"First?": "A"},
+    )
+    _ASK_QUESTION_FLOWS[flow.request_id] = flow
+
+    async def _fake_answer(rid: str) -> bool:
+        # Mirror real cleanup so subsequent get_ask_question_flow() returns None.
+        _ASK_QUESTION_FLOWS.pop(rid, None)
+        return True
+
+    monkeypatch.setattr(
+        "untether.runners.claude.answer_ask_question_with_options",
+        _fake_answer,
+    )
+
+    ctx = _make_command_ctx("opt:0")  # final answer = option 0 ("C")
+    result = await cmd_mod.AskQuestionCommand().handle(ctx)
+
+    # Exactly one edit call with empty inline_keyboard.
+    assert ctx.executor.edit.await_count == 1
+    edit_args, edit_kwargs = ctx.executor.edit.await_args
+    # First positional is ctx.message, second is the cleared RenderedMessage.
+    assert edit_args[0] is ctx.message
+    cleared = edit_args[1]
+    assert isinstance(cleared, RenderedMessage)
+    assert cleared.extra["reply_markup"]["inline_keyboard"] == []
+
+    # The CommandResult still includes the Q&A summary toast.
+    assert result is not None
+    assert "Answers sent" in result.text
+    assert "First?" in result.text and "Second?" in result.text
+
+
+@pytest.mark.anyio
+async def test_550_keyboard_not_cleared_when_answer_fails(monkeypatch) -> None:
+    """#550: If answer_ask_question_with_options returns False (session ended),
+    leave the buttons in place so the user knows the answer didn't land."""
+    from untether.telegram.commands import ask_question as cmd_mod
+
+    flow = AskQuestionState(
+        request_id="req-550-b",
+        channel_id=CHAT_A,
+        questions=[
+            {"question": "Q1", "options": [{"label": "A"}]},
+            {"question": "Q2", "options": [{"label": "B"}]},
+        ],
+        current_index=1,
+        answers={"Q1": "A"},
+    )
+    _ASK_QUESTION_FLOWS[flow.request_id] = flow
+
+    async def _fail_answer(rid: str) -> bool:
+        _ASK_QUESTION_FLOWS.pop(rid, None)
+        return False
+
+    monkeypatch.setattr(
+        "untether.runners.claude.answer_ask_question_with_options",
+        _fail_answer,
+    )
+
+    ctx = _make_command_ctx("opt:0")
+    result = await cmd_mod.AskQuestionCommand().handle(ctx)
+
+    ctx.executor.edit.assert_not_awaited()
+    assert result is not None
+    assert "Failed to send answers" in result.text
+
+
+@pytest.mark.anyio
+async def test_550_edit_failure_does_not_block_answer(monkeypatch, capsys) -> None:
+    """#550: If executor.edit raises (e.g. message-not-found), the warning is
+    logged but the answer-sent CommandResult is still returned."""
+    from untether.telegram.commands import ask_question as cmd_mod
+
+    flow = AskQuestionState(
+        request_id="req-550-c",
+        channel_id=CHAT_A,
+        questions=[
+            {"question": "Q1", "options": [{"label": "A"}]},
+            {"question": "Q2", "options": [{"label": "B"}]},
+        ],
+        current_index=1,
+        answers={"Q1": "A"},
+    )
+    _ASK_QUESTION_FLOWS[flow.request_id] = flow
+
+    async def _ok_answer(rid: str) -> bool:
+        _ASK_QUESTION_FLOWS.pop(rid, None)
+        return True
+
+    monkeypatch.setattr(
+        "untether.runners.claude.answer_ask_question_with_options",
+        _ok_answer,
+    )
+
+    ctx = _make_command_ctx("opt:0")
+    ctx.executor.edit = AsyncMock(side_effect=RuntimeError("message not found"))
+
+    result = await cmd_mod.AskQuestionCommand().handle(ctx)
+
+    assert ctx.executor.edit.await_count == 1
+    assert result is not None
+    assert "Answers sent" in result.text
+    # Warning was logged (structlog routes the event name to stdout in tests).
+    out = capsys.readouterr().out
+    assert "ask_question.keyboard_clear_failed" in out
+
+
+@pytest.mark.anyio
+async def test_550_multi_question_edits_twice(monkeypatch) -> None:
+    """#550: 2-question flow: Q1->Q2 edit fires the question swap (existing
+    behavior), then Q2 final answer fires the keyboard-clear edit (new)."""
+    from untether.telegram.commands import ask_question as cmd_mod
+    from untether.transport import RenderedMessage
+
+    flow = AskQuestionState(
+        request_id="req-550-d",
+        channel_id=CHAT_A,
+        questions=[
+            {"question": "Q1", "options": [{"label": "A"}, {"label": "B"}]},
+            {"question": "Q2", "options": [{"label": "C"}, {"label": "D"}]},
+        ],
+        current_index=0,
+        answers={},
+    )
+    _ASK_QUESTION_FLOWS[flow.request_id] = flow
+
+    async def _ok_answer(rid: str) -> bool:
+        _ASK_QUESTION_FLOWS.pop(rid, None)
+        return True
+
+    monkeypatch.setattr(
+        "untether.runners.claude.answer_ask_question_with_options",
+        _ok_answer,
+    )
+
+    # Click Q1 option 0 -> Q1->Q2 transition edit
+    ctx1 = _make_command_ctx("opt:0")
+    result1 = await cmd_mod.AskQuestionCommand().handle(ctx1)
+    assert result1 is None  # transition returns None
+    assert ctx1.executor.edit.await_count == 1
+    transition_msg = ctx1.executor.edit.await_args[0][1]
+    assert isinstance(transition_msg, RenderedMessage)
+    # Q2 question buttons present (non-empty keyboard)
+    assert transition_msg.extra["reply_markup"]["inline_keyboard"]
+
+    # Click Q2 option 0 -> final clear edit
+    ctx2 = _make_command_ctx("opt:0")
+    result2 = await cmd_mod.AskQuestionCommand().handle(ctx2)
+    assert result2 is not None  # final returns CommandResult
+    assert ctx2.executor.edit.await_count == 1
+    cleared_msg = ctx2.executor.edit.await_args[0][1]
+    assert cleared_msg.extra["reply_markup"]["inline_keyboard"] == []


### PR DESCRIPTION
## Summary

After the user answers the **last** question in a multi-question `AskUserQuestion` flow, the inline keyboard on the question message was left intact. Clicking the now-stale buttons fired `ask_question.flow_missing` warnings (no-op, since the flow state was already cleaned up). Cosmetic but confusing.

Fixes [#550](https://github.com/littlebearapps/untether/issues/550).

## Approach

Approach A from the rc18 handover. In `AskQuestionCommand.handle()`'s final-answer branch:

1. After `answer_ask_question_with_options(flow.request_id)` returns truthy,
2. Build a `RenderedMessage` with text `"✅ All questions answered"` and `reply_markup={"inline_keyboard": []}`,
3. `await ctx.executor.edit(ctx.message, cleared)` inside a `try/except` that logs `ask_question.keyboard_clear_failed` warning and **does not block** the answer return.

Note: `format_question_message(flow)` can't be reused for the cleared text because `flow.current_index` has been incremented past the end of `flow.questions` by the time we hit this branch (so it would `IndexError`). `MessageRef` carries no text, so we use a short completion string.

Failure modes:
- `answer_ask_question_with_options` returns False → keyboard NOT cleared (user can retry).
- `ctx.executor.edit` raises → warning logged, answer-sent response still returned.

## Test plan

- [x] `uv run pytest tests/test_ask_user_question.py -x` — 35 passed (31 existing + 4 new)
- [x] `uv run pytest` — 2675 passed, 2 skipped, coverage 82.67%
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run ruff check src/` clean
- [ ] Tier 2 integration test on `@untether_dev_bot`: send a 2-question `AskUserQuestion`, answer Q1 via button → Q1 swaps to Q2 (existing behaviour), answer Q2 via button → keyboard now empty + `✅ All questions answered` text visible, no `ask_question.flow_missing` warning in dev logs. _(Pending rc18 build.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)