### PR TITLE
chore: staging 0.35.4rc2 (publish Batch 2 to TestPyPI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.4rc1"
+version = "0.35.4rc2"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.4rc1"
+version = "0.35.4rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bump `0.35.4rc1` → `0.35.4rc2` so the Batch 2 security/ops work (#381 #382 #459 #376 #559, merged in #576) publishes as a fresh **TestPyPI** wheel.

`0.35.4rc1` already exists on TestPyPI (from Batch 1 #575), so the dev-merge publish step skipped the unchanged version with `400 File already exists`. A version bump is the standard rc-staging step to get a new installable artifact.

- pyproject `version` bumped; `uv.lock` synced (`uv lock --check` passes).
- No code or changelog change (rc versions skip changelog per `validate_release`).
- Merging this to dev → CI publishes `untether-0.35.4rc2` to TestPyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)