### PR TITLE
fix(claude): #595 catalog warning flood + #596 empty-result surfacing + #597 image/document blocks

### DIFF
--- a/docs/reference/runners/claude/stream-json-cheatsheet.md
+++ b/docs/reference/runners/claude/stream-json-cheatsheet.md
@@ -160,3 +160,22 @@ Array content (Task tool format):
 ```json
 {"type":"tool_result","tool_use_id":"toolu_2","content":[{"type":"text","text":"Task done"}]}
 ```
+
+### Image / document blocks (binary media echoes)
+
+`Read` on an image or PDF echoes the content back inside the user-role
+message as `image` / `document` blocks alongside the `tool_result`
+([#597](https://github.com/littlebearapps/untether/issues/597) — the schema
+must accept them or msgspec drops the whole line):
+
+```json
+{"type":"image","source":{"type":"base64","media_type":"image/jpeg","data":"…"}}
+```
+
+```json
+{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"…"},"title":"report.pdf"}
+```
+
+* `source` — `{"type":"base64"|"url", "media_type": …, "data"|"url": …}`.
+  Untether never renders the payload; the blocks exist so the surrounding
+  message parses. Translation treats them as non-`tool_result` content.

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -3140,10 +3140,47 @@ async def handle_message(
                 else:
                     final_answer = f"```\n{raw_error}\n```"
 
+        # #596: a 0-turn / $0 / empty-answer completion with ok=True is a
+        # no-op resume (upstream: the resumed session considers itself
+        # complete and emits an immediate empty result). Previously this
+        # rendered a bare "error"-labelled header with no body — the user
+        # got silence and had to re-nudge manually. Surface it explicitly.
+        # Missing usage keys default to 1 (non-anomalous) — only an engine
+        # that EXPLICITLY reported zero turns and zero API time qualifies;
+        # engines without usage reporting never trip this.
+        empty_result_anomaly = False
+        if (
+            run_ok is True
+            and not run_outcome.cancelled
+            and not final_answer.strip()
+            and completed.usage
+            and (completed.usage.get("num_turns", 1) or 0) == 0
+            and (completed.usage.get("duration_api_ms", 1) or 0) == 0
+        ):
+            empty_result_anomaly = True
+            logger.warning(
+                "runner.empty_result",
+                engine=runner.engine,
+                resume=(completed.resume or run_outcome.resume).value
+                if (completed.resume or run_outcome.resume)
+                else None,
+                was_resume=resume_token is not None,
+            )
+            final_answer = (
+                "\N{WARNING SIGN} engine returned an empty result "
+                "(0 turns, no API work) — the resumed session may "
+                "consider itself complete. Resend your message, or "
+                "start fresh with /new."
+            )
+
         status = (
             "error"
             if run_ok is False
-            else ("done" if final_answer.strip() else "error")
+            else (
+                "error"
+                if empty_result_anomaly
+                else ("done" if final_answer.strip() else "error")
+            )
         )
         resume_value = None
         final_resume = completed.resume or run_outcome.resume

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -1121,6 +1121,12 @@ def _maybe_audit_env(state: ClaudeStreamState, session_id: str) -> None:
         )
 
 
+# #595: process-lifetime dedup for needs-auth/failed catalog warnings.
+# Keyed (server, status) — a connector that can never connect as configured
+# warns once per service lifetime instead of once per subprocess spawn.
+_CATALOG_STALENESS_WARNED: set[tuple[str, str]] = set()
+
+
 def _capture_mcp_catalog(
     state: ClaudeStreamState,
     session_id: str,
@@ -1137,6 +1143,14 @@ def _capture_mcp_catalog(
     Gated by ``WatchdogSettings.detect_catalog_staleness`` (default on;
     observability only — no recovery action). Logs once per
     (session, server, status) tuple so re-fired init events don't spam.
+
+    #595 severity split: ``pending`` at init is a startup race (the server
+    is still connecting when Claude snapshots the catalog), not staleness —
+    it logs at INFO (``catalog_staleness.pending``). Persistent
+    ``needs-auth``/``failed`` keep the WARNING but dedup across runs via
+    the process-lifetime ``_CATALOG_STALENESS_WARNED`` registry: the
+    per-state set resets on every subprocess spawn, which multiplied a few
+    broken connectors into ~2,930 WARNINGs/48h fleet-wide.
     """
     if not mcp_servers:
         return
@@ -1159,6 +1173,26 @@ def _capture_mcp_catalog(
         if key in state.catalog_staleness_logged:
             continue
         state.catalog_staleness_logged.add(key)
+        if status == "pending":
+            logger.info(
+                "catalog_staleness.pending",
+                session_id=session_id,
+                pid=state.pid,
+                server=name,
+                status=status,
+                source="system.init",
+            )
+            continue
+        process_key = (name, status)
+        if process_key in _CATALOG_STALENESS_WARNED:
+            logger.debug(
+                "catalog_staleness.suppressed",
+                session_id=session_id,
+                server=name,
+                status=status,
+            )
+            continue
+        _CATALOG_STALENESS_WARNED.add(process_key)
         logger.warning(
             "catalog_staleness.detected",
             session_id=session_id,

--- a/src/untether/schemas/claude.py
+++ b/src/untether/schemas/claude.py
@@ -68,6 +68,27 @@ class StreamAdvisorToolResultBlock(
     is_error: bool | None = None
 
 
+# #597 — binary media echoed back through user-role messages (e.g. a `Read`
+# on an image/PDF returns the content as an image/document block inside the
+# tool_result envelope). ``source`` carries ``{"type": "base64"|"url",
+# "media_type": ..., "data"|"url": ...}``; kept as a permissive dict — the
+# payload is never rendered, the schema just needs to accept the line so the
+# rest of the event isn't dropped (jsonl.msgspec.invalid x23 on nsd).
+class StreamImageBlock(
+    msgspec.Struct, tag="image", tag_field="type", forbid_unknown_fields=False
+):
+    source: dict[str, Any] | None = None
+
+
+# #597 — see StreamImageBlock; PDFs and other documents use the same shape
+# plus optional metadata fields (title, context, citations toggle).
+class StreamDocumentBlock(
+    msgspec.Struct, tag="document", tag_field="type", forbid_unknown_fields=False
+):
+    source: dict[str, Any] | None = None
+    title: str | None = None
+
+
 type StreamContentBlock = (
     StreamTextBlock
     | StreamThinkingBlock
@@ -75,6 +96,8 @@ type StreamContentBlock = (
     | StreamToolResultBlock
     | StreamServerToolUseBlock
     | StreamAdvisorToolResultBlock
+    | StreamImageBlock
+    | StreamDocumentBlock
 )
 
 

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -687,9 +687,14 @@ def test_catalog_init_snapshots_mcp_servers_when_all_connected() -> None:
 
 
 def test_catalog_init_logs_staleness_warning_for_non_connected() -> None:
-    """Any non-``connected`` MCP at init emits a catalog_staleness WARNING."""
+    """#595 severity split: ``failed``/``needs-auth`` at init emits the
+    catalog_staleness WARNING; ``pending`` is a startup race and logs at
+    INFO as ``catalog_staleness.pending`` instead."""
     from structlog.testing import capture_logs
 
+    from untether.runners.claude import _CATALOG_STALENESS_WARNED
+
+    _CATALOG_STALENESS_WARNED.clear()
     state = ClaudeStreamState()
     state.factory._resume = ResumeToken(engine=ENGINE, value="sess-2")
     event = _decode_event(
@@ -708,24 +713,106 @@ def test_catalog_init_logs_staleness_warning_for_non_connected() -> None:
         )
 
     warnings = [r for r in logs if r.get("event") == "catalog_staleness.detected"]
-    assert len(warnings) == 2
-    by_server = {r["server"]: r for r in warnings}
-    assert by_server["github"]["status"] == "failed"
-    assert by_server["github"]["session_id"] == "sess-2"
-    assert by_server["github"]["source"] == "system.init"
-    assert by_server["jina"]["status"] == "pending"
-    # "pal" connected must NOT appear
-    assert "pal" not in by_server
-    # Dedup set mirrors the emitted warnings
+    assert len(warnings) == 1
+    assert warnings[0]["server"] == "github"
+    assert warnings[0]["status"] == "failed"
+    assert warnings[0]["session_id"] == "sess-2"
+    assert warnings[0]["source"] == "system.init"
+    pendings = [r for r in logs if r.get("event") == "catalog_staleness.pending"]
+    assert len(pendings) == 1
+    assert pendings[0]["server"] == "jina"
+    assert pendings[0]["log_level"] == "info"
+    # Dedup set mirrors ALL emitted entries (both severities)
     assert ("sess-2", "github", "failed") in state.catalog_staleness_logged
     assert ("sess-2", "jina", "pending") in state.catalog_staleness_logged
     assert ("sess-2", "pal", "connected") not in state.catalog_staleness_logged
+
+
+def test_catalog_staleness_dedups_across_runs() -> None:
+    """#595: a persistently broken connector warns once per process, not
+    once per subprocess spawn — fresh ClaudeStreamState (new run) must NOT
+    re-warn for the same (server, status)."""
+    from structlog.testing import capture_logs
+
+    from untether.runners.claude import _CATALOG_STALENESS_WARNED
+
+    _CATALOG_STALENESS_WARNED.clear()
+    event_payload = _make_system_init_event(
+        "sess-r1", mcp_servers=[{"name": "gmail", "status": "needs-auth"}]
+    )
+
+    state1 = ClaudeStreamState()
+    state1.factory._resume = ResumeToken(engine=ENGINE, value="sess-r1")
+    with capture_logs() as logs1:
+        translate_claude_event(
+            _decode_event(event_payload),
+            title="claude",
+            state=state1,
+            factory=state1.factory,
+        )
+
+    # Second run: fresh state (this is what happens on every Telegram turn).
+    state2 = ClaudeStreamState()
+    state2.factory._resume = ResumeToken(engine=ENGINE, value="sess-r2")
+    with capture_logs() as logs2:
+        translate_claude_event(
+            _decode_event(
+                _make_system_init_event(
+                    "sess-r2", mcp_servers=[{"name": "gmail", "status": "needs-auth"}]
+                )
+            ),
+            title="claude",
+            state=state2,
+            factory=state2.factory,
+        )
+
+    first = [r for r in logs1 if r.get("event") == "catalog_staleness.detected"]
+    second = [r for r in logs2 if r.get("event") == "catalog_staleness.detected"]
+    assert len(first) == 1
+    assert second == []
+    suppressed = [r for r in logs2 if r.get("event") == "catalog_staleness.suppressed"]
+    assert len(suppressed) == 1
+
+
+def test_catalog_pending_still_logged_per_run() -> None:
+    """#595: pending keeps per-run granularity (INFO) — it is not routed
+    through the process-lifetime warning registry."""
+    from structlog.testing import capture_logs
+
+    from untether.runners.claude import _CATALOG_STALENESS_WARNED
+
+    _CATALOG_STALENESS_WARNED.clear()
+    logs_per_run = []
+    for run_idx in (1, 2):
+        state = ClaudeStreamState()
+        state.factory._resume = ResumeToken(engine=ENGINE, value=f"sess-p{run_idx}")
+        with capture_logs() as logs:
+            translate_claude_event(
+                _decode_event(
+                    _make_system_init_event(
+                        f"sess-p{run_idx}",
+                        mcp_servers=[{"name": "slow", "status": "pending"}],
+                    )
+                ),
+                title="claude",
+                state=state,
+                factory=state.factory,
+            )
+        logs_per_run.append(
+            [r for r in logs if r.get("event") == "catalog_staleness.pending"]
+        )
+
+    assert len(logs_per_run[0]) == 1
+    assert len(logs_per_run[1]) == 1
 
 
 def test_catalog_staleness_dedups_repeated_init() -> None:
     """Re-fired init with same server+status only logs once per session."""
     from structlog.testing import capture_logs
 
+    from untether.runners.claude import _CATALOG_STALENESS_WARNED
+
+    _CATALOG_STALENESS_WARNED.clear()
     state = ClaudeStreamState()
     state.factory._resume = ResumeToken(engine=ENGINE, value="sess-3")
     event = _decode_event(

--- a/tests/test_claude_schema.py
+++ b/tests/test_claude_schema.py
@@ -216,3 +216,94 @@ def test_decode_advisor_tool_result_block_with_dict_content() -> None:
     assert isinstance(block, claude_schema.StreamAdvisorToolResultBlock)
     assert block.tool_use_id == "adv_501"
     assert block.content == {"type": "text", "text": "advice"}
+
+
+# ---------------------------------------------------------------------------
+# #597 — image + document content blocks (Read on binary media echoes these
+# back inside user-role messages; x23 jsonl.msgspec.invalid on nsd)
+# ---------------------------------------------------------------------------
+
+
+def test_decode_image_block_in_user_message() -> None:
+    """A `Read` on an image echoes an image content block in the user-role
+    message. Schema must parse it instead of dropping the whole line."""
+    payload = {
+        "type": "user",
+        "uuid": "uuid-img",
+        "session_id": "sess-1",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": "aGVsbG8=",
+                    },
+                },
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_img",
+                    "content": "read 1 image",
+                },
+            ],
+        },
+    }
+    decoded = claude_schema.decode_stream_json_line(json.dumps(payload).encode())
+    assert isinstance(decoded, claude_schema.StreamUserMessage)
+    assert isinstance(decoded.message.content, list)
+    block = decoded.message.content[0]
+    assert isinstance(block, claude_schema.StreamImageBlock)
+    assert block.source is not None
+    assert block.source["media_type"] == "image/jpeg"
+    assert isinstance(decoded.message.content[1], claude_schema.StreamToolResultBlock)
+
+
+def test_decode_document_block_in_user_message() -> None:
+    """PDF reads echo a document content block — same #489-family shape."""
+    payload = {
+        "type": "user",
+        "uuid": "uuid-doc",
+        "session_id": "sess-1",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": "JVBERi0=",
+                    },
+                    "title": "report.pdf",
+                }
+            ],
+        },
+    }
+    decoded = claude_schema.decode_stream_json_line(json.dumps(payload).encode())
+    assert isinstance(decoded, claude_schema.StreamUserMessage)
+    assert isinstance(decoded.message.content, list)
+    block = decoded.message.content[0]
+    assert isinstance(block, claude_schema.StreamDocumentBlock)
+    assert block.title == "report.pdf"
+
+
+def test_decode_image_block_in_assistant_message() -> None:
+    """Assistant-role messages can carry image blocks too (vision replies);
+    the union addition covers both bodies for free."""
+    payload = {
+        "type": "assistant",
+        "uuid": "uuid-img2",
+        "session_id": "sess-1",
+        "message": {
+            "role": "assistant",
+            "model": "claude-fable-5",
+            "content": [
+                {"type": "image", "source": {"type": "url", "url": "https://x/y.png"}}
+            ],
+        },
+    }
+    decoded = claude_schema.decode_stream_json_line(json.dumps(payload).encode())
+    assert isinstance(decoded, claude_schema.StreamAssistantMessage)
+    assert isinstance(decoded.message.content[0], claude_schema.StreamImageBlock)

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -6325,3 +6325,94 @@ def test_591_note_final_records_without_repaint() -> None:
 
     assert edits._finalizing is True
     assert edits.event_seq == seq_before
+
+
+# ---------------------------------------------------------------------------
+# #596 — 0-turn / $0 / empty-answer ok=True completion (no-op resume)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_596_empty_result_anomaly_surfaces_note() -> None:
+    """A resumed run returning 0 turns / 0 API ms / empty answer with
+    ok=True must warn and tell the user instead of delivering silence."""
+    from structlog.testing import capture_logs
+
+    transport = FakeTransport()
+    runner = ScriptRunner(
+        [Return(answer="", usage={"num_turns": 0, "duration_api_ms": 0})],
+        engine=CODEX_ENGINE,
+        resume_value="sess-596",
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=False,
+    )
+
+    with capture_logs() as logs:
+        await handle_message(
+            cfg,
+            runner=runner,
+            incoming=IncomingMessage(channel_id=123, message_id=10, text="continue"),
+            resume_token=ResumeToken(engine=CODEX_ENGINE, value="sess-596"),
+        )
+
+    assert any(r.get("event") == "runner.empty_result" for r in logs)
+    final_text = transport.edit_calls[-1]["message"].text
+    assert "empty result" in final_text
+    assert "/new" in final_text
+
+
+@pytest.mark.anyio
+async def test_596_normal_run_with_turns_not_flagged() -> None:
+    """A run that did real work (turns > 0) with an empty answer is NOT
+    classified as the no-op anomaly."""
+    from structlog.testing import capture_logs
+
+    transport = FakeTransport()
+    runner = ScriptRunner(
+        [Return(answer="", usage={"num_turns": 3, "duration_api_ms": 900})],
+        engine=CODEX_ENGINE,
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=False,
+    )
+
+    with capture_logs() as logs:
+        await handle_message(
+            cfg,
+            runner=runner,
+            incoming=IncomingMessage(channel_id=123, message_id=10, text="hi"),
+            resume_token=None,
+        )
+
+    assert not any(r.get("event") == "runner.empty_result" for r in logs)
+    assert "empty result" not in transport.edit_calls[-1]["message"].text
+
+
+@pytest.mark.anyio
+async def test_596_no_usage_reporting_not_flagged() -> None:
+    """Engines that report no usage at all never trip the anomaly — an
+    empty answer alone is not evidence of a no-op resume."""
+    from structlog.testing import capture_logs
+
+    transport = FakeTransport()
+    runner = ScriptRunner([Return(answer="")], engine=CODEX_ENGINE)
+    cfg = ExecBridgeConfig(
+        transport=transport,
+        presenter=MarkdownPresenter(),
+        final_notify=False,
+    )
+
+    with capture_logs() as logs:
+        await handle_message(
+            cfg,
+            runner=runner,
+            incoming=IncomingMessage(channel_id=123, message_id=10, text="hi"),
+            resume_token=None,
+        )
+
+    assert not any(r.get("event") == "runner.empty_result" for r in logs)


### PR DESCRIPTION
## Summary

Three independent minors from the 2026-07-13 fleet audit.

**#595 — catalog_staleness flood (~2,930 WARNINGs/48h fleet-wide)**
- `pending`-at-init → INFO (`catalog_staleness.pending`): it's a startup race, not staleness.
- `needs-auth`/`failed` keep the WARNING but dedup across runs via a process-lifetime `(server, status)` registry — the per-state set reset on every subprocess spawn, so each broken connector re-warned on every Telegram turn (96% of all nsd warnings). Suppressed re-fires log at debug.

**#596 — 0-turn/$0/empty-answer ok=True → user silence**
- The no-op-resume shape now logs `runner.empty_result` WARNING and delivers a visible note ("engine returned an empty result … resend or start fresh with /new") instead of a bare error header with no body. Only fires when the engine explicitly reported `num_turns=0` and `duration_api_ms=0` — engines without usage reporting can't trip it.

**#597 — msgspec rejects image/document content blocks (#489 family)**
- `StreamImageBlock`/`StreamDocumentBlock` added to the content union (permissive `source` dict — payload never rendered). Both translate loops fall through safely (image echoes correctly count as non-tool_result content for the #544 wakeup reset). Stream-json cheatsheet updated.

## Tests
- 9 new/updated: severity split, cross-run dedup + suppressed log, pending-stays-per-run; anomaly note delivered, turns>0 not flagged, no-usage not flagged; image/document decode in user+assistant bodies.
- Full suite: 2821 passed, coverage 82.8%.

fixes #595, fixes #596, fixes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)