### PR TITLE
fix(claude): #333 — post-result hang root-cause fix (rc18 follow-up to #549)

### DIFF
--- a/src/untether/runner.py
+++ b/src/untether/runner.py
@@ -336,6 +336,20 @@ class JsonlStreamState:
     # `has_live_background_work()`-style info it can gate SIGTERM. Engines
     # without background-task awareness leave this None.
     engine_state: Any = None
+    # #333 Task 4a: subprocess lifecycle state machine. One log per
+    # transition (``subprocess.state.<name>``) gives audits a permanent
+    # canary for hang-class issues even when sibling instrumentation
+    # misses an edge case. ``lifecycle_state`` is monotonic in practice
+    # but engines may skip states (e.g. ``streaming`` is skipped if the
+    # subprocess dies before the first JSONL line).
+    lifecycle_state: str = "spawned"
+    lifecycle_state_entered_at: float = 0.0
+    # #333 Task 4b: per-suppression-reason counter, summarised in
+    # ``session.summary``. Bumped by the bridge stall detector each
+    # tick a suppression branch fires (post_result, children_active,
+    # expected_wait). Plain dict (not defaultdict) so the slots-dataclass
+    # encoding stays trivial; bump via ``counts.get(k, 0) + 1``.
+    stall_suppression_counts: dict[str, int] = field(default_factory=dict)
 
 
 class JsonlSubprocessRunner(BaseRunner):
@@ -345,6 +359,48 @@ class JsonlSubprocessRunner(BaseRunner):
 
     def get_logger(self) -> Any:
         return getattr(self, "logger", get_logger(__name__))
+
+    def _transition_lifecycle(
+        self,
+        stream: JsonlStreamState,
+        new_state: str,
+        logger: Any,
+        *,
+        pid: int | None = None,
+        session_id: str | None = None,
+        **extra: Any,
+    ) -> None:
+        """Emit a ``subprocess.state.<new_state>`` info log and update the
+        stream's lifecycle pointer (Task 4a, #333).
+
+        Idempotent: if ``new_state`` matches the current ``lifecycle_state``
+        no log fires. Safe to call from anywhere — it never raises.
+        """
+        try:
+            if stream.lifecycle_state == new_state:
+                return
+            now = time.monotonic()
+            elapsed_since_last = (
+                round(now - stream.lifecycle_state_entered_at, 1)
+                if stream.lifecycle_state_entered_at
+                else None
+            )
+            prev = stream.lifecycle_state
+            stream.lifecycle_state = new_state
+            stream.lifecycle_state_entered_at = now
+            logger.info(
+                f"subprocess.state.{new_state}",
+                engine=getattr(self, "engine", None),
+                pid=pid,
+                session_id=session_id,
+                previous_state=prev,
+                elapsed_since_last_state_s=elapsed_since_last,
+                **extra,
+            )
+        except Exception:  # noqa: BLE001
+            # Lifecycle logging must never break a run.
+            with contextlib.suppress(Exception):
+                logger.debug("subprocess.state.transition_failed", exc_info=True)
 
     def command(self) -> str:
         raise NotImplementedError

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -915,6 +915,9 @@ class ProgressEdits:
         self._stuck_after_tool_result_recovery_enabled: bool = True
         self._stuck_after_tool_result_recovery_delay: float = 60.0
         self._stuck_state: _StuckAfterToolResultState | None = None
+        # #333 Tier 2: one-shot guard so we only log the limbo detection
+        # once per session, not on every 60 s stall tick.
+        self._post_result_limbo_logged: bool = False
         self.pid: int | None = None
         self.stream: Any = None  # JsonlStreamState, set from run_runner_with_cancel
         self.cancel_event: anyio.Event | None = None  # threaded from RunningTask
@@ -1155,13 +1158,47 @@ class ProgressEdits:
             _monitor_state = self._has_active_monitor()
             _bash_grace = self._has_recent_bash_action(self._bash_grace_seconds)
             _bash_fresh = self._has_fresh_bash_output(threshold / 2.0)
-            _expected_wait = (
+            # #333 Tier 2 (defense-in-depth): post-result idle alone is no
+            # longer enough to suppress auto-cancel indefinitely. The
+            # claude.py watchdog (Tier 1) should close the subprocess
+            # within ``post_result_idle_timeout + grace`` (≈ 660 s). If
+            # we're still in post-result idle past the limbo threshold
+            # AND no other expected-wait flag is set, treat as limbo and
+            # let auto-cancel fire. Older expected-wait suppression is
+            # preserved for the legitimate case (e.g. ScheduleWakeup, an
+            # active Monitor, or a long bash polling loop).
+            _post_result_age = self._post_result_idle_age_seconds()
+            _post_result_limbo = (
                 _post_result_idle
-                or _wakeup_state is not None
+                and _post_result_age is not None
+                and _post_result_age > self._POST_RESULT_LIMBO_THRESHOLD_S
+            )
+            _real_pending = (
+                _wakeup_state is not None
                 or _monitor_state is not None
                 or _bash_grace
                 or _bash_fresh
             )
+            _expected_wait = (
+                _post_result_idle and not _post_result_limbo
+            ) or _real_pending
+
+            # #333 Tier 2: one-shot warning when limbo is detected. This
+            # complements the claude.py watchdog's ``runner.limbo_detected``
+            # event from the runner side — both signals get picked up by
+            # ``untether-issue-watcher`` and indicate Tier 1 missed an
+            # edge case (subprocess wouldn't die to SIGTERM/SIGKILL, or
+            # the watchdog itself never ran).
+            if _post_result_limbo and not self._post_result_limbo_logged:
+                self._post_result_limbo_logged = True
+                logger.warning(
+                    "progress_edits.post_result_limbo_detected",
+                    channel_id=self.channel_id,
+                    pid=self.pid,
+                    post_result_age_s=round(_post_result_age or 0.0, 1),
+                    limbo_threshold_s=self._POST_RESULT_LIMBO_THRESHOLD_S,
+                    stall_warn_count=self._stall_warn_count,
+                )
 
             last_action = self._last_action_summary()
 
@@ -1643,6 +1680,29 @@ class ProgressEdits:
         if engine_state is None:
             return False
         return getattr(engine_state, "result_received_at", None) is not None
+
+    def _post_result_idle_age_seconds(self) -> float | None:
+        """#333 Tier 2: seconds since ``result_received_at`` was armed.
+
+        Returns None if not in post-result idle state. Used by the stall
+        detector to detect limbo — when the watchdog's post-result
+        countdown should have closed the subprocess but didn't.
+
+        Uses ``self.clock()`` (matches the bridge's clock injection) — in
+        production this is ``time.monotonic`` which is what claude.py uses
+        to set ``result_received_at``; in tests it's the fake clock so
+        ages line up with whatever the test driver advances.
+        """
+        stream = self.stream
+        if stream is None:
+            return None
+        engine_state = getattr(stream, "engine_state", None)
+        if engine_state is None:
+            return None
+        armed_at = getattr(engine_state, "result_received_at", None)
+        if armed_at is None:
+            return None
+        return self.clock() - armed_at
 
     def _has_pending_wakeup(self) -> tuple[float, int] | None:
         """#481: suppression — ScheduleWakeup with future deadline.
@@ -2248,6 +2308,13 @@ class ProgressEdits:
     _STALL_MAX_WARNINGS: int = 10  # absolute cap
     _STALL_MAX_WARNINGS_NO_PID: int = 3  # aggressive cap when pid=None + no events
     _TCP_ACTIVE_THRESHOLD: int = 20  # TCP connections above this suggest active work
+    # #333 Tier 2: post-result idle limbo threshold. The Claude watchdog
+    # (claude.py:_post_result_idle_watchdog + _post_result_subcountdown)
+    # closes the subprocess within ``post_result_idle_timeout`` (600 s) +
+    # 5 s SIGTERM grace + observation slack. If we're still in post-
+    # result idle past this point with no other expected-wait signal,
+    # Tier 1 missed an edge case — stop suppressing auto-cancel.
+    _POST_RESULT_LIMBO_THRESHOLD_S: float = 660.0
 
     async def on_event(self, evt: UntetherEvent) -> None:
         if not self.tracker.note_event(evt):

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -13,6 +13,7 @@ import os
 import pty
 import re
 import shutil
+import signal
 import subprocess as subprocess_module
 import time
 import tty
@@ -2057,6 +2058,12 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     _proc_stdin: Any | None = None  # PIPE stdin for control channel (permission mode)
     _control_timeout_seconds: float = CONTROL_REQUEST_TIMEOUT_SECONDS
     _max_pending_control_requests: int = 100
+    # #333 Tier 1 / Tier 3: subcountdown tuning constants. Class-level so
+    # tests can override via monkeypatch without touching production code.
+    _subcountdown_poll_interval_s: float = 5.0
+    _subcountdown_limbo_detect_threshold_s: float = 30.0
+    _subcountdown_sigterm_grace_s: float = 5.0
+    _subcountdown_sigterm_grace_poll_s: float = 0.5
 
     def format_resume(self, token: ResumeToken) -> str:
         if token.engine != ENGINE:
@@ -2657,6 +2664,8 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         reader_done: anyio.Event,
         run_logger: Any,
         timeout_s: float,
+        proc: Any = None,
+        stream: Any = None,
     ) -> None:
         """Close stdin once the bidirectional CLI has been idle past the result.
 
@@ -2714,10 +2723,58 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         )
         exit_reason = "loop_exited"
         try:
+            # #333 Tier 1 entry check: if ``reader_done`` is already set
+            # before the first poll (e.g. the JSONL reader finished
+            # extremely quickly), still run the subcountdown if the
+            # subprocess is alive. Mirrors the mid-loop check below.
+            if reader_done.is_set():
+                sid_now = (
+                    state.factory.resume.value
+                    if state.factory.resume is not None
+                    else None
+                )
+                if proc is not None and proc.returncode is None:
+                    exit_reason = await self._post_result_subcountdown(
+                        state=state,
+                        proc=proc,
+                        run_logger=run_logger,
+                        timeout_s=timeout_s,
+                        stream=stream,
+                        session_id=sid_now,
+                    )
+                    return
+                exit_reason = "reader_done"
+                return
             while not reader_done.is_set():
                 try:
                     await anyio.sleep(poll_interval)
                     if reader_done.is_set():
+                        # #333 Tier 1: the JSONL reader exhausted — either
+                        # because the subprocess emitted CompletedEvent and
+                        # is exiting (the happy path), or because Claude
+                        # Code v2.1.143 closed stdout while keeping the
+                        # subprocess alive (the limbo path). Before rc18
+                        # the watchdog returned here, bypassing the 600 s
+                        # countdown and leaving the subprocess + MCP
+                        # children to idle for 30+ min until the user
+                        # cancelled. Now we check if the subprocess is
+                        # still alive and, if so, enter a stdout-closed
+                        # subcountdown.
+                        sid_now = (
+                            state.factory.resume.value
+                            if state.factory.resume is not None
+                            else None
+                        )
+                        if proc is not None and proc.returncode is None:
+                            exit_reason = await self._post_result_subcountdown(
+                                state=state,
+                                proc=proc,
+                                run_logger=run_logger,
+                                timeout_s=timeout_s,
+                                stream=stream,
+                                session_id=sid_now,
+                            )
+                            return
                         exit_reason = "reader_done"
                         return
                     armed_at = state.result_received_at
@@ -2898,6 +2955,193 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 ),
                 reason=exit_reason,
             )
+
+    async def _post_result_subcountdown(
+        self,
+        *,
+        state: ClaudeStreamState,
+        proc: Any,
+        run_logger: Any,
+        timeout_s: float,
+        stream: Any = None,
+        session_id: str | None = None,
+    ) -> str:
+        """Watch a stdout-closed-but-process-alive subprocess (#333 Tier 1).
+
+        Entered when ``reader_done`` fires while ``proc.returncode is None`` —
+        the JSONL reader exhausted but the subprocess is still alive (Claude
+        Code v2.1.143 sometimes closes stdout without exiting). We wait up
+        to ``timeout_s`` for the subprocess to exit naturally; if it doesn't,
+        SIGTERM the process group, wait 5 s, then SIGKILL. Returns the
+        ``task_exited`` reason for the caller to record.
+
+        Tier 3: 30 s into the subcountdown, if the subprocess is still
+        alive and no real pending state references the session, emit
+        ``runner.limbo_detected`` warning. ``untether-issue-watcher``
+        picks this up automatically.
+        """
+        import os as _os
+
+        from ..utils.proc_diag import collect_proc_diag
+
+        reader_done_at = time.monotonic()
+        run_logger.info(
+            "claude.post_result_idle.reader_done_but_alive",
+            session_id=session_id,
+            pid=proc.pid,
+            elapsed_since_result_s=(
+                round(time.monotonic() - state.result_received_at, 1)
+                if state.result_received_at is not None
+                else None
+            ),
+            timeout_s=timeout_s,
+        )
+        if stream is not None:
+            self._transition_lifecycle(
+                stream, "reader_eof", run_logger, pid=proc.pid, session_id=session_id
+            )
+            self._transition_lifecycle(
+                stream,
+                "subcountdown",
+                run_logger,
+                pid=proc.pid,
+                session_id=session_id,
+                timeout_s=timeout_s,
+            )
+
+        # Poll loop: tick every ``_subcountdown_poll_interval_s`` up to
+        # ``timeout_s``, exit early if the subprocess dies naturally or
+        # pending state appears (in which case we re-arm and stay alive —
+        # the user is still interacting).
+        limbo_logged = False
+        deadline = reader_done_at + timeout_s
+        while True:
+            await anyio.sleep(self._subcountdown_poll_interval_s)
+            if proc.returncode is not None:
+                if stream is not None:
+                    self._transition_lifecycle(
+                        stream,
+                        "exited",
+                        run_logger,
+                        pid=proc.pid,
+                        session_id=session_id,
+                        rc=proc.returncode,
+                    )
+                return "subprocess_exited_during_subcountdown"
+
+            sid = (
+                state.factory.resume.value if state.factory.resume is not None else None
+            )
+            pending_requests = (
+                [k for k, v in _REQUEST_TO_SESSION.items() if v == sid] if sid else []
+            )
+            pending_asks = (
+                [k for k in _PENDING_ASK_REQUESTS if _REQUEST_TO_SESSION.get(k) == sid]
+                if sid
+                else []
+            )
+            if pending_requests or pending_asks:
+                # User is mid-interaction — re-arm the deadline so the
+                # subcountdown doesn't fire while a control_response is
+                # in flight. Match _post_result_idle_watchdog's deferred
+                # re-arm semantics (line 2843).
+                run_logger.info(
+                    "claude.post_result_idle.subcountdown_deferred",
+                    session_id=sid,
+                    pid=proc.pid,
+                    pending_requests=len(pending_requests),
+                    pending_asks=len(pending_asks),
+                )
+                deadline = time.monotonic() + timeout_s
+                continue
+
+            elapsed = time.monotonic() - reader_done_at
+            # Tier 3: limbo detection — a one-shot warning surfacing the
+            # condition for triage. ``untether-issue-watcher`` files this
+            # automatically on the next sweep.
+            if (
+                not limbo_logged
+                and elapsed >= self._subcountdown_limbo_detect_threshold_s
+            ):
+                limbo_logged = True
+                diag = collect_proc_diag(proc.pid)
+                run_logger.warning(
+                    "runner.limbo_detected",
+                    engine="claude",
+                    pid=proc.pid,
+                    session_id=sid,
+                    seconds_since_reader_done=round(elapsed, 1),
+                    seconds_since_last_result=(
+                        round(time.monotonic() - state.result_received_at, 1)
+                        if state.result_received_at is not None
+                        else None
+                    ),
+                    mcp_child_pids=list(diag.child_pids) if diag else [],
+                    rss_kb=diag.rss_kb if diag else None,
+                    tcp_total=diag.tcp_total if diag else None,
+                )
+                if stream is not None:
+                    self._transition_lifecycle(
+                        stream,
+                        "limbo",
+                        run_logger,
+                        pid=proc.pid,
+                        session_id=sid,
+                        seconds_since_reader_done=round(elapsed, 1),
+                    )
+
+            if time.monotonic() >= deadline:
+                # Timeout: SIGTERM the process group (start_new_session=True
+                # so PID == pgid). 5 s grace, then SIGKILL.
+                run_logger.warning(
+                    "claude.post_result_idle.sigterm_after_timeout",
+                    session_id=sid,
+                    pid=proc.pid,
+                    timeout_s=timeout_s,
+                    elapsed_s=round(elapsed, 1),
+                )
+                if stream is not None:
+                    self._transition_lifecycle(
+                        stream,
+                        "sigterm_sent",
+                        run_logger,
+                        pid=proc.pid,
+                        session_id=sid,
+                    )
+                with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                    _os.killpg(proc.pid, signal.SIGTERM)
+                # Give MCP children configured grace to clean up.
+                grace_deadline = time.monotonic() + self._subcountdown_sigterm_grace_s
+                while time.monotonic() < grace_deadline:
+                    await anyio.sleep(self._subcountdown_sigterm_grace_poll_s)
+                    if proc.returncode is not None:
+                        if stream is not None:
+                            self._transition_lifecycle(
+                                stream,
+                                "exited",
+                                run_logger,
+                                pid=proc.pid,
+                                session_id=sid,
+                                rc=proc.returncode,
+                            )
+                        return "reader_done_but_alive_timeout"
+                # Still alive — SIGKILL the group.
+                run_logger.warning(
+                    "claude.post_result_idle.sigkill_after_grace",
+                    session_id=sid,
+                    pid=proc.pid,
+                )
+                if stream is not None:
+                    self._transition_lifecycle(
+                        stream,
+                        "sigkill_sent",
+                        run_logger,
+                        pid=proc.pid,
+                        session_id=sid,
+                    )
+                with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                    _os.killpg(proc.pid, signal.SIGKILL)
+                return "reader_done_but_alive_timeout"
 
     def translate(
         self,
@@ -3209,6 +3453,8 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                             reader_done,
                             run_logger,
                             post_result_idle_timeout_s,
+                            proc,
+                            stream,
                         )
                     async for evt in self._iter_jsonl_events(
                         stdout=proc.stdout,

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import signal
 import time
 from datetime import UTC
 from pathlib import Path
@@ -3756,3 +3757,333 @@ def test_first_user_message_text_captured_in_new_state() -> None:
     )
     state = runner.new_state("user typed /loop X", None)
     assert state.first_user_message_text == "user typed /loop X"
+
+
+# ===========================================================================
+# #333 — post-result hang fix (Tier 1 watchdog subcountdown + Tier 3 limbo)
+# ===========================================================================
+
+
+class _FakeProc:
+    """Minimal anyio.Process stand-in for subcountdown tests.
+
+    Setting ``returncode`` to a non-None value simulates subprocess exit.
+    """
+
+    def __init__(self, pid: int = 99999, returncode: int | None = None):
+        self.pid = pid
+        self.returncode: int | None = returncode
+
+
+class _RecordingLogger:
+    """Capture structlog-style log events for assertions."""
+
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str, dict]] = []  # (level, event, kwargs)
+
+    def _record(self, level: str, *args: object, **kwargs: object) -> None:
+        event = str(args[0]) if args else kwargs.get("event", "")
+        self.records.append((level, str(event), dict(kwargs)))
+
+    def info(self, *a: object, **k: object) -> None:
+        self._record("info", *a, **k)
+
+    def warning(self, *a: object, **k: object) -> None:
+        self._record("warning", *a, **k)
+
+    def debug(self, *a: object, **k: object) -> None:
+        self._record("debug", *a, **k)
+
+    def error(self, *a: object, **k: object) -> None:
+        self._record("error", *a, **k)
+
+    def events(self, level: str | None = None) -> list[str]:
+        return [e for lvl, e, _ in self.records if level is None or lvl == level]
+
+
+@pytest.mark.anyio
+async def test_333_reader_done_but_alive_triggers_subcountdown(monkeypatch) -> None:
+    """#333 Tier 1: when reader_done fires while subprocess is still alive,
+    the watchdog must enter the subcountdown instead of returning early."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    # Speed up the subcountdown poll loop and SIGTERM grace for tests.
+    runner._subcountdown_poll_interval_s = 0.02
+    runner._subcountdown_limbo_detect_threshold_s = 0.05
+    runner._subcountdown_sigterm_grace_s = 0.1
+    runner._subcountdown_sigterm_grace_poll_s = 0.02
+
+    state = ClaudeStreamState()
+    state.factory.started(
+        ResumeToken(engine="claude", value="sub-sess-1"),
+    )
+    state.result_received_at = time.monotonic() - 0.5
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=42424, returncode=None)
+    killed_signals: list[int] = []
+
+    def _fake_killpg(pgid: int, sig: int) -> None:
+        killed_signals.append(sig)
+        # Simulate SIGTERM not stopping the process (so SIGKILL follows).
+        if sig == signal.SIGKILL:
+            proc.returncode = -9
+
+    monkeypatch.setattr("os.killpg", _fake_killpg)
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+
+    # Pre-fire reader_done so the entry check sees it and hands off to the
+    # subcountdown immediately.
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            0.1,  # 100 ms timeout — short enough for real-time test
+            proc,
+            stream,
+        )
+        # Wait for the subcountdown to fire SIGTERM (or until timeout).
+        with anyio.move_on_after(3.0):
+            while signal.SIGKILL not in killed_signals:
+                await anyio.sleep(0.02)
+        tg.cancel_scope.cancel()
+
+    events = logger.events()
+    assert "claude.post_result_idle.reader_done_but_alive" in events
+    assert signal.SIGTERM in killed_signals
+    assert signal.SIGKILL in killed_signals  # SIGTERM didn't stop our fake proc
+    exit_reasons = [
+        kw.get("reason")
+        for lvl, e, kw in logger.records
+        if e == "claude.post_result_idle.task_exited"
+    ]
+    assert "reader_done_but_alive_timeout" in exit_reasons
+
+
+@pytest.mark.anyio
+async def test_333_subprocess_exits_during_subcountdown(monkeypatch) -> None:
+    """#333 Tier 1: if the subprocess exits naturally during the subcountdown,
+    the watchdog records `subprocess_exited_during_subcountdown` and does NOT
+    SIGTERM."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.02
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="sub-sess-2"))
+    state.result_received_at = time.monotonic() - 0.5
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=42425, returncode=None)
+    killed_signals: list[int] = []
+
+    monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            5.0,  # plenty of time — subprocess should exit first
+            proc,
+            stream,
+        )
+        # Wait for the subcountdown to begin, then simulate subprocess exit.
+        await anyio.sleep(0.1)
+        proc.returncode = 0
+        # Wait for the watchdog to notice and record the exit reason.
+        with anyio.move_on_after(2.0):
+            while not any(
+                e == "claude.post_result_idle.task_exited" for _, e, _ in logger.records
+            ):
+                await anyio.sleep(0.02)
+        tg.cancel_scope.cancel()
+
+    assert killed_signals == []
+    exit_reasons = [
+        kw.get("reason")
+        for lvl, e, kw in logger.records
+        if e == "claude.post_result_idle.task_exited"
+    ]
+    assert "subprocess_exited_during_subcountdown" in exit_reasons
+
+
+@pytest.mark.anyio
+async def test_333_subcountdown_defers_on_pending_request(monkeypatch) -> None:
+    """#333 Tier 1: if pending control_request appears, subcountdown re-arms
+    instead of SIGTERMing (mirrors _post_result_idle_watchdog's deferred
+    re-arm)."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+
+    sid = "sub-sess-3"
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+    _REQUEST_TO_SESSION["req_x"] = sid
+    try:
+        runner = ClaudeRunner(claude_cmd="claude")
+        runner._subcountdown_poll_interval_s = 0.02
+
+        state = ClaudeStreamState()
+        state.factory.started(ResumeToken(engine="claude", value=sid))
+        state.result_received_at = time.monotonic() - 0.5
+        stream = JsonlStreamState(expected_session=None)
+
+        proc = _FakeProc(pid=42426, returncode=None)
+        killed_signals: list[int] = []
+
+        monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+
+        logger = _RecordingLogger()
+        reader_done = anyio.Event()
+        reader_done.set()
+
+        class FakeStdin:
+            async def aclose(self) -> None:
+                pass
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                runner._post_result_idle_watchdog,
+                state,
+                FakeStdin(),
+                reader_done,
+                logger,
+                0.05,  # tiny timeout — would normally trigger SIGTERM fast
+                proc,
+                stream,
+            )
+            # Let several poll cycles run. Each tick should see the pending
+            # request and defer rather than fire SIGTERM.
+            await anyio.sleep(0.4)
+            tg.cancel_scope.cancel()
+
+        assert killed_signals == [], (
+            "watchdog must defer SIGTERM while a control_request is pending"
+        )
+        deferred = [
+            e
+            for lvl, e, kw in logger.records
+            if e == "claude.post_result_idle.subcountdown_deferred"
+        ]
+        assert deferred, "expected subcountdown_deferred log to fire"
+    finally:
+        _REQUEST_TO_SESSION.clear()
+        _PENDING_ASK_REQUESTS.clear()
+
+
+@pytest.mark.anyio
+async def test_333_lifecycle_state_transitions_logged(monkeypatch) -> None:
+    """Task 4a: subprocess.state.* transitions emitted in the expected order
+    when the subcountdown fires."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.02
+    runner._subcountdown_sigterm_grace_s = 0.1
+    runner._subcountdown_sigterm_grace_poll_s = 0.02
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="state-sess"))
+    state.result_received_at = time.monotonic() - 0.5
+    stream = JsonlStreamState(expected_session=None)
+    assert stream.lifecycle_state == "spawned"
+
+    proc = _FakeProc(pid=42427, returncode=None)
+
+    def _fake_killpg(pgid: int, sig: int) -> None:
+        if sig == signal.SIGTERM:
+            proc.returncode = -15  # exit on SIGTERM
+
+    monkeypatch.setattr("os.killpg", _fake_killpg)
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            0.1,
+            proc,
+            stream,
+        )
+        with anyio.move_on_after(3.0):
+            while stream.lifecycle_state != "exited":
+                await anyio.sleep(0.02)
+        tg.cancel_scope.cancel()
+
+    state_events = [e for e in logger.events() if e.startswith("subprocess.state.")]
+    assert "subprocess.state.reader_eof" in state_events
+    assert "subprocess.state.subcountdown" in state_events
+    assert "subprocess.state.sigterm_sent" in state_events
+    assert "subprocess.state.exited" in state_events
+    # Final lifecycle_state reflects the last transition.
+    assert stream.lifecycle_state == "exited"

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -5722,9 +5722,11 @@ async def test_333_post_result_with_pending_wakeup_keeps_suppression() -> None:
     edits.cancel_event = cancel_event
 
     # post-result armed 100 s ago AND a ScheduleWakeup is still live.
-    import time as _t
-
-    future_deadline = _t.monotonic() + 60.0
+    # NOTE: deadline must be expressed in the fake clock's frame.
+    # ``time.monotonic()`` in fresh CI containers is small, so a
+    # real-time deadline can look already-expired against the fake
+    # clock's larger values (#333 Tier 2 test, CI vs local).
+    future_deadline = 1010.0 + 60.0
     es = _make_engine_state(
         result_received_at=900.0,
         live_wakeups={"toolu_w1": future_deadline},

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -5614,3 +5614,133 @@ async def test_heartbeat_mutates_schedule_wakeup_countdown() -> None:
     action_state = next(iter(edits.tracker._actions.values()))
     assert "countdown_s" in action_state.action.detail
     assert action_state.action.detail["countdown_s"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# #333 Tier 2 — post-result limbo lets auto-cancel fire when watchdog fails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_333_post_result_limbo_lets_auto_cancel_fire() -> None:
+    """#333 Tier 2: when post-result idle age exceeds the limbo threshold AND
+    no other expected-wait flag is set, the stall detector stops suppressing
+    auto-cancel. Defense-in-depth for the case where claude.py Tier 1
+    subcountdown failed to close the subprocess."""
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=1000.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits._STALL_THRESHOLD_TOOL = 0.05
+    edits._STALL_THRESHOLD_APPROVAL = 10.0
+    edits._stall_repeat_seconds = 0.0
+    edits._STALL_MAX_WARNINGS = 1
+    edits._POST_RESULT_LIMBO_THRESHOLD_S = 60.0
+    cancel_event = anyio.Event()
+    edits.cancel_event = cancel_event
+
+    # ``result_received_at`` set 100 s ago (> 60 s limbo threshold).
+    edits.stream = _make_stream(
+        last_event_type="result",
+        engine_state=_make_engine_state(result_received_at=900.0),
+    )
+
+    async with anyio.create_task_group() as tg:
+
+        async def drive() -> None:
+            clock.set(1010.0)  # 10 s after stall window opens
+            with anyio.move_on_after(1.0):
+                await cancel_event.wait()
+            edits.signal_send.close()
+
+        tg.start_soon(edits.run)
+        tg.start_soon(drive)
+
+    # Limbo detection logged + auto-cancel fired.
+    assert edits._post_result_limbo_logged is True
+    assert cancel_event.is_set()
+
+
+@pytest.mark.anyio
+async def test_333_post_result_below_limbo_threshold_still_suppresses() -> None:
+    """#333 Tier 2: within the limbo threshold, post-result idle still
+    suppresses auto-cancel (preserves existing behaviour for normal sessions
+    where the watchdog will close stdin shortly)."""
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=1000.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits._STALL_THRESHOLD_TOOL = 0.05
+    edits._STALL_THRESHOLD_APPROVAL = 10.0
+    edits._stall_repeat_seconds = 1000.0
+    edits._STALL_MAX_WARNINGS = 2
+    edits._POST_RESULT_LIMBO_THRESHOLD_S = 600.0
+    cancel_event = anyio.Event()
+    edits.cancel_event = cancel_event
+
+    # ``result_received_at`` 10 s ago (< 600 s limbo threshold).
+    edits.stream = _make_stream(
+        last_event_type="result",
+        engine_state=_make_engine_state(result_received_at=990.0),
+    )
+
+    async with anyio.create_task_group() as tg:
+
+        async def drive() -> None:
+            clock.set(1010.0)
+            await anyio.sleep(0.2)
+            edits.signal_send.close()
+
+        tg.start_soon(edits.run)
+        tg.start_soon(drive)
+
+    assert edits._post_result_limbo_logged is False
+    assert not cancel_event.is_set()
+
+
+@pytest.mark.anyio
+async def test_333_post_result_with_pending_wakeup_keeps_suppression() -> None:
+    """#333 Tier 2: even when post-result idle age exceeds the limbo
+    threshold, another active expected-wait signal (ScheduleWakeup here)
+    keeps auto-cancel suppressed."""
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=1000.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits._STALL_THRESHOLD_TOOL = 0.05
+    edits._STALL_THRESHOLD_APPROVAL = 10.0
+    edits._stall_repeat_seconds = 1000.0
+    edits._STALL_MAX_WARNINGS = 1
+    edits._POST_RESULT_LIMBO_THRESHOLD_S = 60.0
+    cancel_event = anyio.Event()
+    edits.cancel_event = cancel_event
+
+    # post-result armed 100 s ago AND a ScheduleWakeup is still live.
+    import time as _t
+
+    future_deadline = _t.monotonic() + 60.0
+    es = _make_engine_state(
+        result_received_at=900.0,
+        live_wakeups={"toolu_w1": future_deadline},
+    )
+    edits.stream = _make_stream(last_event_type="result", engine_state=es)
+
+    async with anyio.create_task_group() as tg:
+
+        async def drive() -> None:
+            clock.set(1010.0)
+            await anyio.sleep(0.2)
+            edits.signal_send.close()
+
+        tg.start_soon(edits.run)
+        tg.start_soon(drive)
+
+    # _real_pending was True (wakeup), so _expected_wait stays True even
+    # though _post_result_limbo also went True. Auto-cancel does NOT fire.
+    assert not cancel_event.is_set()


### PR DESCRIPTION
## Summary

PR #549 (rc17) added entry/exit/tick instrumentation to `_post_result_idle_watchdog`. That instrumentation caught the [#333](https://github.com/littlebearapps/untether/issues/333) post-result hang in the wild on channelo session `8876c902` (2026-05-17): **26.6 min limbo** between passes 5 and 6 of a `/monitor` watch.

**Root cause:** when Claude Code v2.1.143 closes stdout but keeps the subprocess alive, `_post_result_idle_watchdog` exited early via `task_exited reason=reader_done`, bypassing the 600 s countdown. Stall-detector suppression cascades (post_result + MCP-heartbeat-driven children-active) hid the limbo from auto-cancel indefinitely. Only `/cancel` broke it.

## What changed

**Tier 1 — `_post_result_subcountdown` (claude.py):** when `reader_done` fires while `proc.returncode is None`, enter a stdout-closed subcountdown. Poll for natural exit, defer if pending control_request / ask_question, SIGTERM the process group after `timeout_s`, 5 s grace, SIGKILL if still alive. New `task_exited` reasons: `reader_done_but_alive_timeout`, `subprocess_exited_during_subcountdown`.

**Tier 2 — stall-detector semantics (runner_bridge.py):** `_POST_RESULT_LIMBO_THRESHOLD_S = 660.0`. When post-result idle age > threshold AND no other expected-wait flag is set, stop suppressing auto-cancel. Defense-in-depth for the case where Tier 1 missed.

**Tier 3 — `runner.limbo_detected` warning (claude.py):** fired 30 s into the subcountdown when subprocess is still alive and no pending state holds the session open. Auto-filed as `auto:error-report` GitHub issues by `untether-issue-watcher`.

**Task 4a — subprocess state machine (runner.py + claude.py):** `JsonlStreamState.lifecycle_state` + `_transition_lifecycle()` helper. States emitted from the watchdog: `reader_eof`, `subcountdown`, `limbo`, `sigterm_sent`, `sigkill_sent`, `exited`. Permanent canary for future hang-class issues.

## Files

- `src/untether/runner.py` — JsonlStreamState fields + `_transition_lifecycle` helper
- `src/untether/runners/claude.py` — Tier 1 subcountdown, Tier 3 limbo warning, state machine integration, `signal` import
- `src/untether/runner_bridge.py` — Tier 2 limbo threshold + `_post_result_idle_age_seconds` helper
- `tests/test_claude_runner.py` — 4 new tests for Tier 1 + Task 4a
- `tests/test_exec_bridge.py` — 3 new tests for Tier 2

## Test plan

- [x] `uv run pytest` — 2678 passed, 2 skipped (was 2671 + 2 on `dev`; +7 new tests)
- [x] `uv run pytest tests/test_claude_runner.py tests/test_exec_bridge.py tests/test_claude_control.py -x -q` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run ruff check src/` clean
- [ ] **Tier 6 integration** on `@untether_dev_bot`: trigger a long MCP-heavy session, observe `subprocess.state.*` transitions in `journalctl --user -u untether-dev`; deliberate stdout-EOF-while-alive reproduction is the deterministic gate in unit tests. _(Pending rc18 build.)_

Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)