### PR TITLE
fix(claude): #590 reap leaked MCP children — descendant-aware kills + post-exit orphan sweep

### DIFF
--- a/contrib/untether.service
+++ b/contrib/untether.service
@@ -64,6 +64,16 @@ TimeoutStopSec=150
 OOMScoreAdjust=-100
 OOMPolicy=continue
 
+# Memory guard (#589) — OPTIONAL, uncomment on memory-constrained hosts.
+# The nsd ARM64 VPS hit the kernel OOM killer 5x in one evening under
+# accumulated MCP-child pressure. With the #590 orphan sweep the leak is
+# fixed, but a unit-level ceiling contains any future regression: MemoryHigh
+# throttles/reclaims before the kernel steps in, MemoryMax hard-caps the
+# whole cgroup (main process + all engine subprocesses + MCP children).
+# Size to ~60-75% of host RAM; leave headroom for the CLIs themselves.
+#MemoryHigh=4G
+#MemoryMax=6G
+
 Environment=HOME=%h
 Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 EnvironmentFile=%h/.untether/.env

--- a/src/untether/runner.py
+++ b/src/untether/runner.py
@@ -994,6 +994,10 @@ class JsonlSubprocessRunner(BaseRunner):
 
     _stall_auto_kill: bool = False
 
+    # #590: post-exit orphan sweep ([watchdog] reap_orphans, default true).
+    # Refreshed per run from WatchdogSettings by the bridge.
+    _reap_orphans: bool = True
+
     def _check_prespawn_ram_guard(
         self, resume: ResumeToken | None
     ) -> CompletedEvent | None:
@@ -1191,20 +1195,11 @@ class JsonlSubprocessRunner(BaseRunner):
                                 pid=pid,
                                 reason="zero_tcp_zero_cpu",
                             )
-                            try:
-                                _os.killpg(pid, signal.SIGKILL)
-                            except (
-                                ProcessLookupError,
-                                PermissionError,
-                                OSError,
-                            ) as e:
-                                logger.debug(
-                                    "subprocess.watchdog.suppressed",
-                                    pid=pid,
-                                    error=str(e),
-                                    error_type=e.__class__.__name__,
-                                    context="liveness_kill",
-                                )
+                            # #590: descendant-aware — bare killpg missed
+                            # grandchildren in separate sessions/pgroups.
+                            from .utils.subprocess import signal_pid_group
+
+                            signal_pid_group(pid, signal.SIGKILL)
                         prev_diag = diag
 
             await anyio.sleep(self._WATCHDOG_POLL_SECONDS)
@@ -1222,20 +1217,12 @@ class JsonlSubprocessRunner(BaseRunner):
         )
         # Kill the process group to terminate orphan children holding pipes open.
         # manage_subprocess uses start_new_session=True, so the process group
-        # matches the subprocess PID.
-        try:
-            _os.killpg(pid, signal.SIGKILL)
-            logger.warning("subprocess.killed_orphan_group", pid=pid)
-        except (ProcessLookupError, PermissionError) as e:
-            logger.debug(
-                "subprocess.watchdog.suppressed",
-                pid=pid,
-                error=str(e),
-                error_type=e.__class__.__name__,
-                context="orphan_killpg",
-            )
-        except OSError:
-            logger.debug("subprocess.killpg_failed", pid=pid, exc_info=True)
+        # matches the subprocess PID. #590: descendant-aware so pgroup
+        # escapees holding the pipes are also terminated.
+        from .utils.subprocess import signal_pid_group
+
+        signal_pid_group(pid, signal.SIGKILL)
+        logger.warning("subprocess.killed_orphan_group", pid=pid)
 
     async def run_impl(
         self, prompt: str, resume: ResumeToken | None
@@ -1276,6 +1263,7 @@ class JsonlSubprocessRunner(BaseRunner):
 
         async with manage_subprocess(
             cmd,
+            reap_orphans=self._reap_orphans,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -3047,6 +3047,9 @@ async def handle_message(
             runner._LIVENESS_TIMEOUT_SECONDS = watchdog.liveness_timeout
         if hasattr(runner, "_stall_auto_kill"):
             runner._stall_auto_kill = watchdog.stall_auto_kill
+        # #590: post-exit orphan sweep toggle.
+        if hasattr(runner, "_reap_orphans"):
+            runner._reap_orphans = watchdog.reap_orphans
 
     # #481: heartbeat tick cadence — drives the long-running-action elapsed
     # tail and the post-result closing-message poller. Read live so config

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -54,7 +54,12 @@ from ..settings import load_settings_if_exists
 from ..utils.env_audit import audit_proc_env
 from ..utils.paths import get_run_base_dir
 from ..utils.streams import drain_stderr
-from ..utils.subprocess import manage_subprocess, redact_env_i_args, wrap_with_env_i
+from ..utils.subprocess import (
+    manage_subprocess,
+    redact_env_i_args,
+    signal_pid_group,
+    wrap_with_env_i,
+)
 from .run_options import get_run_options
 from .tool_actions import tool_input_path, tool_kind_and_title
 
@@ -367,6 +372,12 @@ class ClaudeStreamState:
     # colliding with Claude Code's own ``req_*`` namespace.
     pending_catalog_refresh_ids: list[str] = field(default_factory=list)
     catalog_refresh_seq: int = 0
+    # #590: descendant PIDs captured while the subprocess was alive (at
+    # reader-done and at limbo detection). Read by manage_subprocess's
+    # post-exit orphan sweep so pgroup ESCAPEES — MCP chains that setsid
+    # into their own session and survive a plain killpg — are still
+    # terminated after the leader exits.
+    orphan_pid_snapshot: list[int] = field(default_factory=list)
     # #497: debounce gate. Holds the ``time.monotonic()`` timestamp of the
     # last enqueued refresh; the translate path skips re-enqueue while
     # ``(now - last) < catalog_refresh_min_interval_s``. None until the
@@ -3054,8 +3065,6 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         ``runner.limbo_detected`` warning. ``untether-issue-watcher``
         picks this up automatically.
         """
-        import os as _os
-
         from ..utils.proc_diag import collect_proc_diag
 
         reader_done_at = time.monotonic()
@@ -3154,6 +3163,13 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             ):
                 limbo_logged = True
                 diag = collect_proc_diag(proc.pid)
+                # #590: refresh the orphan snapshot — children spawned AFTER
+                # the reader-done snapshot (the sl "late leaker" shape) are
+                # captured here so the post-exit sweep can reach them.
+                if diag is not None:
+                    state.orphan_pid_snapshot.extend(
+                        p for p in diag.child_pids if p not in state.orphan_pid_snapshot
+                    )
                 run_logger.warning(
                     "runner.limbo_detected",
                     engine="claude",
@@ -3213,8 +3229,9 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                         pid=proc.pid,
                         session_id=sid,
                     )
-                with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
-                    _os.killpg(proc.pid, signal.SIGTERM)
+                # #590: descendant-aware — bare killpg missed MCP chains
+                # that re-parented into separate sessions/pgroups.
+                signal_pid_group(proc.pid, signal.SIGTERM)
                 # Give MCP children configured grace to clean up.
                 grace_deadline = time.monotonic() + self._subcountdown_sigterm_grace_s
                 while time.monotonic() < grace_deadline:
@@ -3244,8 +3261,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                         pid=proc.pid,
                         session_id=sid,
                     )
-                with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
-                    _os.killpg(proc.pid, signal.SIGKILL)
+                signal_pid_group(proc.pid, signal.SIGKILL)
                 return "reader_done_but_alive_timeout"
 
     def translate(
@@ -3447,6 +3463,10 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
 
             async with manage_subprocess(
                 cmd,
+                # #590: sweep leaked MCP children after exit; the snapshot
+                # list is filled at reader-done / limbo time (escapees).
+                reap_orphans=self._reap_orphans,
+                orphan_pid_snapshot=state.orphan_pid_snapshot,
                 stdin=stdin_arg,
                 stdout=subprocess_module.PIPE,
                 stderr=subprocess_module.PIPE,
@@ -3577,6 +3597,21 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                         session_stdin=this_proc_stdin if use_control_channel else None,
                     ):
                         yield evt
+                    # #590: snapshot descendants while the subprocess is
+                    # still alive — after exit, /proc children links are
+                    # gone and pgroup escapees become invisible. The sweep
+                    # in manage_subprocess reads this list at teardown.
+                    if proc.returncode is None:
+                        try:
+                            from ..utils.proc_diag import find_descendants
+
+                            state.orphan_pid_snapshot.extend(
+                                p
+                                for p in find_descendants(proc.pid)
+                                if p not in state.orphan_pid_snapshot
+                            )
+                        except OSError:
+                            pass
                     reader_done.set()
 
                     # Close stdin after all events to let CLI exit.

--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -312,6 +312,14 @@ class WatchdogSettings(BaseModel):
     liveness_timeout: float = Field(default=600.0, ge=60, le=3600)
     stall_auto_kill: bool = False
     stall_repeat_seconds: float = Field(default=180.0, ge=30, le=600)
+    # #590: after an engine subprocess exits (including clean rc=0), sweep
+    # surviving process-group members and captured descendant PIDs — the
+    # Claude CLI leaks MCP node children on exit fleet-wide (1/run on sl,
+    # 11-37/day on nsd, driving the #589 OOM kills). Killing everything the
+    # session spawned at session end is the #573 lifecycle policy (OWASP
+    # ASI08/ASI10); it also terminates user-backgrounded Bash tasks that
+    # outlive the run. Set false to keep survivors.
+    reap_orphans: bool = True
     tool_timeout: float = Field(default=600.0, ge=60, le=7200)
     mcp_tool_timeout: float = Field(default=900.0, ge=60, le=7200)
     subagent_timeout: float = Field(default=900.0, ge=60, le=7200)

--- a/src/untether/utils/subprocess.py
+++ b/src/untether/utils/subprocess.py
@@ -164,11 +164,151 @@ def _signal_descendants(pids: list[int], sig: signal.Signals, log_event: str) ->
             )
 
 
+def signal_pid_group(pid: int, sig: signal.Signals) -> None:
+    """Deliver *sig* to a bare pid's process group AND its captured
+    descendants (#590).
+
+    The pid-based twin of :func:`_signal_process` for callers that hold a
+    pid rather than an anyio ``Process`` (the Claude post-result watchdog).
+    Bare ``os.killpg`` misses grandchildren that re-parented into separate
+    sessions/pgroups (e.g. MCP ``node`` → ``mcp-remote`` chains), so the
+    descendant tree is snapshotted BEFORE signalling the group.
+    """
+    if os.name != "posix":
+        return
+    descendants: list[int] = []
+    if sys.platform == "linux":
+        try:
+            descendants = find_descendants(pid)
+        except OSError:
+            descendants = []
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        os.killpg(pid, sig)
+    _signal_descendants(descendants, sig, "subprocess.group_signal.failed")
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OSError):
+        return True
+    return True
+
+
+def _pgid_members(pgid: int) -> list[int]:
+    """Enumerate live PIDs whose process group is *pgid* (Linux /proc scan).
+
+    Used by the post-exit orphan sweep for logging and per-PID delivery.
+    Best-effort: unreadable or vanished entries are skipped; non-Linux
+    returns an empty list (the killpg-based sweep still works there).
+    """
+    if sys.platform != "linux":
+        return []
+    members: list[int] = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return []
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/stat", "rb") as fh:
+                stat = fh.read()
+            # Field 5 (pgrp) sits after the comm field, which can contain
+            # spaces/parens — parse from the LAST ')'.
+            after_comm = stat[stat.rindex(b")") + 2 :].split()
+            if int(after_comm[1]) == pgid:
+                members.append(int(entry))
+        except (OSError, ValueError, IndexError):
+            continue
+    return members
+
+
+async def reap_orphaned_group(
+    pgid: int,
+    *,
+    extra_pids: Sequence[int] = (),
+    grace_s: float = 2.0,
+) -> list[int]:
+    """#590: sweep process-group survivors after the group leader exited.
+
+    The Claude CLI leaks MCP ``node`` children on clean (rc=0) exits —
+    observed fleet-wide as 1 orphan per run accumulating until the daily
+    systemd SIGKILL sweep, and the dominant memory pressure behind the nsd
+    OOM kills (#589). Nothing previously killed them: ``manage_subprocess``
+    only signalled while the *leader* was still alive.
+
+    Delivers SIGTERM to the group (plus any *extra_pids* captured while the
+    leader was alive — pgroup escapees), waits up to *grace_s* for a clean
+    exit, then SIGKILLs survivors. Returns the PIDs targeted (best-effort,
+    for the ``subprocess.orphans_reaped`` log). No-ops instantly when the
+    group is already empty.
+    """
+    if os.name != "posix":
+        return []
+    live_extras = [p for p in extra_pids if p != pgid and _pid_alive(p)]
+
+    def _group_alive() -> bool:
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return False
+        except (PermissionError, OSError):
+            return True
+        return True
+
+    if not _group_alive() and not live_extras:
+        return []
+
+    victims: set[int] = set(_pgid_members(pgid))
+    victims.update(live_extras)
+
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        os.killpg(pgid, signal.SIGTERM)
+    _signal_descendants(live_extras, signal.SIGTERM, "subprocess.orphan_sweep.failed")
+
+    deadline_polls = max(1, int(grace_s / 0.1))
+    for _ in range(deadline_polls):
+        if not _group_alive() and not any(_pid_alive(p) for p in live_extras):
+            break
+        await anyio.sleep(0.1)
+
+    survivors = [p for p in victims if _pid_alive(p)]
+    if _group_alive() or survivors:
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(pgid, signal.SIGKILL)
+        _signal_descendants(survivors, signal.SIGKILL, "subprocess.orphan_sweep.failed")
+
+    reaped = sorted(victims)
+    if reaped:
+        logger.info(
+            "subprocess.orphans_reaped",
+            pgid=pgid,
+            pids=reaped,
+            extra_pids=sorted(live_extras),
+        )
+    return reaped
+
+
 @asynccontextmanager
 async def manage_subprocess(
-    cmd: Sequence[str], **kwargs: Any
+    cmd: Sequence[str],
+    *,
+    reap_orphans: bool = True,
+    orphan_pid_snapshot: Sequence[int] | None = None,
+    **kwargs: Any,
 ) -> AsyncIterator[Process]:
-    """Ensure subprocesses receive SIGTERM, then SIGKILL after a 10s timeout."""
+    """Ensure subprocesses receive SIGTERM, then SIGKILL after a 10s timeout.
+
+    ``reap_orphans`` (#590, ``[watchdog] reap_orphans``): after the leader
+    has exited — including clean rc=0 — sweep surviving process-group
+    members and any PIDs the caller captured into *orphan_pid_snapshot*
+    while the leader was alive (a mutable list works: it is read only at
+    teardown time).
+    """
     if os.name == "posix":
         kwargs.setdefault("start_new_session", True)
     proc = await anyio.open_process(cmd, **kwargs)
@@ -182,6 +322,17 @@ async def manage_subprocess(
                 if timed_out:
                     kill_process(proc)
                     await proc.wait()
+        # #590: the leader is dead — reap group survivors (leaked MCP
+        # children etc.) before releasing the transport.
+        if reap_orphans:
+            with anyio.CancelScope(shield=True):
+                try:
+                    await reap_orphaned_group(
+                        proc.pid,
+                        extra_pids=tuple(orphan_pid_snapshot or ()),
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.debug("subprocess.orphan_sweep_failed", exc_info=True)
         # #599: release the asyncio subprocess transport explicitly, on every
         # exit path including clean rc=0. Without this the transport is only
         # reached by GC at interpreter exit — after the event loop closed —

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -3919,6 +3919,9 @@ async def test_333_reader_done_but_alive_triggers_subcountdown(monkeypatch) -> N
             proc.returncode = -9
 
     monkeypatch.setattr("os.killpg", _fake_killpg)
+    # #590: signal_pid_group snapshots real /proc descendants before
+    # signalling — neutralise it so tests never touch live processes.
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
 
     logger = _RecordingLogger()
     reader_done = anyio.Event()
@@ -3989,6 +3992,9 @@ async def test_333_subprocess_exits_during_subcountdown(monkeypatch) -> None:
     killed_signals: list[int] = []
 
     monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+    # #590: signal_pid_group snapshots real /proc descendants before
+    # signalling — neutralise it so tests never touch live processes.
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
 
     logger = _RecordingLogger()
     reader_done = anyio.Event()
@@ -4060,6 +4066,11 @@ async def test_333_subcountdown_defers_on_pending_request(monkeypatch) -> None:
         killed_signals: list[int] = []
 
         monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+        # #590: signal_pid_group snapshots real /proc descendants before
+        # signalling — neutralise it so tests never touch live processes.
+        monkeypatch.setattr(
+            "untether.utils.subprocess.find_descendants", lambda pid: []
+        )
 
         logger = _RecordingLogger()
         reader_done = anyio.Event()
@@ -4133,6 +4144,9 @@ async def test_333_lifecycle_state_transitions_logged(monkeypatch) -> None:
             proc.returncode = -15  # exit on SIGTERM
 
     monkeypatch.setattr("os.killpg", _fake_killpg)
+    # #590: signal_pid_group snapshots real /proc descendants before
+    # signalling — neutralise it so tests never touch live processes.
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
 
     logger = _RecordingLogger()
     reader_done = anyio.Event()
@@ -4210,6 +4224,9 @@ async def test_591_limbo_grace_short_circuits_subcountdown(monkeypatch) -> None:
         proc.returncode = -15
 
     monkeypatch.setattr("os.killpg", _fake_killpg)
+    # #590: signal_pid_group snapshots real /proc descendants before
+    # signalling — neutralise it so tests never touch live processes.
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
 
     logger = _RecordingLogger()
     reader_done = anyio.Event()
@@ -4277,6 +4294,9 @@ async def test_591_limbo_grace_deferred_by_live_background_work(monkeypatch) -> 
     proc = _FakeProc(pid=52425, returncode=None)
     killed_signals: list[int] = []
     monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+    # #590: signal_pid_group snapshots real /proc descendants before
+    # signalling — neutralise it so tests never touch live processes.
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
 
     logger = _RecordingLogger()
     reader_done = anyio.Event()
@@ -4330,6 +4350,9 @@ async def test_591_limbo_grace_zero_disables_shortcut(monkeypatch) -> None:
     proc = _FakeProc(pid=52426, returncode=None)
     killed_signals: list[int] = []
     monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+    # #590: signal_pid_group snapshots real /proc descendants before
+    # signalling — neutralise it so tests never touch live processes.
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
 
     logger = _RecordingLogger()
     reader_done = anyio.Event()
@@ -4355,3 +4378,70 @@ async def test_591_limbo_grace_zero_disables_shortcut(monkeypatch) -> None:
         tg.cancel_scope.cancel()
 
     assert killed_signals == [], "grace=0 must fall back to the full timeout"
+
+
+@pytest.mark.anyio
+async def test_590_limbo_refreshes_orphan_snapshot(monkeypatch) -> None:
+    """#590: limbo detection extends state.orphan_pid_snapshot from the live
+    child-pid diag so late-spawned MCP leakers are visible to the post-exit
+    sweep (the sl leaker was invisible to the reader-done snapshot)."""
+    from types import SimpleNamespace
+
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.02
+    runner._subcountdown_limbo_detect_threshold_s = 0.05
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="orphan-sess-1"))
+    state.result_received_at = time.monotonic() - 0.5
+    state.orphan_pid_snapshot.append(900)  # pre-existing reader-done capture
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=62424, returncode=None)
+    monkeypatch.setattr(
+        "untether.utils.proc_diag.collect_proc_diag",
+        lambda pid: SimpleNamespace(
+            child_pids=[901, 902, 900], rss_kb=1000, tcp_total=3
+        ),
+    )
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            30.0,
+            proc,
+            stream,
+            0.0,  # grace disabled — we only want the limbo tick
+        )
+        with anyio.move_on_after(3.0):
+            while "runner.limbo_detected" not in logger.events():
+                await anyio.sleep(0.02)
+        tg.cancel_scope.cancel()
+
+    assert "runner.limbo_detected" in logger.events()
+    # 901/902 added; 900 not duplicated.
+    assert state.orphan_pid_snapshot == [900, 901, 902]

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -308,3 +308,161 @@ async def test_manage_subprocess_aclose_errors_are_suppressed(
         pass  # exiting must not raise despite aclose blowing up
 
     assert fake.aclose_called == 1
+
+
+# ---------------------------------------------------------------------------
+# #590 — descendant-aware signalling + post-exit orphan sweep
+# ---------------------------------------------------------------------------
+
+
+def test_signal_pid_group_delivers_to_group_and_descendants(monkeypatch) -> None:
+    """signal_pid_group snapshots descendants BEFORE killpg and delivers the
+    signal to both — bare killpg missed pgroup escapees."""
+    killpg_calls: list[tuple[int, int]] = []
+    kill_calls: list[tuple[int, int]] = []
+
+    monkeypatch.setattr(subprocess_utils, "find_descendants", lambda pid: [111, 222])
+    monkeypatch.setattr(
+        subprocess_utils.os,
+        "killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+    monkeypatch.setattr(
+        subprocess_utils.os, "kill", lambda pid, sig: kill_calls.append((pid, sig))
+    )
+    monkeypatch.setattr(subprocess_utils.sys, "platform", "linux")
+
+    subprocess_utils.signal_pid_group(4242, signal.SIGTERM)
+
+    assert killpg_calls == [(4242, signal.SIGTERM)]
+    assert (111, signal.SIGTERM) in kill_calls
+    assert (222, signal.SIGTERM) in kill_calls
+
+
+@pytest.mark.anyio
+async def test_reap_orphaned_group_noop_when_group_empty(monkeypatch) -> None:
+    """No group members and no extras — the sweep returns instantly and
+    signals nothing (the common clean-teardown case must stay free)."""
+    signals: list[tuple[int, int]] = []
+
+    def probe_killpg(pgid: int, sig: int) -> None:
+        if sig == 0:
+            raise ProcessLookupError
+        signals.append((pgid, sig))
+
+    monkeypatch.setattr(subprocess_utils.os, "killpg", probe_killpg)
+
+    reaped = await subprocess_utils.reap_orphaned_group(999)
+
+    assert reaped == []
+    assert signals == []
+
+
+@pytest.mark.anyio
+async def test_reap_orphaned_group_sigterms_then_sigkills_survivors(
+    monkeypatch,
+) -> None:
+    """Group members survive the leader: SIGTERM the group; members that
+    ignore it are SIGKILLed after the grace."""
+    alive = {31001: True, 31002: True}
+    killpg_signals: list[int] = []
+    kill_calls: list[tuple[int, int]] = []
+
+    def fake_killpg(pgid: int, sig: int) -> None:
+        if sig == 0:
+            if not any(alive.values()):
+                raise ProcessLookupError
+            return
+        killpg_signals.append(sig)
+        if sig == signal.SIGTERM:
+            alive[31001] = False  # one member obeys SIGTERM
+        if sig == signal.SIGKILL:
+            alive[31002] = False
+
+    def fake_kill(pid: int, sig: int) -> None:
+        if sig == 0:
+            if not alive.get(pid, False):
+                raise ProcessLookupError
+            return
+        kill_calls.append((pid, sig))
+
+    monkeypatch.setattr(subprocess_utils.os, "killpg", fake_killpg)
+    monkeypatch.setattr(subprocess_utils.os, "kill", fake_kill)
+    monkeypatch.setattr(subprocess_utils, "_pgid_members", lambda pgid: [31001, 31002])
+
+    reaped = await subprocess_utils.reap_orphaned_group(31000, grace_s=0.2)
+
+    assert reaped == [31001, 31002]
+    assert killpg_signals[0] == signal.SIGTERM
+    assert signal.SIGKILL in killpg_signals
+    assert (31002, signal.SIGKILL) in kill_calls
+
+
+@pytest.mark.anyio
+async def test_reap_orphaned_group_kills_snapshot_escapees(monkeypatch) -> None:
+    """PIDs captured while the leader was alive (pgroup escapees in their
+    own session) are signalled even though killpg can't reach them."""
+    alive = {41001: True}
+    kill_calls: list[tuple[int, int]] = []
+
+    def fake_killpg(pgid: int, sig: int) -> None:
+        raise ProcessLookupError  # the group itself is already empty
+
+    def fake_kill(pid: int, sig: int) -> None:
+        if sig == 0:
+            if not alive.get(pid, False):
+                raise ProcessLookupError
+            return
+        kill_calls.append((pid, sig))
+        if sig == signal.SIGTERM:
+            alive[pid] = False
+
+    monkeypatch.setattr(subprocess_utils.os, "killpg", fake_killpg)
+    monkeypatch.setattr(subprocess_utils.os, "kill", fake_kill)
+    monkeypatch.setattr(subprocess_utils, "_pgid_members", lambda pgid: [])
+
+    reaped = await subprocess_utils.reap_orphaned_group(
+        41000, extra_pids=(41001,), grace_s=0.2
+    )
+
+    assert reaped == [41001]
+    assert (41001, signal.SIGTERM) in kill_calls
+
+
+@pytest.mark.anyio
+async def test_manage_subprocess_reaps_after_clean_exit(monkeypatch) -> None:
+    """#590: the sweep runs on the clean rc=0 path with the caller's
+    snapshot, and honours reap_orphans=False."""
+    reap_calls: list[tuple[int, tuple[int, ...]]] = []
+
+    async def fake_reap(pgid: int, *, extra_pids=(), grace_s: float = 2.0):
+        reap_calls.append((pgid, tuple(extra_pids)))
+        return list(extra_pids)
+
+    monkeypatch.setattr(subprocess_utils, "reap_orphaned_group", fake_reap)
+
+    fake = _FakeAcloseProc(returncode=0, pid=5555)
+
+    async def fake_open(cmd, **kwargs):
+        return fake
+
+    monkeypatch.setattr("untether.utils.subprocess.anyio.open_process", fake_open)
+
+    snapshot = [777]
+    async with subprocess_utils.manage_subprocess(
+        ["fake-cmd"], orphan_pid_snapshot=snapshot
+    ):
+        snapshot.append(888)  # captured mid-run, read at teardown
+
+    assert reap_calls == [(5555, (777, 888))]
+
+    reap_calls.clear()
+    fake2 = _FakeAcloseProc(returncode=0, pid=5556)
+
+    async def fake_open2(cmd, **kwargs):
+        return fake2
+
+    monkeypatch.setattr("untether.utils.subprocess.anyio.open_process", fake_open2)
+    async with subprocess_utils.manage_subprocess(["fake-cmd"], reap_orphans=False):
+        pass
+    assert reap_calls == []


### PR DESCRIPTION
## Summary

Fixes the fleet-wide MCP `node` child leak (#590) — the dominant memory pressure behind nsd's OOM kills (#589).

**Root causes addressed:**
1. **Nothing swept after clean exits.** `manage_subprocess` only signalled while the leader was alive; on rc=0 the leaked children (1/run on sl, 11–37/day on nsd) survived until the daily systemd stop — and 25 survived even that on nsd.
2. **Watchdog kills were bare `killpg`.** The post-result subcountdown SIGTERM/SIGKILL and the base-runner liveness/orphan kills missed MCP chains that re-parented into separate sessions/pgroups.

**Changes:**
- `reap_orphaned_group()` — post-exit sweep in `manage_subprocess` teardown (all engines, incl. clean rc=0): SIGTERM group + captured escapee PIDs → 2s grace → SIGKILL survivors; `subprocess.orphans_reaped` log; instant no-op when the group is empty. Config `[watchdog] reap_orphans` (default **true** — confirmed with Nathan; per #573's session-end cleanup policy this also terminates user-backgrounded Bash tasks at run end).
- `signal_pid_group()` — pid-based descendant-aware kill (reuses the #275 snapshot machinery) replacing bare `os.killpg` at the 4 watchdog kill sites.
- `ClaudeStreamState.orphan_pid_snapshot` — descendants captured at reader-done + refreshed at limbo detection, so late-spawned leakers (invisible to the first limbo snapshot per the #590 evidence) are reaped.
- `contrib/untether.service` — optional commented `MemoryHigh`/`MemoryMax` guidance for memory-constrained hosts (#589 defence-in-depth). Concurrency caps stay deferred to #384/#298.

## Tests
- 6 new sweep/signal tests + limbo-snapshot refresh test; existing killpg tests hardened against real /proc descendant reads.
- Full suite: 2819 passed, coverage 82.7%.

## Integration (dev bot)
- Clean Claude run: `subprocess.exit rc=0`, pgroup empty afterwards, service cgroup contains only the main process (previously lba-1 accumulated sh/node orphans between daily restarts).

fixes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)