### PR TITLE
0.35.3rc19 — /monitor campaign issue sweep (10 commits)

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -128,6 +128,14 @@ voice_transcription_api_key = "gsk_..."   # SecretStr — masked in logs
 
 Groq's Whisper Large v3 Turbo is fast and cheap; any OpenAI-compatible Whisper endpoint works (including a self-hosted one). The API key is `SecretStr`-masked in `repr()` / `str()` / structlog so it never lands in journal or crash output. Full setup: [Voice notes](https://untether.littlebearapps.com/how-to/voice-notes/).
 
+## Do I need to restart Untether after editing `untether.toml`?
+
+No — almost everything in `untether.toml` hot-reloads automatically within ~1 second of saving the file. Untether watches the config file and re-applies changes in-place: cron and webhook triggers, watchdog timing, progress verbosity, voice-transcription settings, the allowed-user list, message timing, the file-transfer + outbox config, the `show_resume_line` toggle, and every per-engine override.
+
+The exceptions are a handful of restart-only keys that affect process bring-up: `bot_token`, `chat_id`, `session_mode`, `topics`, and `message_overflow`. If you edit one of those, Untether logs a `restart_required=true` warning, broadcasts a message to the active project chats, and you'll need to `systemctl --user restart untether` (or `/restart` from Telegram) to apply the change.
+
+**For agents:** after editing `untether.toml`, **do NOT run `systemctl restart untether` from inside an active agent session**. Untether already hot-reloaded the change; the restart is unnecessary and the graceful drain will time out (120s) trying to wait for your own session to finish, which silently drops your final answer message to the user. The reload-applied notification that arrives in the chat after your edit is your confirmation it took effect.
+
 ## How do I update Untether?
 
 If you installed with `uv`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.3rc18"
+version = "0.35.3rc19"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/untether/config_reload_notification.py
+++ b/src/untether/config_reload_notification.py
@@ -1,0 +1,129 @@
+"""Hot-reload notification formatting (#547 axis 2, #548).
+
+When ``config_watch`` successfully applies a change to ``untether.toml``,
+``handle_reload`` in ``telegram/loop.py`` uses these helpers to compose a
+short Telegram message that:
+
+1. Confirms the reload succeeded (closes the user's "did my edit work?"
+   feedback loop without making them switch to ``journalctl``).
+2. Frames "no restart needed" as the headline — the literal phrase agents
+   will tokenise and remember, which addresses the recurring
+   "edit-then-``systemctl restart``" pattern documented in #547. Restart
+   reflex is trained-in; the explicit framing flips it back.
+
+Three message shapes:
+
+- :func:`format_hot_reload_only_notice` — every changed key was applied
+  immediately. Headline: **No restart needed**.
+- :func:`format_restart_required_notice` — every changed key requires a
+  restart. Headline: **Restart required**.
+- :func:`format_partial_reload_notice` — mixed (some applied, some
+  restart-only). Headline: **Some keys need restart**.
+
+The headline is deliberately bold-emphasised; downstream agents read these
+messages in next-turn context and the framing materially changes whether
+they reach for ``systemctl restart`` after editing config.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = [
+    "format_hot_reload_only_notice",
+    "format_partial_reload_notice",
+    "format_reload_notification",
+    "format_restart_required_notice",
+]
+
+
+# Path display: strip the user's home prefix for compactness; absolute
+# paths in chat are visually noisy and the user always knows which file
+# was edited (there's only one ``untether.toml`` per instance).
+def _short_path(path: Path | str) -> str:
+    p = Path(path)
+    try:
+        return f"~/{p.relative_to(Path.home())}"
+    except ValueError:
+        return str(p)
+
+
+def format_hot_reload_only_notice(
+    *,
+    path: Path | str,
+    changed_keys: list[str],
+) -> str:
+    """Reload succeeded; all changes took effect immediately.
+
+    Headline contains the literal phrase ``No restart needed`` so agents
+    parsing this message in next-turn context don't reach for
+    ``systemctl restart``.
+    """
+    keys_str = ", ".join(f"`{k}`" for k in sorted(set(changed_keys))) or "(no keys)"
+    return (
+        f"♻️ **Hot-reloaded `{_short_path(path)}`** — change took effect immediately.\n"
+        f"**No restart needed.** Untether reloaded the file automatically.\n"
+        f"Changed: {keys_str}"
+    )
+
+
+def format_restart_required_notice(
+    *,
+    path: Path | str,
+    restart_keys: list[str],
+) -> str:
+    """A key in the restart-only set was edited; manual action required.
+
+    Headline contains the literal phrase ``Restart required``; restart-only
+    keys are explicitly named so the agent can advise the user (or revert
+    to a hot-reloadable equivalent).
+    """
+    keys_str = ", ".join(f"`{k}`" for k in sorted(set(restart_keys))) or "(no keys)"
+    return (
+        f"⚠️ **Restart required for `{_short_path(path)}` change** — "
+        f"the edited key is in the restart-only set.\n"
+        f"Run `systemctl --user restart untether` to apply, or revert and "
+        f"use the hot-reloadable equivalent.\n"
+        f"Restart-only keys touched: {keys_str}"
+    )
+
+
+def format_partial_reload_notice(
+    *,
+    path: Path | str,
+    hot_keys: list[str],
+    restart_keys: list[str],
+) -> str:
+    """Mixed reload — some keys applied immediately, others need restart."""
+    hot_str = ", ".join(f"`{k}`" for k in sorted(set(hot_keys))) or "(none)"
+    restart_str = ", ".join(f"`{k}`" for k in sorted(set(restart_keys))) or "(none)"
+    return (
+        f"♻️ **Partial reload of `{_short_path(path)}`** — "
+        f"{len(hot_keys)} of {len(hot_keys) + len(restart_keys)} keys "
+        f"applied immediately. **No restart needed for those.**\n"
+        f"Applied now: {hot_str}\n"
+        f"Need restart to apply: {restart_str}\n"
+        f"Run `systemctl --user restart untether` when ready (or revert the "
+        f"restart-only keys to a hot-reloadable equivalent)."
+    )
+
+
+def format_reload_notification(
+    *,
+    path: Path | str,
+    hot_keys: list[str],
+    restart_keys: list[str],
+) -> str:
+    """Dispatch to the right per-case helper based on what changed.
+
+    Public entry point used by ``telegram/loop.py:handle_reload``.
+    """
+    has_hot = bool(hot_keys)
+    has_restart = bool(restart_keys)
+    if has_restart and has_hot:
+        return format_partial_reload_notice(
+            path=path, hot_keys=hot_keys, restart_keys=restart_keys
+        )
+    if has_restart:
+        return format_restart_required_notice(path=path, restart_keys=restart_keys)
+    return format_hot_reload_only_notice(path=path, changed_keys=hot_keys)

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -288,6 +288,25 @@ def _should_auto_continue(
     return auto_continued_count < max_retries
 
 
+def _format_outbox_skipped_notice(skipped: list[tuple[str, str]]) -> str:
+    """#524: human-readable notice for outbox entries that were dropped
+    rather than delivered. Headline framing matches the agent's intent:
+    the user (and the agent reading in next-turn context) should see what
+    the agent meant to send and why it didn't ship.
+
+    Sorted by name, capped at 10 entries (rest collapsed to "...").
+    """
+    lines = ["\U0001f4ce Outbox skipped (unsupported / blocked):"]
+    items = sorted(skipped, key=lambda kv: kv[0])
+    cap = 10
+    for name, reason in items[:cap]:
+        suffix = "/" if reason == "directory" else ""
+        lines.append(f"- {name}{suffix} — {reason}")
+    if len(items) > cap:
+        lines.append(f"- … and {len(items) - cap} more")
+    return "\n".join(lines)
+
+
 def _format_auto_continue_notice(auto_continued_count: int) -> str:
     """#551 Tier 1: build the Telegram notice text shown when auto-continue
     fires. The 🔁 prefix distinguishes auto-resume from a fresh start so
@@ -310,6 +329,16 @@ _DEFAULT_PREAMBLE = (
     "- If hooks fire at session end, your final response MUST still contain the "
     "user's requested content. Hook concerns are secondary — briefly note them "
     "AFTER the main content, never instead of it.\n\n"
+    "Configuration changes (`untether.toml`):\n"
+    "- Untether hot-reloads `~/.untether/untether.toml` automatically — "
+    "edits take effect within ~1 second of saving.\n"
+    "- Do NOT run `systemctl --user restart untether` after editing config. "
+    "The restart is unnecessary, and because it shuts down the very session "
+    "issuing the command, the graceful drain will time out (120s) and your "
+    "final answer to the user will be silently dropped.\n"
+    "- Restart-only keys (`bot_token`, `chat_id`, `session_mode`, `topics`, "
+    "`message_overflow`) are flagged at reload time — if you didn't see "
+    "such a warning, no restart is needed.\n\n"
     "Plan-mode requirements (when you call `ExitPlanMode`):\n"
     "- Your `plan` parameter MUST be a concise 3–5 bullet summary of your "
     "findings, decisions, or proposed changes — never just a file path. "
@@ -930,6 +959,11 @@ class ProgressEdits:
         # #333 Tier 2: one-shot guard so we only log the limbo detection
         # once per session, not on every 60 s stall tick.
         self._post_result_limbo_logged: bool = False
+        # #526: pacing for the ``subprocess.approval_pending`` INFO event so
+        # an approval-waiting session emits at most every 30 min — gives
+        # operators a heartbeat without padding warn-filters with WARNs
+        # that would otherwise fire identically to genuine stalls.
+        self._last_approval_pending_emit_at: float = 0.0
         self.pid: int | None = None
         self.stream: Any = None  # JsonlStreamState, set from run_runner_with_cancel
         self.cancel_event: anyio.Event | None = None  # threaded from RunningTask
@@ -1221,26 +1255,58 @@ class ProgressEdits:
                 else None
             )
 
-            logger.warning(
-                "progress_edits.stall_detected",
-                channel_id=self.channel_id,
-                seconds_since_last_event=round(elapsed, 1),
-                last_event_seq=self.event_seq,
-                stall_warn_count=self._stall_warn_count,
-                pid=self.pid,
-                last_action=last_action,
-                last_event_type=(self.stream.last_event_type if self.stream else None),
-                process_alive=diag.alive if diag else None,
-                process_state=diag.state if diag else None,
-                tcp_established=diag.tcp_established if diag else None,
-                tcp_total=diag.tcp_total if diag else None,
-                rss_kb=diag.rss_kb if diag else None,
-                fd_count=diag.fd_count if diag else None,
-                cpu_active=cpu_active,
-                tree_active=tree_active,
-                recent_events=[(round(t, 1), lbl) for t, lbl in recent[-5:]],
-                stderr_hint=stderr_hint,
-            )
+            # #526: when the stall is the user reading the plan /
+            # deliberating on an approval, demote the WARN to a different
+            # structured INFO (``subprocess.approval_pending``) and pace it
+            # to once per 30 minutes. The chat-side rendering below still
+            # emits the friendly "⏳ Awaiting your approval (N min)" copy
+            # (#494-C) — operators just stop getting warn-filter spam for
+            # what is by definition not a hang. The daemon
+            # (``untether-issue-watcher``) and ``/monitor`` are configured
+            # to treat WARNs as auto-fileable, so this also stops
+            # spurious GitHub issue creation (closes #533).
+            if threshold_reason == "pending_approval":
+                _APPROVAL_PENDING_REFIRE_S = 1800.0
+                if (
+                    self._last_approval_pending_emit_at == 0.0
+                    or now - self._last_approval_pending_emit_at
+                    >= _APPROVAL_PENDING_REFIRE_S
+                ):
+                    self._last_approval_pending_emit_at = now
+                    logger.info(
+                        "subprocess.approval_pending",
+                        channel_id=self.channel_id,
+                        engine=getattr(self.tracker, "engine", None),
+                        pid=self.pid,
+                        seconds_since_last_event=round(elapsed, 1),
+                        last_action=last_action,
+                        recent_events=[(round(t, 1), lbl) for t, lbl in recent[-3:]],
+                        approval_pending=True,
+                    )
+            else:
+                logger.warning(
+                    "progress_edits.stall_detected",
+                    channel_id=self.channel_id,
+                    seconds_since_last_event=round(elapsed, 1),
+                    last_event_seq=self.event_seq,
+                    stall_warn_count=self._stall_warn_count,
+                    pid=self.pid,
+                    last_action=last_action,
+                    last_event_type=(
+                        self.stream.last_event_type if self.stream else None
+                    ),
+                    process_alive=diag.alive if diag else None,
+                    process_state=diag.state if diag else None,
+                    tcp_established=diag.tcp_established if diag else None,
+                    tcp_total=diag.tcp_total if diag else None,
+                    rss_kb=diag.rss_kb if diag else None,
+                    fd_count=diag.fd_count if diag else None,
+                    cpu_active=cpu_active,
+                    tree_active=tree_active,
+                    recent_events=[(round(t, 1), lbl) for t, lbl in recent[-5:]],
+                    stderr_hint=stderr_hint,
+                    approval_pending=False,
+                )
 
             # Auto-cancel: dead process, no-PID zombie, or absolute cap.
             # #470/#481: when an expected-wait state is active, skip the
@@ -3319,7 +3385,7 @@ async def handle_message(
         if _run_root is not None:
             _oc = cfg.outbox_config
             try:
-                await deliver_outbox_files(
+                _outbox_result = await deliver_outbox_files(
                     send_file=cfg.send_file,
                     channel_id=incoming.channel_id,
                     thread_id=incoming.thread_id,
@@ -3333,3 +3399,34 @@ async def handle_message(
                 )
             except Exception:  # noqa: BLE001
                 logger.warning("outbox.delivery_failed", exc_info=True)
+                _outbox_result = None
+
+            # #524: surface skipped items so the agent's "I prepared the
+            # guides folder for you" final message doesn't become a silent
+            # lie. The "..." pseudo-entry is the max-files-exceeded notice
+            # which we keep in logs but skip from the user-facing block
+            # (the per-file reason there isn't actionable).
+            if (
+                _outbox_result is not None
+                and _outbox_result.skipped
+                and getattr(_oc, "outbox_notify_skipped", True)
+            ):
+                notable_skipped = [
+                    (name, reason)
+                    for (name, reason) in _outbox_result.skipped
+                    if name != "..."
+                ]
+                if notable_skipped:
+                    skipped_text = _format_outbox_skipped_notice(notable_skipped)
+                    try:
+                        await cfg.transport.send(
+                            channel_id=incoming.channel_id,
+                            message=RenderedMessage(text=skipped_text, extra={}),
+                            options=SendOptions(
+                                reply_to=user_ref,
+                                notify=False,
+                                thread_id=incoming.thread_id,
+                            ),
+                        )
+                    except Exception:  # noqa: BLE001
+                        logger.warning("outbox.skipped_notice_failed", exc_info=True)

--- a/src/untether/runtime_loader.py
+++ b/src/untether/runtime_loader.py
@@ -80,21 +80,29 @@ def build_router(
     default_engine: str,
 ) -> AutoRouter:
     entries: list[RunnerEntry] = []
-    warnings: list[str] = []
+    # #532: per-issue (engine_id, issue_text, had_user_config) tuples so we
+    # can emit ONE summary line + a focused WARN only for engines the user
+    # actually configured. Previously every non-default engine without a CLI
+    # on PATH fired its own WARN on every config.reload — 5xN log spam on
+    # any single-engine host (e.g. channelo runs only claude).
+    issues: list[tuple[str, str, bool]] = []
 
     for backend in backends:
         engine_id = backend.id
         issue: str | None = None
         status: EngineStatus = "ok"
         engine_cfg: dict
+        had_user_config = False
         try:
             engine_cfg = settings.engine_config(engine_id, config_path=config_path)
+            had_user_config = bool(engine_cfg)
         except ConfigError as exc:
             if engine_id == default_engine:
                 raise
             issue = str(exc)
             status = "bad_config"
             engine_cfg = {}
+            had_user_config = True  # they tried to configure it, just badly
 
         try:
             runner = backend.build_runner(engine_cfg, config_path)
@@ -106,12 +114,14 @@ def build_router(
                 try:
                     runner = backend.build_runner({}, config_path)
                 except Exception as fallback_exc:  # noqa: BLE001
-                    warnings.append(f"{engine_id}: {issue or str(fallback_exc)}")
+                    issues.append(
+                        (engine_id, issue or str(fallback_exc), had_user_config)
+                    )
                     continue
                 status = "bad_config"
             else:
                 status = "load_error"
-                warnings.append(f"{engine_id}: {issue}")
+                issues.append((engine_id, issue, had_user_config))
                 continue
 
         cmd = backend.cli_cmd or backend.id
@@ -126,7 +136,7 @@ def build_router(
             raise ConfigError(f"Default engine {engine_id!r} unavailable: {issue}")
 
         if status != "ok" and engine_id != default_engine:
-            warnings.append(f"{engine_id}: {issue}")
+            issues.append((engine_id, issue or "unknown", had_user_config))
 
         entries.append(
             RunnerEntry(
@@ -137,10 +147,53 @@ def build_router(
             )
         )
 
-    for warning in warnings:
-        logger.warning("setup.warning", issue=warning)
+    _log_setup_summary(entries, issues, default_engine)
 
     return AutoRouter(entries=entries, default_engine=default_engine)
+
+
+def _log_setup_summary(
+    entries: list[RunnerEntry],
+    issues: list[tuple[str, str, bool]],
+    default_engine: str,
+) -> None:
+    """#532: one INFO summary per reload + focused WARN per engine the user
+    has actively configured.
+
+    The previous behaviour emitted ``[warning] setup.warning`` per missing
+    engine on every ``config.reload.applied``. On a single-engine host that
+    is 5 WARNs per reload, padding warn/error filters in
+    untether-issue-watcher, /monitor, and Grafana with intentional install
+    state.
+    """
+    found = sorted(e.engine for e in entries if e.status == "ok")
+    missing_on_path = sorted(
+        engine for engine, issue, _ in issues if "not found on PATH" in issue
+    )
+    bad_config = sorted(
+        engine for engine, issue, _ in issues if "not found on PATH" not in issue
+    )
+
+    # Always emit the summary — single line, INFO, intentional state.
+    logger.info(
+        "setup.summary",
+        default_engine=default_engine,
+        found=found,
+        missing_on_path=missing_on_path,
+        bad_config=bad_config,
+    )
+
+    # Loud WARN only for engines the user actually tried to configure.
+    # Engines with no [engines.<id>] block in untether.toml are not
+    # interesting — the user didn't ask for them.
+    for engine_id, issue, had_user_config in issues:
+        if had_user_config:
+            logger.warning(
+                "setup.warning",
+                engine=engine_id,
+                issue=issue,
+                reason="user-configured engine has issue",
+            )
 
 
 def load_backends(
@@ -162,8 +215,11 @@ def load_backends(
         backends.append(backend)
     if not backends:
         raise ConfigError("No engine backends are available.")
+    # #532: backend-load failures are rare (entry-point install issues, plugin
+    # allowlist gates) so a per-issue INFO is plenty; the corresponding WARN
+    # for user-selected engines will come from build_router downstream.
     for issue in load_issues:
-        logger.warning("setup.warning", issue=issue)
+        logger.info("setup.backend_load_skipped", issue=issue)
     return backends
 
 

--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -75,6 +75,11 @@ class TelegramFilesSettings(BaseModel):
     outbox_dir: NonEmptyStr = ".untether-outbox"
     outbox_max_files: int = Field(default=10, ge=1, le=50)
     outbox_cleanup: bool = True
+    # #524: surface "skipped" outbox entries (directories, oversized files,
+    # deny-globbed files, …) to the user in chat. Previously these were
+    # logged as ``outbox.skipped`` only — the agent's "I've prepared the
+    # guides folder for you" final message became a silent lie.
+    outbox_notify_skipped: bool = True
 
     @field_validator("uploads_dir")
     @classmethod

--- a/src/untether/telegram/client.py
+++ b/src/untether/telegram/client.py
@@ -332,22 +332,58 @@ class TelegramClient:
         text: str | None = None,
         show_alert: bool | None = None,
     ) -> bool:
-        async def execute() -> bool:
+        """Acknowledge a Telegram callback query.
+
+        #546: callback answers are bypassed around the per-chat send outbox
+        so they don't queue behind ``send_message``/``edit_message_text``
+        ops. Rapid taps (e.g. approving plans in two chats inside ~2 s)
+        previously saw the 2nd/3rd answer escalate from the ~220 ms HTTP
+        baseline to 1.4-2.9 s because each callback also blocked on the
+        ``_next_at[None]`` 1.0 s pacing bucket shared with other chat-less
+        ops. Telegram does NOT rate-limit ``answerCallbackQuery`` per chat
+        (it keys off callback-query-id) so the outbox pacing was always
+        the wrong abstraction for this call.
+
+        We still benefit from the underlying ``_client.answer_callback_query``'s
+        retry-after handling for ``RetryAfter``; the outbox detour just adds
+        latency on top of the HTTP round-trip without protecting against
+        anything Telegram actually enforces here.
+        """
+        start = time.monotonic()
+        try:
             return await self._client.answer_callback_query(
                 callback_query_id=callback_query_id,
                 text=text,
                 show_alert=show_alert,
             )
-
-        return bool(
-            await self.enqueue_op(
-                key=self.unique_key("answer_callback_query"),
-                label="answer_callback_query",
-                execute=execute,
-                priority=SEND_PRIORITY,
-                chat_id=None,
+        except TelegramRetryAfter as exc:
+            # Telegram asked us to back off — re-attempt once after the
+            # requested delay. If still rate-limited, fail fast: the
+            # spinner will expire naturally within 30 s, and double-
+            # delivery here is worse than user re-tapping.
+            await self._sleep(exc.retry_after)
+            try:
+                return await self._client.answer_callback_query(
+                    callback_query_id=callback_query_id,
+                    text=text,
+                    show_alert=show_alert,
+                )
+            except TelegramRetryAfter:
+                logger.warning(
+                    "telegram.answer_callback_query.retry_exhausted",
+                    callback_query_id=callback_query_id,
+                    total_ms=round((time.monotonic() - start) * 1000, 1),
+                )
+                return False
+        except Exception as exc:  # noqa: BLE001 — match outbox behaviour
+            logger.error(
+                "telegram.answer_callback_query.failed",
+                callback_query_id=callback_query_id,
+                error=str(exc),
+                error_type=exc.__class__.__name__,
+                total_ms=round((time.monotonic() - start) * 1000, 1),
             )
-        )
+            return False
 
     async def get_chat(self, chat_id: int) -> Chat | None:
         async def execute() -> Chat | None:

--- a/src/untether/telegram/commands/cancel.py
+++ b/src/untether/telegram/commands/cancel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 from ...logging import get_logger
@@ -14,6 +15,38 @@ if TYPE_CHECKING:
     from ..bridge import TelegramBridgeConfig
 
 logger = get_logger(__name__)
+
+
+# #525: rapid double/triple-tap of the inline Cancel button (or any path that
+# can race onto the same progress message within a second) caused
+# ``cancel.requested`` to fire three times for one user intent. Telegram
+# delivered duplicate callbacks before the keyboard could be cleared; the
+# downstream effect of repeat ``cancel_requested.set()`` is benign today, but
+# the log noise + duplicate-dispatch hazard (any future side-effectful cancel
+# action would inherit a 3x fan-out) warranted hardening.
+#
+# A 1-second TTL keyed on (chat_id, progress_message_id) is enough to dedupe
+# the human-tap window without affecting legitimate retries seconds later
+# (e.g. user types ``/cancel`` after the keyboard already dismissed).
+_CANCEL_DEDUP_TTL_S = 1.0
+_RECENT_CANCELS: dict[tuple[int, int], float] = {}
+
+
+def _claim_cancel(chat_id: int, message_id: int) -> bool:
+    """Return ``True`` if this cancel is the first fire within TTL, else
+    ``False`` (caller should silently drop the duplicate). Side-effect: GCs
+    expired entries.
+    """
+    now = time.monotonic()
+    cutoff = now - _CANCEL_DEDUP_TTL_S
+    # Best-effort GC: cheap because dict is keyed per active progress message.
+    for k in [k for k, t in _RECENT_CANCELS.items() if t < cutoff]:
+        _RECENT_CANCELS.pop(k, None)
+    key = (chat_id, message_id)
+    if key in _RECENT_CANCELS:
+        return False
+    _RECENT_CANCELS[key] = now
+    return True
 
 
 async def handle_cancel(
@@ -36,6 +69,14 @@ async def handle_cancel(
         ]
         if len(matches) == 1:
             ref, task = matches[0]
+            if not _claim_cancel(chat_id, ref.message_id):
+                logger.debug(
+                    "cancel.deduped",
+                    chat_id=chat_id,
+                    progress_message_id=ref.message_id,
+                    source="text-fallback",
+                )
+                return
             logger.info(
                 "cancel.requested", chat_id=chat_id, progress_message_id=ref.message_id
             )
@@ -113,6 +154,14 @@ async def handle_cancel(
         await reply(text="nothing is currently running for that message.")
         return
 
+    if not _claim_cancel(chat_id, reply_id):
+        logger.debug(
+            "cancel.deduped",
+            chat_id=chat_id,
+            progress_message_id=reply_id,
+            source="text-reply",
+        )
+        return
     logger.info(
         "cancel.requested",
         chat_id=chat_id,
@@ -166,6 +215,21 @@ async def handle_callback_cancel(
         await cfg.bot.answer_callback_query(
             callback_query_id=query.callback_query_id,
             text="nothing is currently running for that message.",
+        )
+        return
+    if not _claim_cancel(query.chat_id, query.message_id):
+        logger.debug(
+            "cancel.deduped",
+            chat_id=query.chat_id,
+            progress_message_id=query.message_id,
+            source="callback",
+        )
+        # Still ACK the callback to clear the user's spinner — Telegram
+        # delivered an extra tap event; silently dropping the dedup'd
+        # action while ACKing keeps the UX smooth.
+        await cfg.bot.answer_callback_query(
+            callback_query_id=query.callback_query_id,
+            text="cancelling...",
         )
         return
     logger.info(

--- a/src/untether/telegram/commands/dispatch.py
+++ b/src/untether/telegram/commands/dispatch.py
@@ -233,15 +233,25 @@ async def _dispatch_callback(
     async def _answer_callback(text: str | None = None, *, early: bool = False) -> None:
         nonlocal _answered
         if callback_query_id is not None and not _answered:
+            # #546: latency_ms now isolates the HTTP round-trip alone — as of
+            # rc19, ``answer_callback_query`` no longer queues behind the
+            # per-chat send outbox. The ``queue_wait_ms=0`` field is kept
+            # explicit so monitoring dashboards can confirm the queue path
+            # was indeed bypassed; if a regression accidentally routes
+            # callback answers through the outbox again, this stays at 0
+            # and a separate ``telegram.outbox.op.completed`` debug line
+            # would appear instead.
             start = time.monotonic()
             await cfg.bot.answer_callback_query(callback_query_id, text=text)
             _answered = True
+            now = time.monotonic()
             logger.info(
                 "callback.answered",
                 command=command_id,
                 chat_id=chat_id,
-                latency_ms=round((time.monotonic() - start) * 1000, 1),
-                total_ms=round((time.monotonic() - dispatch_start) * 1000, 1),
+                latency_ms=round((now - start) * 1000, 1),
+                queue_wait_ms=0.0,
+                total_ms=round((now - dispatch_start) * 1000, 1),
                 early=early,
                 has_toast=text is not None,
             )

--- a/src/untether/telegram/commands/parse.py
+++ b/src/untether/telegram/commands/parse.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Container
+
 
 def is_cancel_command(text: str) -> bool:
     stripped = text.strip()
@@ -28,3 +30,35 @@ def _parse_slash_command(text: str) -> tuple[str | None, str]:
         tail = "\n".join(lines[1:])
         args_text = f"{args_text}\n{tail}" if args_text else tail
     return command.lower(), args_text
+
+
+# #523: `.new` and similar leading-dot typos used to dispatch a full agent
+# subprocess (full OAuth handshake, preamble, MCP catalog probe) before the
+# user could cancel — wasting a non-trivial per-run cold-start cost. `.` and
+# `/` are adjacent on iOS/Android punctuation rows, and several keyboards
+# auto-replace a leading `/` with `.`.
+def parse_dot_typo(text: str, known_commands: Container[str]) -> str | None:
+    """Return the registered command name if ``text`` looks like a typo of
+    ``/<cmd>`` (i.e. begins with ``.<cmd>`` with no whitespace before the
+    command and ``<cmd>`` is a known slash command). Else ``None``.
+
+    Only fires on simple shapes ``.cmd`` or ``.cmd args``. Multi-line and
+    sentence-shaped inputs are left alone (they'd usually be real prose
+    that happens to start with a dot, e.g. ``..wait, what?``).
+    """
+    if not text:
+        return None
+    stripped = text.lstrip()
+    if not stripped.startswith("."):
+        return None
+    if stripped.startswith(("..", "./")):
+        # Multi-dot ellipsis or a literal path; not a command typo.
+        return None
+    first_line = stripped.splitlines()[0]
+    token, _, _ = first_line.partition(" ")
+    cmd = token[1:].lower()
+    if not cmd or not cmd.isidentifier():
+        return None
+    if cmd in known_commands:
+        return cmd
+    return None

--- a/src/untether/telegram/loop.py
+++ b/src/untether/telegram/loop.py
@@ -54,7 +54,7 @@ from .commands.handlers import (
     set_command_menu,
     should_show_resume_line,
 )
-from .commands.parse import is_cancel_command
+from .commands.parse import is_cancel_command, parse_dot_typo
 from .commands.reply import make_reply
 from .context import _merge_topic_context, _usage_ctx_set, _usage_topic
 from .engine_defaults import resolve_engine_for_message
@@ -86,6 +86,17 @@ _SEEN_MESSAGES_LIMIT = 2048
 _SEEN_UPDATES_LIMIT = 4096
 
 _handle_file_put_default = handle_file_put_default
+
+# #528: AskUserQuestion text-reply echo. Earlier versions hard-sliced at
+# [:100] which truncated mid-word with no ellipsis; the agent always
+# received the full reply but the user couldn't see it in the chat.
+_ANSWERED_ECHO_MAX = 300
+
+
+def _format_answered_echo(text: str) -> str:
+    if len(text) <= _ANSWERED_ECHO_MAX:
+        return f"↩️ Answered: {text}"
+    return f"↩️ Answered: {text[: _ANSWERED_ECHO_MAX - 1]}…"
 
 
 def _chat_session_key(
@@ -236,6 +247,65 @@ async def _notify_restart_required(cfg: TelegramBridgeConfig, keys: list[str]) -
     logger.info(
         "config.reload.restart_notify.sent",
         keys=keys,
+        targets=sorted(targets),
+        sent_count=sent_count,
+    )
+
+
+async def _notify_reload_applied(
+    cfg: TelegramBridgeConfig,
+    *,
+    path: Path,
+    hot_keys: list[str],
+    restart_keys: list[str],
+) -> None:
+    """#547 axis 2 / #548: broadcast a hot-reload confirmation message so
+    agents and users see "did my edit work?" answered in-chat (instead of
+    having to switch to ``journalctl``). The headline framing ("No restart
+    needed.") flips the trained-in agent reflex to ``systemctl restart``
+    after editing config.
+
+    Reuses the same broadcast pattern as ``_notify_restart_required``: send
+    to every active project chat + admin DMs, falling back to
+    ``cfg.chat_id`` if no routed targets exist. Per-chat failures are
+    logged and skipped — one bad chat can't mask the affirmation from
+    the rest.
+    """
+    if not hot_keys and not restart_keys:
+        return
+    from ..config_reload_notification import format_reload_notification
+
+    text = format_reload_notification(
+        path=path, hot_keys=hot_keys, restart_keys=restart_keys
+    )
+    targets: set[int] = set()
+    targets.update(cfg.runtime.project_chat_ids())
+    targets.update(cfg.allowed_user_ids or ())
+    if not targets:
+        targets.add(cfg.chat_id)
+    sent_count = 0
+    for chat_id in sorted(targets):
+        try:
+            sent = await cfg.exec_cfg.transport.send(
+                channel_id=chat_id,
+                message=RenderedMessage(
+                    text=text,
+                    extra={"parse_mode": "Markdown"},
+                ),
+                options=SendOptions(notify=False),  # non-disruptive
+            )
+            if sent is not None:
+                sent_count += 1
+        except Exception as exc:  # noqa: BLE001 — logged then continue
+            logger.warning(
+                "config.reload.applied_notify.failed",
+                chat_id=chat_id,
+                error=str(exc),
+            )
+    logger.info(
+        "config.reload.applied_notify.sent",
+        hot_keys=hot_keys,
+        restart_keys=restart_keys,
         targets=sorted(targets),
         sent_count=sent_count,
     )
@@ -1396,6 +1466,12 @@ async def run_main_loop(
                 refresh_commands()
                 refresh_topics_scope()
                 await set_command_menu(cfg)
+                # #547 axis 2 / #548: accumulate the keys that actually
+                # changed in this reload so the broadcast at the end of
+                # handle_reload can tell the user (and any agent reading
+                # in next-turn context) whether a restart is required.
+                _reload_hot_keys: list[str] = []
+                _reload_restart_keys: list[str] = []
                 if state.transport_snapshot is not None:
                     new_snapshot = reload.settings.transports.telegram.model_dump()
                     changed = _diff_keys(state.transport_snapshot, new_snapshot)
@@ -1408,6 +1484,8 @@ async def run_main_loop(
                         restart_only = TelegramTransportSettings.RESTART_REQUIRED_FIELDS
                         restart_keys = [k for k in changed if k in restart_only]
                         hot_keys = [k for k in changed if k not in restart_only]
+                        _reload_hot_keys.extend(hot_keys)
+                        _reload_restart_keys.extend(restart_keys)
                         if restart_keys:
                             logger.warning(
                                 "config.reload.transport_config_changed",
@@ -1448,6 +1526,26 @@ async def run_main_loop(
                         restart_required=True,
                     )
                     state.transport_id = reload.settings.transport
+
+                # #547 axis 2 / #548: broadcast the affirmative
+                # "Hot-reloaded — No restart needed." (or, if any
+                # restart-only key was edited, the matching
+                # "Restart required" / "Partial reload" message). The
+                # headline framing flips the trained-in agent reflex to
+                # ``systemctl restart`` after editing config; agents read
+                # this message in next-turn context and adapt.
+                if _reload_hot_keys or _reload_restart_keys:
+                    try:
+                        await _notify_reload_applied(
+                            cfg,
+                            path=reload.config_path,
+                            hot_keys=_reload_hot_keys,
+                            restart_keys=_reload_restart_keys,
+                        )
+                    except Exception:  # noqa: BLE001 — never break reload
+                        logger.warning(
+                            "config.reload.applied_notify.crashed", exc_info=True
+                        )
 
                 # --- Hot-reload trigger configuration ---
                 if trigger_manager is not None:
@@ -2375,7 +2473,7 @@ async def run_main_loop(
                                 flow.request_id
                             )
                             if success:
-                                await reply(text=f"↩️ Answered: {text[:100]}")
+                                await reply(text=_format_answered_echo(text))
                             return
 
                     pending_ask = get_pending_ask_request(channel_id=msg.chat_id)
@@ -2388,8 +2486,41 @@ async def run_main_loop(
                         )
                         success = await answer_ask_question(ask_req_id, text)
                         if success:
-                            await reply(text=f"↩️ Answered: {text[:100]}")
+                            await reply(text=_format_answered_echo(text))
                             return
+
+                # #523: catch `.new`-style leading-dot typos for slash
+                # commands and surface a hint instead of dispatching a
+                # full agent subprocess (which costs the per-run cold-
+                # start of OAuth handshake + MCP catalog probe + preamble
+                # injection, then leaves the user to cancel).
+                # Only fires for plain text inputs (not voice transcripts
+                # or document captions) so user-typed prose like
+                # ``.new project idea: ...`` stays out of the heuristic.
+                if (
+                    not is_voice_transcribed
+                    and msg.voice is None
+                    and msg.document is None
+                ):
+                    typo_cmd = parse_dot_typo(
+                        text, state.command_ids | state.reserved_chat_commands
+                    )
+                    if typo_cmd is not None:
+                        logger.info(
+                            "command.dot_typo.suppressed",
+                            chat_id=chat_id,
+                            typed=text[:40],
+                            command=typo_cmd,
+                        )
+                        await reply(
+                            text=(
+                                f"Did you mean `/{typo_cmd}`? "
+                                f"(The leading `.` looks like a typo for `/`.)\n\n"
+                                f"Re-send with the slash if you meant the command, "
+                                f"or rephrase to send to the agent."
+                            )
+                        )
+                        return
 
                 pending = _PendingPrompt(
                     msg=msg,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,3 +26,21 @@ def make_cfg() -> Callable[..., TelegramBridgeConfig]:
         return build_cfg(transport, runner)
 
     return _factory
+
+
+@pytest.fixture(autouse=True)
+def _clear_cancel_dedup() -> None:
+    """#525: ``_RECENT_CANCELS`` is module-level state that persists across
+    tests. Without an explicit clear, two tests using the same
+    ``(chat_id, progress_message_id)`` pair within ~1 second wall-clock
+    would have the second see a "duplicate" and silently drop the
+    cancel — confusing for the test author.
+
+    Auto-clearing per-test keeps the tests independent. The dedup
+    behaviour itself is exercised by ``tests/test_cancel_dedup.py``.
+    """
+    from untether.telegram.commands.cancel import _RECENT_CANCELS
+
+    _RECENT_CANCELS.clear()
+    yield
+    _RECENT_CANCELS.clear()

--- a/tests/test_cancel_dedup.py
+++ b/tests/test_cancel_dedup.py
@@ -1,0 +1,109 @@
+"""#525: triple-fire dedup for the inline Cancel button + text-reply paths.
+
+Telegram delivered duplicate callbacks for the same tap when the user
+double/triple-tapped the inline Cancel button before the keyboard could be
+cleared. Repeat ``cancel.requested`` fires were benign today (cancel just
+worked once and the duplicate set() was a no-op) but log noise + future
+side-effectful cancel actions (telemetry, webhook, structured cancel hook)
+would inherit the 3x fan-out. A 1-second TTL dedup keyed on
+(chat_id, progress_message_id) prevents this without affecting legitimate
+later retries.
+"""
+
+from __future__ import annotations
+
+import time
+
+from untether.telegram.commands.cancel import (
+    _CANCEL_DEDUP_TTL_S,
+    _RECENT_CANCELS,
+    _claim_cancel,
+)
+
+
+def setup_function() -> None:
+    _RECENT_CANCELS.clear()
+
+
+def teardown_function() -> None:
+    _RECENT_CANCELS.clear()
+
+
+def test_first_claim_returns_true() -> None:
+    assert _claim_cancel(-5235455627, 51263) is True
+
+
+def test_immediate_second_claim_returns_false() -> None:
+    assert _claim_cancel(-5235455627, 51263) is True
+    assert _claim_cancel(-5235455627, 51263) is False
+
+
+def test_triple_fire_within_one_second_dedupes_to_one() -> None:
+    """Reproduces the #525 evidence: three cancels at +0ms, +493ms, +512ms."""
+    chat_id = -5235455627
+    msg_id = 51263
+    fires = [_claim_cancel(chat_id, msg_id) for _ in range(3)]
+    assert fires == [True, False, False]
+
+
+def test_different_messages_in_same_chat_each_get_one_fire() -> None:
+    chat_id = -5235455627
+    assert _claim_cancel(chat_id, 51263) is True
+    assert _claim_cancel(chat_id, 51264) is True  # different message
+    assert _claim_cancel(chat_id, 51263) is False
+    assert _claim_cancel(chat_id, 51264) is False
+
+
+def test_same_message_in_different_chats_each_get_one_fire() -> None:
+    msg_id = 51263
+    assert _claim_cancel(-5235455627, msg_id) is True
+    assert _claim_cancel(-5173025382, msg_id) is True  # different chat
+    assert _claim_cancel(-5235455627, msg_id) is False
+
+
+def test_claim_re_succeeds_after_ttl_expires(monkeypatch) -> None:
+    """After the 1-second dedup window expires, a legitimate retry (e.g.
+    user types ``/cancel`` after the keyboard already dismissed) succeeds.
+    """
+    real_monotonic = time.monotonic
+    base = real_monotonic()
+
+    times = iter(
+        [
+            base,
+            base + 0.1,
+            base + _CANCEL_DEDUP_TTL_S + 0.5,  # well past TTL
+        ]
+    )
+    monkeypatch.setattr(
+        "untether.telegram.commands.cancel.time.monotonic", lambda: next(times)
+    )
+
+    assert _claim_cancel(-5235455627, 51263) is True
+    assert _claim_cancel(-5235455627, 51263) is False
+    assert _claim_cancel(-5235455627, 51263) is True  # past TTL → new claim
+
+
+def test_expired_entries_are_garbage_collected(monkeypatch) -> None:
+    real_monotonic = time.monotonic
+    base = real_monotonic()
+    times = iter(
+        [
+            base,
+            base + 0.1,
+            base + 0.2,
+            base + _CANCEL_DEDUP_TTL_S + 1.0,  # trigger GC
+        ]
+    )
+    monkeypatch.setattr(
+        "untether.telegram.commands.cancel.time.monotonic", lambda: next(times)
+    )
+
+    _claim_cancel(-1, 1)
+    _claim_cancel(-2, 2)
+    _claim_cancel(-3, 3)
+    assert len(_RECENT_CANCELS) == 3
+    _claim_cancel(-4, 4)  # third call sees all prior as expired, GCs them
+    # After GC + insert of (-4, 4), only that survives.
+    assert (-4, 4) in _RECENT_CANCELS
+    assert len(_RECENT_CANCELS) == 1

--- a/tests/test_config_reload_notification.py
+++ b/tests/test_config_reload_notification.py
@@ -1,0 +1,122 @@
+"""#547 axis 2 / #548 — hot-reload Telegram notification formatting.
+
+Headline framing is the load-bearing UX choice: agents read these
+messages in next-turn context and the literal "No restart needed" /
+"Restart required" wording flips the trained-in "after editing config,
+restart the service" reflex.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from untether.config_reload_notification import (
+    format_hot_reload_only_notice,
+    format_partial_reload_notice,
+    format_reload_notification,
+    format_restart_required_notice,
+)
+
+
+def test_hot_reload_only_headline_says_no_restart_needed() -> None:
+    text = format_hot_reload_only_notice(
+        path="/home/nathan/.untether/untether.toml",
+        changed_keys=["triggers.crons.bc-daily-triage.schedule"],
+    )
+    assert "Hot-reloaded" in text
+    assert "**No restart needed.**" in text
+    assert "automatically" in text
+    assert "triggers.crons.bc-daily-triage.schedule" in text
+
+
+def test_restart_required_headline_says_restart_required() -> None:
+    text = format_restart_required_notice(
+        path="/home/nathan/.untether/untether.toml",
+        restart_keys=["session_mode"],
+    )
+    assert "**Restart required" in text
+    assert "session_mode" in text
+    assert "systemctl --user restart untether" in text
+
+
+def test_partial_reload_separates_hot_and_restart_keys() -> None:
+    text = format_partial_reload_notice(
+        path="/home/nathan/.untether/untether.toml",
+        hot_keys=["progress.verbose", "progress.max_actions"],
+        restart_keys=["session_mode"],
+    )
+    assert "Partial reload" in text
+    assert "**No restart needed for those.**" in text
+    assert "Applied now:" in text
+    assert "progress.verbose" in text
+    assert "progress.max_actions" in text
+    assert "Need restart to apply:" in text
+    assert "session_mode" in text
+    assert "2 of 3 keys" in text
+
+
+def test_dispatcher_picks_hot_only_when_no_restart_keys() -> None:
+    text = format_reload_notification(
+        path=Path("~/.untether/untether.toml").expanduser(),
+        hot_keys=["progress.verbose"],
+        restart_keys=[],
+    )
+    assert "**No restart needed.**" in text
+    assert "Restart required" not in text
+    assert "Partial reload" not in text
+
+
+def test_dispatcher_picks_restart_only_when_no_hot_keys() -> None:
+    text = format_reload_notification(
+        path=Path("~/.untether/untether.toml").expanduser(),
+        hot_keys=[],
+        restart_keys=["session_mode", "topics"],
+    )
+    assert "**Restart required" in text
+    assert "session_mode" in text
+    assert "topics" in text
+    assert "**No restart needed.**" not in text
+
+
+def test_dispatcher_picks_partial_when_both_present() -> None:
+    text = format_reload_notification(
+        path=Path("~/.untether/untether.toml").expanduser(),
+        hot_keys=["progress.verbose"],
+        restart_keys=["session_mode"],
+    )
+    assert "Partial reload" in text
+
+
+def test_path_shortened_to_tilde_when_under_home() -> None:
+    home = Path.home()
+    text = format_hot_reload_only_notice(
+        path=home / ".untether" / "untether.toml",
+        changed_keys=["triggers"],
+    )
+    assert "~/.untether/untether.toml" in text
+
+
+def test_path_used_as_is_when_outside_home() -> None:
+    text = format_hot_reload_only_notice(
+        path="/etc/untether/untether.toml",
+        changed_keys=["triggers"],
+    )
+    assert "/etc/untether/untether.toml" in text
+
+
+def test_keys_deduplicated_and_sorted() -> None:
+    text = format_hot_reload_only_notice(
+        path="/tmp/x.toml",
+        changed_keys=["zeta", "alpha", "alpha", "mu"],
+    )
+    # Order: alpha, mu, zeta — duplicates removed
+    pos_alpha = text.find("`alpha`")
+    pos_mu = text.find("`mu`")
+    pos_zeta = text.find("`zeta`")
+    assert 0 < pos_alpha < pos_mu < pos_zeta
+
+
+def test_empty_changed_keys_render_gracefully() -> None:
+    text = format_hot_reload_only_notice(path="/tmp/x.toml", changed_keys=[])
+    assert "Hot-reloaded" in text
+    assert "(no keys)" in text

--- a/tests/test_dot_typo_parse.py
+++ b/tests/test_dot_typo_parse.py
@@ -1,0 +1,113 @@
+"""#523: leading-dot typo recognition for slash commands.
+
+`.new`, `.cancel`, etc. would previously be dispatched as fresh agent
+prompts (full Claude cold-start cost paid before the user could cancel).
+The parse helper short-circuits those at the route_message layer with a
+"Did you mean /<cmd>?" hint.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from untether.telegram.commands.parse import parse_dot_typo
+
+KNOWN: frozenset[str] = frozenset(
+    {
+        "new",
+        "cancel",
+        "continue",
+        "ctx",
+        "topic",
+        "usage",
+        "export",
+        "browse",
+        "restart",
+        "verbose",
+        "config",
+        "planmode",
+        "ping",
+        "help",
+        "file",
+        "proc",
+        "at",
+        "listen",
+        "agent",
+        "model",
+        "reasoning",
+    }
+)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [".new", ".cancel", ".usage", ".help", ".restart"],
+)
+def test_bare_dot_command_recognised(text: str) -> None:
+    cmd = text.lstrip(".")
+    assert parse_dot_typo(text, KNOWN) == cmd
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (".new project idea", "new"),
+        (".at 30m do something", "at"),
+        (".topic switch  to-x", "topic"),
+    ],
+)
+def test_dot_command_with_args_recognised(text: str, expected: str) -> None:
+    assert parse_dot_typo(text, KNOWN) == expected
+
+
+def test_returns_none_for_empty_string() -> None:
+    assert parse_dot_typo("", KNOWN) is None
+
+
+def test_returns_none_for_plain_text() -> None:
+    assert parse_dot_typo("hello world", KNOWN) is None
+    assert parse_dot_typo("please run the daily check", KNOWN) is None
+
+
+def test_returns_none_for_slash_command() -> None:
+    """``/new`` is a legitimate slash command and must not match here —
+    that's the slash-command parser's job downstream."""
+    assert parse_dot_typo("/new", KNOWN) is None
+
+
+def test_returns_none_for_unknown_command_after_dot() -> None:
+    """``.foo`` where ``foo`` isn't a registered command is just prose —
+    don't false-trigger."""
+    assert parse_dot_typo(".foo", KNOWN) is None
+    assert parse_dot_typo(".asdf bar", KNOWN) is None
+
+
+def test_returns_none_for_double_dot_ellipsis() -> None:
+    """``..new`` (ellipsis-like, not a typo) shouldn't trigger."""
+    assert parse_dot_typo("..new", KNOWN) is None
+    assert parse_dot_typo("...new", KNOWN) is None
+
+
+def test_returns_none_for_relative_path() -> None:
+    """``./new`` is a literal path, never a command typo."""
+    assert parse_dot_typo("./new", KNOWN) is None
+    assert parse_dot_typo("./scripts/build.sh", KNOWN) is None
+
+
+def test_returns_none_for_sentence_starting_with_dot() -> None:
+    """``.well that didn't work`` — ``well`` not in KNOWN so no match."""
+    assert parse_dot_typo(".well that didn't work", KNOWN) is None
+
+
+def test_case_insensitive_match() -> None:
+    assert parse_dot_typo(".New", KNOWN) == "new"
+    assert parse_dot_typo(".CANCEL", KNOWN) == "cancel"
+
+
+def test_leading_whitespace_preserved() -> None:
+    """Whitespace-prefixed (rare on mobile but possible)."""
+    assert parse_dot_typo("  .new", KNOWN) == "new"
+
+
+def test_dot_command_followed_by_newline() -> None:
+    assert parse_dot_typo(".new\nlonger prompt here", KNOWN) == "new"

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -2433,6 +2433,128 @@ async def test_stall_fires_after_approval_threshold() -> None:
 
 
 @pytest.mark.anyio
+async def test_stall_approval_pending_demotes_warn_to_info(monkeypatch) -> None:
+    """#526: when threshold_reason == 'pending_approval', the WARN
+    ``progress_edits.stall_detected`` is replaced by an INFO
+    ``subprocess.approval_pending`` event so warn-filter dashboards stop
+    spamming during normal approval flows. The chat-side message is
+    independent (covered by #494-C) and continues to fire.
+    """
+    from structlog.testing import capture_logs
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits._STALL_THRESHOLD_APPROVAL = 0.1
+
+    from untether.model import Action, ActionEvent
+
+    evt = ActionEvent(
+        engine="claude",
+        action=Action(
+            id="ctrl.1",
+            kind="warning",
+            title="Permission Request [CanUseTool] - tool: ExitPlanMode",
+            detail={"inline_keyboard": {"buttons": [[{"text": "Approve"}]]}},
+        ),
+        phase="started",
+    )
+    await edits.on_event(evt)
+    clock.set(100.0)
+
+    with capture_logs() as logs:
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                clock.set(100.2)
+                await anyio.sleep(0.05)
+                edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    # The WARN must NOT have been emitted.
+    stall_warns = [e for e in logs if e.get("event") == "progress_edits.stall_detected"]
+    assert stall_warns == [], (
+        f"approval-pending must not emit progress_edits.stall_detected WARN, got: "
+        f"{stall_warns}"
+    )
+
+    # The INFO replacement MUST have been emitted.
+    approval_infos = [
+        e for e in logs if e.get("event") == "subprocess.approval_pending"
+    ]
+    assert len(approval_infos) >= 1
+    assert approval_infos[0].get("approval_pending") is True
+    assert approval_infos[0].get("log_level") == "info"
+
+
+@pytest.mark.anyio
+async def test_stall_approval_pending_info_event_paced_to_30_min(
+    monkeypatch,
+) -> None:
+    """#526: even on rapid stall ticks (every minute or so), the
+    ``subprocess.approval_pending`` INFO fires at most once per 30
+    minutes. The first tick emits; subsequent ticks within the window
+    are silent.
+    """
+    from structlog.testing import capture_logs
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits._STALL_THRESHOLD_APPROVAL = 0.05
+    edits._stall_repeat_seconds = 0.0  # bypass the per-tick repeat guard
+
+    from untether.model import Action, ActionEvent
+
+    evt = ActionEvent(
+        engine="claude",
+        action=Action(
+            id="ctrl.1",
+            kind="warning",
+            title="Permission Request [CanUseTool] - tool: AskUserQuestion",
+            detail={"inline_keyboard": {"buttons": [[{"text": "Approve"}]]}},
+        ),
+        phase="started",
+    )
+    await edits.on_event(evt)
+    clock.set(100.0)
+
+    with capture_logs() as logs:
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                # Advance the wall clock past threshold for 2-3 ticks
+                # (well within the 30-min approval-pending window) and
+                # confirm the INFO fires only once.
+                clock.set(100.2)
+                await anyio.sleep(0.03)
+                clock.set(100.5)
+                await anyio.sleep(0.03)
+                clock.set(100.8)
+                await anyio.sleep(0.03)
+                edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    approval_infos = [
+        e for e in logs if e.get("event") == "subprocess.approval_pending"
+    ]
+    assert len(approval_infos) == 1, (
+        f"Expected exactly 1 approval-pending INFO within 30-min window, got: "
+        f"{len(approval_infos)} ({approval_infos})"
+    )
+
+
+@pytest.mark.anyio
 async def test_stall_normal_threshold_without_approval() -> None:
     """Stall monitor uses normal threshold when no pending approval."""
     transport = FakeTransport()

--- a/tests/test_loop_coverage.py
+++ b/tests/test_loop_coverage.py
@@ -17,9 +17,11 @@ import pytest
 from untether.runners.run_options import EngineRunOptions
 from untether.telegram.engine_overrides import EngineOverrides
 from untether.telegram.loop import (
+    _ANSWERED_ECHO_MAX,
     ForwardCoalescer,
     ForwardKey,
     _drain_backlog,
+    _format_answered_echo,
     _forward_key,
     _PendingPrompt,
     _resolve_engine_run_options,
@@ -657,3 +659,43 @@ class TestForwardCoalescer:
             await anyio.sleep(0.15)
 
         assert len(dispatched) == 2
+
+
+# ---------------------------------------------------------------------------
+# #528 — AskUserQuestion text-reply echo helper
+# ---------------------------------------------------------------------------
+
+
+def test_format_answered_echo_short_text_returned_verbatim() -> None:
+    text = (
+        "You tell me, please - please list all of the next tasks now here in the chat"
+    )
+    assert len(text) <= _ANSWERED_ECHO_MAX
+    assert _format_answered_echo(text) == f"↩️ Answered: {text}"
+
+
+def test_format_answered_echo_long_text_ellipsised_not_hard_truncated() -> None:
+    text = "abcdefghij" * 40  # 400 chars, comfortably above _ANSWERED_ECHO_MAX (300)
+    out = _format_answered_echo(text)
+    assert out.startswith("↩️ Answered: ")
+    body = out.removeprefix("↩️ Answered: ")
+    assert body.endswith("…")
+    # Body retains _ANSWERED_ECHO_MAX-1 chars of original + the ellipsis
+    assert len(body) == _ANSWERED_ECHO_MAX
+    assert body[:-1] == text[: _ANSWERED_ECHO_MAX - 1]
+
+
+def test_format_answered_echo_boundary_exactly_max() -> None:
+    text = "x" * _ANSWERED_ECHO_MAX
+    out = _format_answered_echo(text)
+    # No ellipsis when exactly at limit
+    assert out == f"↩️ Answered: {text}"
+    assert "…" not in out
+
+
+def test_format_answered_echo_boundary_one_over_max() -> None:
+    text = "x" * (_ANSWERED_ECHO_MAX + 1)
+    out = _format_answered_echo(text)
+    body = out.removeprefix("↩️ Answered: ")
+    assert body.endswith("…")
+    assert len(body) == _ANSWERED_ECHO_MAX

--- a/tests/test_outbox_delivery.py
+++ b/tests/test_outbox_delivery.py
@@ -383,3 +383,63 @@ async def test_deliver_continues_on_send_failure(tmp_path: Path) -> None:
     # First file failed, second succeeded
     assert len(result.sent) == 1
     assert result.sent[0].abs_path.name == "b.txt"
+
+
+# ---------------------------------------------------------------------------
+# #524 — surface skipped outbox entries (directories, oversized, etc.) so the
+# agent's "I've prepared the guides folder for you" final message doesn't
+# become a silent lie.
+# ---------------------------------------------------------------------------
+
+
+def test_format_outbox_skipped_notice_directory_uses_trailing_slash() -> None:
+    from untether.runner_bridge import _format_outbox_skipped_notice
+
+    text = _format_outbox_skipped_notice([("guides", "directory")])
+    assert text.startswith("\U0001f4ce Outbox skipped")
+    assert "guides/ — directory" in text
+
+
+def test_format_outbox_skipped_notice_multiple_items_sorted() -> None:
+    from untether.runner_bridge import _format_outbox_skipped_notice
+
+    text = _format_outbox_skipped_notice(
+        [
+            ("z.txt", "too large: 60 MB > 50 MB"),
+            ("guides", "directory"),
+            ("key.pem", "denied by glob: **/*.pem"),
+        ]
+    )
+    lines = text.splitlines()
+    # Headline + 3 items, sorted alphabetically by name
+    assert len(lines) == 4
+    assert "guides/ — directory" in lines[1]
+    assert "key.pem" in lines[2]
+    assert "z.txt" in lines[3]
+
+
+def test_format_outbox_skipped_notice_caps_at_ten_with_overflow() -> None:
+    from untether.runner_bridge import _format_outbox_skipped_notice
+
+    items = [(f"file_{i:02d}.txt", "denied") for i in range(15)]
+    text = _format_outbox_skipped_notice(items)
+    lines = text.splitlines()
+    # Headline + 10 visible + overflow line = 12
+    assert len(lines) == 12
+    assert lines[-1] == "- … and 5 more"
+
+
+def test_telegram_files_settings_default_notify_skipped() -> None:
+    """#524: the new setting defaults to True so the surface fires
+    automatically on upgrade without users opting in."""
+    from untether.settings import TelegramFilesSettings
+
+    cfg = TelegramFilesSettings()
+    assert cfg.outbox_notify_skipped is True
+
+
+def test_telegram_files_settings_can_disable_notify_skipped() -> None:
+    from untether.settings import TelegramFilesSettings
+
+    cfg = TelegramFilesSettings(outbox_notify_skipped=False)
+    assert cfg.outbox_notify_skipped is False

--- a/tests/test_preamble.py
+++ b/tests/test_preamble.py
@@ -64,6 +64,26 @@ def test_default_preamble_includes_outbox_instructions() -> None:
     assert "/file get" in _DEFAULT_PREAMBLE
 
 
+def test_default_preamble_warns_against_systemctl_restart() -> None:
+    """#547 axis 1: agents routinely follow ``edit untether.toml`` with
+    ``systemctl --user restart untether`` because their training data is
+    full of "restart the service after config changes". Untether already
+    hot-reloads the file; the restart drops the agent's own final answer
+    (drain timeout + outbox.fail_pending). The preamble must tell agents
+    explicitly NOT to restart after editing config."""
+    # Headline: hot-reload mentioned
+    assert "hot-reload" in _DEFAULT_PREAMBLE.lower()
+    # Explicit "do NOT" framing
+    assert "Do NOT" in _DEFAULT_PREAMBLE
+    assert "systemctl" in _DEFAULT_PREAMBLE
+    assert "restart untether" in _DEFAULT_PREAMBLE
+    # Consequence spelled out so agents understand why
+    assert "drop" in _DEFAULT_PREAMBLE.lower() or "lost" in _DEFAULT_PREAMBLE.lower()
+    # Restart-only keys mentioned so agents know the exception
+    assert "bot_token" in _DEFAULT_PREAMBLE
+    assert "chat_id" in _DEFAULT_PREAMBLE
+
+
 # ───── #508 / #515 — plan-mode preamble clauses ────────────────────────
 
 

--- a/tests/test_runtime_loader.py
+++ b/tests/test_runtime_loader.py
@@ -62,3 +62,153 @@ def test_resolve_default_engine_unknown(tmp_path: Path) -> None:
             config_path=tmp_path / "untether.toml",
             engine_ids=["codex"],
         )
+
+
+# ---------------------------------------------------------------------------
+# #532: setup.summary consolidation + focused setup.warning for user-configured
+# engines only. Previously each missing engine fired its own WARN on every
+# config.reload — 5xN spam on single-engine hosts.
+# ---------------------------------------------------------------------------
+
+
+def _settings_with_engines(engine_configs: dict[str, dict] | None = None):
+    base = {
+        "transport": "telegram",
+        "transports": {
+            "telegram": {
+                "bot_token": "token",
+                "chat_id": 123,
+                "allow_any_user": True,
+            }
+        },
+    }
+    if engine_configs is not None:
+        base["engines"] = engine_configs
+    return UntetherSettings.model_validate(base)
+
+
+def test_setup_summary_emitted_once_with_found_and_missing_lists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A typical single-engine host (channelo: claude-only) should emit ONE
+    setup.summary line listing claude as found and the rest as
+    missing_on_path — no per-engine WARN spam.
+    """
+    from structlog.testing import capture_logs
+
+    config_path = tmp_path / "untether.toml"
+    config_path.touch()
+
+    # Only claude is on PATH; the rest are missing.
+    def fake_which(cmd: str) -> str | None:
+        return "/usr/bin/claude" if cmd == "claude" else None
+
+    monkeypatch.setattr(runtime_loader.shutil, "which", fake_which)
+
+    settings = _settings_with_engines()  # no user-level [engines] block
+    backends = runtime_loader.load_backends(
+        engine_ids=["claude", "codex", "gemini", "opencode", "pi"],
+        allowlist=None,
+        default_engine="claude",
+    )
+
+    with capture_logs() as logs:
+        runtime_loader.build_router(
+            settings=settings,
+            config_path=config_path,
+            backends=backends,
+            default_engine="claude",
+        )
+
+    summary = [e for e in logs if e.get("event") == "setup.summary"]
+    assert len(summary) == 1
+    s = summary[0]
+    assert "claude" in s["found"]
+    assert set(s["missing_on_path"]) == {"codex", "gemini", "opencode", "pi"}
+    assert s["bad_config"] == []
+    assert s["default_engine"] == "claude"
+
+    # No WARN should fire for engines the user didn't configure.
+    warnings = [e for e in logs if e.get("event") == "setup.warning"]
+    assert warnings == [], (
+        f"expected zero setup.warning lines for unconfigured engines, got: {warnings}"
+    )
+
+
+def test_setup_warning_fires_for_user_configured_engine_missing_on_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the user has put ``[engines.gemini]`` in their TOML but ``gemini``
+    isn't on PATH, that IS noteworthy — fire one focused WARN. The summary
+    line still emits alongside.
+    """
+    from structlog.testing import capture_logs
+
+    config_path = tmp_path / "untether.toml"
+    config_path.touch()
+
+    def fake_which(cmd: str) -> str | None:
+        return "/usr/bin/claude" if cmd == "claude" else None
+
+    monkeypatch.setattr(runtime_loader.shutil, "which", fake_which)
+
+    settings = _settings_with_engines(
+        {"gemini": {"model": "gemini-pro"}}
+    )  # user configured gemini despite it missing
+    backends = runtime_loader.load_backends(
+        engine_ids=["claude", "gemini"],
+        allowlist=None,
+        default_engine="claude",
+    )
+
+    with capture_logs() as logs:
+        runtime_loader.build_router(
+            settings=settings,
+            config_path=config_path,
+            backends=backends,
+            default_engine="claude",
+        )
+
+    summary = [e for e in logs if e.get("event") == "setup.summary"]
+    assert len(summary) == 1
+    assert "gemini" in summary[0]["missing_on_path"]
+
+    warnings = [e for e in logs if e.get("event") == "setup.warning"]
+    assert len(warnings) == 1
+    assert warnings[0]["engine"] == "gemini"
+    assert "not found on PATH" in warnings[0]["issue"]
+
+
+def test_setup_summary_all_engines_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When every engine is on PATH, summary lists all under ``found`` with
+    empty missing/bad lists; no warnings.
+    """
+    from structlog.testing import capture_logs
+
+    config_path = tmp_path / "untether.toml"
+    config_path.touch()
+    monkeypatch.setattr(runtime_loader.shutil, "which", lambda _cmd: "/bin/echo")
+
+    settings = _settings_with_engines()
+    backends = runtime_loader.load_backends(
+        engine_ids=["claude", "codex"],
+        allowlist=None,
+        default_engine="claude",
+    )
+
+    with capture_logs() as logs:
+        runtime_loader.build_router(
+            settings=settings,
+            config_path=config_path,
+            backends=backends,
+            default_engine="claude",
+        )
+
+    summary = [e for e in logs if e.get("event") == "setup.summary"]
+    assert len(summary) == 1
+    assert set(summary[0]["found"]) == {"claude", "codex"}
+    assert summary[0]["missing_on_path"] == []
+    assert summary[0]["bad_config"] == []
+    assert [e for e in logs if e.get("event") == "setup.warning"] == []

--- a/tests/test_telegram_queue.py
+++ b/tests/test_telegram_queue.py
@@ -250,7 +250,10 @@ async def test_set_my_commands_uses_outbox() -> None:
 
 
 @pytest.mark.anyio
-async def test_answer_callback_query_uses_outbox() -> None:
+async def test_answer_callback_query_bypasses_outbox() -> None:
+    """#546: answer_callback_query bypasses the per-chat send outbox so
+    rapid taps don't escalate latency 6-10x by stacking behind the 1.0s
+    private-chat pacing bucket. The underlying bot call still happens."""
     bot = FakeBot()
     client = TelegramClient(client=bot, private_chat_rps=0.0, group_chat_rps=0.0)
 
@@ -263,6 +266,39 @@ async def test_answer_callback_query_uses_outbox() -> None:
     assert result is True
     assert bot.calls == ["answer_callback_query"]
     assert bot.callback_calls == [("cb-1", "ok", True)]
+    await client.close()
+
+
+@pytest.mark.anyio
+async def test_answer_callback_query_does_not_call_outbox_enqueue() -> None:
+    """#546 regression: ``answer_callback_query`` must bypass
+    ``_outbox.enqueue`` so it never queues behind a slow
+    ``send_message`` / ``edit_message_text`` op stacked on the shared
+    ``_next_at[None]`` pacing bucket. Verified by replacing the outbox
+    with one that explodes on enqueue.
+    """
+    bot = FakeBot()
+    client = TelegramClient(client=bot, private_chat_rps=0.0, group_chat_rps=0.0)
+
+    enqueue_calls: list[Any] = []
+
+    async def exploding_enqueue(*args: Any, **kwargs: Any) -> Any:
+        enqueue_calls.append(("enqueue", args, kwargs))
+        raise AssertionError(
+            "answer_callback_query must NOT route through outbox.enqueue "
+            "(#546). Callbacks bypass the per-chat send pacing because "
+            "Telegram rate-limits per callback-query-id, not per chat."
+        )
+
+    client._outbox.enqueue = exploding_enqueue  # type: ignore[assignment]
+
+    result = await client.answer_callback_query(
+        callback_query_id="cb-fast",
+        text="ack",
+    )
+    assert result is True
+    assert bot.callback_calls == [("cb-fast", "ack", None)]
+    assert enqueue_calls == [], "outbox.enqueue must not be called"
     await client.close()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.3rc18"
+version = "0.35.3rc19"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bundles 9 OPEN issues from the recent `/monitor` campaign (lba-1 staging, runs 2026-05-13 through 2026-05-16) into one rc19 staged for fleet rollout, plus the daemon-filed #533 duplicate.

User-confirmed scope decisions: all in-scope issues moved into v0.35.3 milestone; #527 (umbrella stall predicate refactor) explicitly deferred to v0.35.4.

### Already fixed in master (closed out separately)
- #544 — ScheduleWakeup state-lifetime — verified rc16/PR #545; 3 new + 2 existing tests pass
- #497 — catalog.refresh_sent storm — verified rc14/PR #541

### Bundled here
| # | Title | Commit |
|---|---|---|
| #528 | "↩️ Answered:" echo no longer truncated to 100 chars | `d175be9` |
| #525 | dedup cancel.requested triple-fire (1s TTL on chat/msg id) | `f558235` |
| #532 | consolidate per-engine setup.warning to one setup.summary INFO | `a9dc234` |
| #547 axis 1 | preamble warns agents against `systemctl restart untether` | `12cf4ca` |
| #523 | recognise leading-dot slash-command typos (`.new`, `.usage`, …) | `b02c20d` |
| #524 | surface skipped outbox entries (directories etc.) in chat | `fde1bd8` |
| #526 (+ #533) | demote stall WARN to INFO during approval-pending | `66ba78f` |
| #547 axes 2+3 + #548 | hot-reload Telegram confirmation message | `40dc6b7` |
| #546 | bypass outbox for answer_callback_query (latency fix) | `ee03b32` |
| version bump | 0.35.3rc18 → 0.35.3rc19 + uv.lock | `12c2d71` |

### Deferred to v0.35.4
- #547 axis 3 — drain self-restart heuristic (needs bigger refactor; axes 1+2 break the pattern at its source)
- #527 — unified predicate-based stall detector umbrella refactor (per user decision)

## Pre-PR validation
- `uv run pytest` — 2737 passed / 2 skipped (1 skipped is pre-existing)
- Coverage gate — 82.58% (above 80%)
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean
- `uv lock --check` — clean

## Test plan
- [ ] CI green on TestPyPI publish path
- [ ] After merge to `dev`: integration tests on `@untether_dev_bot` (claude chat `-5284581592`):
  - U2: AskUserQuestion → "Other (type it out)" → 250-char reply → echo not truncated (#528)
  - U6: ExitPlanMode → triple-tap Cancel within 1s → journal shows ONE `cancel.requested` (#525)
  - U7: `/new` then any prompt → assistant transcript contains the new preamble sentence (#547 axis 1)
  - send `.new` → reply offers `/new` correction (#523)
  - edit `~/.untether-dev/untether.toml` → confirm "♻️ Hot-reloaded ... **No restart needed.**" message appears in chat (#547 axis 2 / #548); journal shows ONE `setup.summary` INFO (no per-engine WARN, #532)
  - prompt Claude to write `.untether-outbox/guides/` (dir) + `.untether-outbox/x.md` (file) → final message includes "📎 Outbox skipped: guides/ — directory" + delivers x.md (#524)
  - trigger ExitPlanMode and leave pending 15+ min → no `subprocess.liveness_stall` WARNs; `subprocess.approval_pending` INFO fires once per 30 min (#526)
  - rapid-tap 3 approvals → all `callback.answered.latency_ms` stay near the ~220ms baseline (#546)
- [ ] `scripts/run-integration-tests.sh 0.35.3rc19 --manual` attestation written
- [ ] `scripts/fleet-rollout.sh 0.35.3rc19` to all 4 hosts (lba-1 + nsd + channelo + mac); /ping smoke on each
- [ ] Comment on each closed issue with rc19 rollout confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)