### PR TITLE
fix(claude): #592 pre-result silence cap + #593 PID threading & cancel enforcement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ docs = [
 [tool.pytest.ini_options]
 addopts = ["--cov=untether", "--cov-branch", "--cov-report=term-missing", "--cov-fail-under=80"]
 testpaths = ["tests"]
+markers = [
+    "cancel_enforcement: opts a test out of the autouse #593 cancel-enforcement neutraliser",
+]
 
 [tool.mutmut]
 paths_to_mutate = ["src/untether"]

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -1138,6 +1138,73 @@ class ProgressEdits:
                 "progress_edits.post_result_closing_send_failed", exc_info=True
             )
 
+    # #593: cancel-enforcement tuning. Class-level so tests can shrink them.
+    _CANCEL_ESCALATION_S: float = 30.0
+    _CANCEL_ESCALATION_POLL_S: float = 0.5
+    _CANCEL_SIGKILL_GRACE_S: float = 5.0
+
+    async def _enforce_cancel_teardown(self) -> None:
+        """#593: make the stall auto-cancel decision actually tear down.
+
+        ``cancel_event.set()`` only cancels the run task group; the
+        generator unwind can then stall behind the shielded subcountdown or
+        an OOM-starved event loop (observed on nsd: 14m52s between
+        ``stall_auto_cancel`` and ``handle.cancelled``, a dead-weight
+        subprocess occupying the chat slot through an active OOM crisis).
+        Poll for natural teardown up to ``_CANCEL_ESCALATION_S``; if the
+        subprocess is still alive, kill it directly (descendant-aware,
+        SIGTERM → grace → SIGKILL). Shielded so the enclosing scopes'
+        cancellation can't strip the safety net; the early-exit poll keeps
+        the shield cheap on the normal path (subprocess dies within
+        seconds of the cancel).
+        """
+        pid = self.pid
+        if pid is None:
+            # Nothing to enforce against — no PID was ever learned (spawn
+            # itself hung, or a non-subprocess runner).
+            logger.warning(
+                "progress_edits.cancel_enforcement_no_pid",
+                channel_id=self.channel_id,
+            )
+            return
+
+        def _alive() -> bool:
+            stream = self.stream
+            if stream is not None and stream.proc_returncode is not None:
+                return False
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return False
+            except OSError:
+                return True
+            return True
+
+        from .utils.subprocess import signal_pid_group
+
+        with anyio.CancelScope(shield=True):
+            deadline = time.monotonic() + self._CANCEL_ESCALATION_S
+            while time.monotonic() < deadline:
+                if not _alive():
+                    return
+                await anyio.sleep(self._CANCEL_ESCALATION_POLL_S)
+            if not _alive():
+                return
+            logger.warning(
+                "progress_edits.cancel_escalated",
+                channel_id=self.channel_id,
+                pid=pid,
+                escalation_s=self._CANCEL_ESCALATION_S,
+            )
+            signal_pid_group(pid, _signal.SIGTERM)
+            grace_deadline = time.monotonic() + self._CANCEL_SIGKILL_GRACE_S
+            while time.monotonic() < grace_deadline:
+                if not _alive():
+                    return
+                await anyio.sleep(self._CANCEL_ESCALATION_POLL_S)
+            if _alive():
+                signal_pid_group(pid, _signal.SIGKILL)
+
     async def _stall_monitor(self) -> None:
         """Periodically check for event stalls, log diagnostics, and notify.
 
@@ -1451,6 +1518,14 @@ class ProgressEdits:
                     logger.debug(
                         "progress_edits.stall_auto_cancel_notify_failed", exc_info=True
                     )
+                # #593: enforcement — the cancel DECISION must end in actual
+                # teardown. cancel_event only cancels the run task group;
+                # the generator unwind can stall behind a shielded
+                # subcountdown or an OOM-starved event loop (observed:
+                # 14m52s between stall_auto_cancel and handle.cancelled on
+                # nsd). If the subprocess is still alive after the
+                # escalation window, kill it directly (descendant-aware).
+                await self._enforce_cancel_teardown()
                 # Close signal stream so _run_loop exits
                 self.signal_send.close()
                 return

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -378,6 +378,9 @@ class ClaudeStreamState:
     # into their own session and survive a plain killpg — are still
     # terminated after the leader exits.
     orphan_pid_snapshot: list[int] = field(default_factory=list)
+    # #592: one-shot latch — the pre-result silence cap fired and killed
+    # the subprocess; prevents re-firing on subsequent watchdog ticks.
+    pre_result_silence_killed: bool = False
     # #497: debounce gate. Holds the ``time.monotonic()`` timestamp of the
     # last enqueued refresh; the translate path skips re-enqueue while
     # ``(now - last) < catalog_refresh_min_interval_s``. None until the
@@ -2145,6 +2148,9 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     # hold the process (and its RSS/TCP) open. Cap the wait at this grace
     # instead. 0 disables the shortcut (full timeout always applies).
     _post_result_limbo_grace_s: float = 60.0
+    # Floor for the post-result watchdog poll cadence (class attr so tests
+    # can shrink it; production keeps the 5s floor).
+    _watchdog_min_poll_s: float = 5.0
 
     def format_resume(self, token: ResumeToken) -> str:
         if token.engine != ENGINE:
@@ -2738,6 +2744,92 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 )
         state.pending_catalog_refresh_ids.clear()
 
+    async def _maybe_cancel_pre_result_silence(
+        self,
+        *,
+        state: ClaudeStreamState,
+        stream: Any,
+        proc: Any,
+        run_logger: Any,
+        silence_timeout_s: float,
+        started_at: float,
+    ) -> bool:
+        """#592: kill a run whose stream went silent forever pre-first-result.
+
+        The post-result watchdog only arms after a ``result`` event and the
+        liveness machinery never escalates an alive-but-idle process — a run
+        that goes silent before its first result idled FOREVER (8-day zombie
+        Claude subprocess + leaked MCP children + held session lock on mac).
+
+        Fires only when: zero stream output for ``silence_timeout_s``
+        (measured from the later of watchdog start and the last stdout
+        line), NO pending permission/ask requests (plan-approval waits are
+        by design, #526/#527) and NO live background work. The kill is
+        descendant-aware; a reason line is appended to ``stderr_capture`` so
+        the run's error message tells the user what happened. Returns True
+        when the cap fired.
+        """
+        if silence_timeout_s <= 0 or proc is None or proc.returncode is not None:
+            return False
+        if state.pre_result_silence_killed:
+            return False
+        last_out = float(getattr(stream, "last_stdout_at", 0.0) or 0.0)
+        silence_s = time.monotonic() - max(last_out, started_at)
+        if silence_s < silence_timeout_s:
+            return False
+        sid = state.factory.resume.value if state.factory.resume is not None else None
+        pending_requests = (
+            [k for k, v in _REQUEST_TO_SESSION.items() if v == sid] if sid else []
+        )
+        pending_asks = (
+            [k for k in _PENDING_ASK_REQUESTS if _REQUEST_TO_SESSION.get(k) == sid]
+            if sid
+            else []
+        )
+        live_bg = has_live_background_work(state)
+        if pending_requests or pending_asks or live_bg:
+            run_logger.info(
+                "claude.pre_result_silence.suppressed",
+                session_id=sid,
+                pid=proc.pid,
+                silence_s=round(silence_s, 1),
+                pending_requests=len(pending_requests),
+                pending_asks=len(pending_asks),
+                live_background_work=live_bg,
+            )
+            return False
+        state.pre_result_silence_killed = True
+        run_logger.warning(
+            "claude.pre_result_silence.cancel",
+            session_id=sid,
+            pid=proc.pid,
+            silence_s=round(silence_s, 1),
+            timeout_s=silence_timeout_s,
+        )
+        # Thread the reason into the run's error message via the stderr
+        # excerpt (#575 machinery) — the resulting rc=143 error would
+        # otherwise be indistinguishable from any other kill.
+        if hasattr(stream, "stderr_capture"):
+            stream.stderr_capture.append(
+                f"untether: no stream output for {int(silence_s // 60)}m before "
+                f"any result — pre-result silence cap "
+                f"({int(silence_timeout_s // 60)}m) hit; run auto-cancelled (#592)"
+            )
+        signal_pid_group(proc.pid, signal.SIGTERM)
+        grace_deadline = time.monotonic() + self._subcountdown_sigterm_grace_s
+        while time.monotonic() < grace_deadline:
+            await anyio.sleep(self._subcountdown_sigterm_grace_poll_s)
+            if proc.returncode is not None:
+                return True
+        if proc.returncode is None:
+            run_logger.warning(
+                "claude.pre_result_silence.sigkill_after_grace",
+                session_id=sid,
+                pid=proc.pid,
+            )
+            signal_pid_group(proc.pid, signal.SIGKILL)
+        return True
+
     async def _post_result_idle_watchdog(
         self,
         state: ClaudeStreamState,
@@ -2748,6 +2840,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         proc: Any = None,
         stream: Any = None,
         limbo_grace_s: float | None = None,
+        pre_result_silence_timeout_s: float = 3600.0,
     ) -> None:
         """Close stdin once the bidirectional CLI has been idle past the result.
 
@@ -2772,7 +2865,9 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         """
         # Poll often enough to react within a few seconds of the deadline,
         # but not so often that we burn CPU on a fully idle session.
-        poll_interval = max(5.0, min(timeout_s / 20.0, 30.0))
+        # (_watchdog_min_poll_s is a class attr so tests can shrink it.)
+        poll_interval = max(self._watchdog_min_poll_s, min(timeout_s / 20.0, 30.0))
+        watchdog_started_at = time.monotonic()
 
         # #333 instrumentation. channelo rc15→rc16 hit a 43+ min post-result
         # hang where this watchdog silently failed to fire (no
@@ -2885,6 +2980,20 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                                 state.last_schedule_wakeup_arm_delay
                             ),
                         )
+                        # #592: a run that never produces its first result
+                        # was previously unbounded — nothing owned the
+                        # "alive-but-silent forever" case.
+                        killed = await self._maybe_cancel_pre_result_silence(
+                            state=state,
+                            stream=stream,
+                            proc=proc,
+                            run_logger=run_logger,
+                            silence_timeout_s=pre_result_silence_timeout_s,
+                            started_at=watchdog_started_at,
+                        )
+                        if killed:
+                            exit_reason = "pre_result_silence_cancelled"
+                            return
                         continue
                     elapsed = time.monotonic() - armed_at
 
@@ -3528,6 +3637,12 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 # #361 stash PID so the env audit in translate_claude_event
                 # can sample /proc/<pid>/environ on system.init.
                 state.pid = proc.pid
+                # #593: the base runner sets last_pid but this override never
+                # did — the bridge's thread_pid() early-poll returned None for
+                # Claude, so stall diagnostics ran blind (pid=None
+                # process_alive=None) exactly when a run never emitted a
+                # StartedEvent (the only other PID source).
+                self.last_pid = proc.pid
                 self.current_stream = stream
                 reader_done = anyio.Event()
 
@@ -3537,6 +3652,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 post_result_idle_enabled = True
                 post_result_idle_timeout_s = 600.0
                 post_result_limbo_grace_s = self._post_result_limbo_grace_s
+                pre_result_silence_timeout_s = 3600.0
                 try:
                     result = load_settings_if_exists()
                     if result is not None:
@@ -3549,6 +3665,9 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                         )
                         post_result_limbo_grace_s = float(
                             settings_obj.watchdog.post_result_limbo_grace
+                        )
+                        pre_result_silence_timeout_s = float(
+                            settings_obj.watchdog.pre_result_silence_timeout
                         )
                 except Exception:  # noqa: BLE001 — settings errors must not block a run
                     run_logger.debug(
@@ -3586,6 +3705,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                             proc,
                             stream,
                             post_result_limbo_grace_s,
+                            pre_result_silence_timeout_s,
                         )
                     async for evt in self._iter_jsonl_events(
                         stdout=proc.stdout,

--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -390,6 +390,17 @@ class WatchdogSettings(BaseModel):
     post_result_idle_enabled: bool = True
     post_result_idle_timeout: float = Field(default=600.0, ge=30, le=3600)
 
+    # #592: pre-first-result silence cap. A run whose stream goes silent
+    # forever BEFORE any result event was previously never auto-cancelled —
+    # the post-result watchdog only arms after a result, and the liveness
+    # machinery never escalates an alive-but-idle process (8-day zombie
+    # Claude subprocess on mac). After this many seconds with zero stream
+    # output, no pending permission/ask requests, and no live background
+    # work, the subprocess is killed (descendant-aware) and the run ends
+    # with an explanatory error. Default 1h accommodates subscription
+    # rate-limit waits; 0 disables. Range 0-24h.
+    pre_result_silence_timeout: float = Field(default=3600.0, ge=0, le=86400)
+
     # #591: short-circuit grace for the post-result subcountdown. Once the
     # JSONL reader is done and nothing references the session (no pending
     # control/ask requests, no live background work), the subprocess is only

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -4445,3 +4445,246 @@ async def test_590_limbo_refreshes_orphan_snapshot(monkeypatch) -> None:
     assert "runner.limbo_detected" in logger.events()
     # 901/902 added; 900 not duplicated.
     assert state.orphan_pid_snapshot == [900, 901, 902]
+
+
+# ===========================================================================
+# #592 — pre-first-result silence cap (the 8-day-zombie dead zone)
+# ===========================================================================
+
+
+def _silence_watchdog_runner() -> "ClaudeRunner":
+    from untether.runners.claude import ClaudeRunner
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._watchdog_min_poll_s = 0.02
+    runner._subcountdown_sigterm_grace_s = 0.1
+    runner._subcountdown_sigterm_grace_poll_s = 0.02
+    return runner
+
+
+@pytest.mark.anyio
+async def test_592_pre_result_silence_cap_kills_silent_run(monkeypatch) -> None:
+    """A run with zero stream output and no result is killed once the
+    silence cap elapses; the reason lands in stderr_capture so the run's
+    error message explains itself."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = _silence_watchdog_runner()
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="silent-sess-1"))
+    # result_received_at stays None — pre-result forever.
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=72424, returncode=None)
+    killed_signals: list[int] = []
+
+    def _fake_killpg(pgid: int, sig: int) -> None:
+        killed_signals.append(sig)
+        proc.returncode = -15  # SIGTERM obeyed
+
+    monkeypatch.setattr("os.killpg", _fake_killpg)
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()  # never set — the reader is blocked forever
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            0.2,  # post-result timeout (drives poll cadence only here)
+            proc,
+            stream,
+            0.0,  # limbo grace off
+            0.15,  # pre_result_silence_timeout_s — the cap under test
+        )
+        with anyio.move_on_after(3.0):
+            while signal.SIGTERM not in killed_signals:
+                await anyio.sleep(0.02)
+        tg.cancel_scope.cancel()
+
+    assert signal.SIGTERM in killed_signals
+    assert "claude.pre_result_silence.cancel" in logger.events("warning")
+    exit_reasons = [
+        kw.get("reason")
+        for lvl, e, kw in logger.records
+        if e == "claude.post_result_idle.task_exited"
+    ]
+    assert "pre_result_silence_cancelled" in exit_reasons
+    assert any("pre-result silence cap" in line for line in stream.stderr_capture)
+    assert state.pre_result_silence_killed is True
+
+
+@pytest.mark.anyio
+async def test_592_silence_cap_suppressed_by_pending_request(monkeypatch) -> None:
+    """A pending permission request (e.g. plan-mode approval wait) must
+    suppress the cap — cron+plan-mode long idles are by design."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+    )
+
+    sid = "silent-sess-2"
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+    _REQUEST_TO_SESSION["req_silence"] = sid
+    try:
+        runner = _silence_watchdog_runner()
+        state = ClaudeStreamState()
+        state.factory.started(ResumeToken(engine="claude", value=sid))
+        stream = JsonlStreamState(expected_session=None)
+
+        proc = _FakeProc(pid=72425, returncode=None)
+        killed_signals: list[int] = []
+        monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+
+        logger = _RecordingLogger()
+        reader_done = anyio.Event()
+
+        class FakeStdin:
+            async def aclose(self) -> None:
+                pass
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                runner._post_result_idle_watchdog,
+                state,
+                FakeStdin(),
+                reader_done,
+                logger,
+                0.2,
+                proc,
+                stream,
+                0.0,
+                0.1,
+            )
+            await anyio.sleep(0.6)
+            tg.cancel_scope.cancel()
+
+        assert killed_signals == []
+        assert "claude.pre_result_silence.suppressed" in logger.events("info")
+        assert state.pre_result_silence_killed is False
+    finally:
+        _REQUEST_TO_SESSION.clear()
+
+
+@pytest.mark.anyio
+async def test_592_silence_cap_suppressed_by_live_background_work(
+    monkeypatch,
+) -> None:
+    """Live background work (pending wakeup) suppresses the cap."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = _silence_watchdog_runner()
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="silent-sess-3"))
+    state.live_wakeups["toolu_silent"] = time.monotonic() + 3600.0
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=72426, returncode=None)
+    killed_signals: list[int] = []
+    monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            0.2,
+            proc,
+            stream,
+            0.0,
+            0.1,
+        )
+        await anyio.sleep(0.6)
+        tg.cancel_scope.cancel()
+
+    assert killed_signals == []
+    assert state.pre_result_silence_killed is False
+
+
+@pytest.mark.anyio
+async def test_592_silence_cap_zero_disables(monkeypatch) -> None:
+    """pre_result_silence_timeout=0 disables the cap entirely."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = _silence_watchdog_runner()
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="silent-sess-4"))
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=72427, returncode=None)
+    killed_signals: list[int] = []
+    monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            0.2,
+            proc,
+            stream,
+            0.0,
+            0.0,  # disabled
+        )
+        await anyio.sleep(0.5)
+        tg.cancel_scope.cancel()
+
+    assert killed_signals == []
+    assert state.pre_result_silence_killed is False

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -36,6 +36,25 @@ from untether.transport import MessageRef, RenderedMessage, SendOptions
 CODEX_ENGINE = "codex"
 
 
+@pytest.fixture(autouse=True)
+def _neutralise_cancel_enforcement(request, monkeypatch):
+    """#593: the stall auto-cancel path now enforces teardown by probing —
+    and if needed killing — the recorded PID. Most tests here use fake PIDs
+    (12345 etc.) that can collide with real host processes; neutralise the
+    enforcement everywhere except the dedicated #593 tests (marked
+    ``cancel_enforcement``), which patch the probe/kill primitives
+    themselves."""
+    if request.node.get_closest_marker("cancel_enforcement"):
+        yield
+        return
+
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(ProgressEdits, "_enforce_cancel_teardown", _noop)
+    yield
+
+
 class FakeTransport:
     def __init__(self) -> None:
         self._next_id = 1
@@ -6325,3 +6344,99 @@ def test_591_note_final_records_without_repaint() -> None:
 
     assert edits._finalizing is True
     assert edits.event_seq == seq_before
+
+
+# ---------------------------------------------------------------------------
+# #593 — stall auto-cancel enforcement (decision must end in teardown)
+# ---------------------------------------------------------------------------
+
+
+def _enforcement_edits(pid: int | None) -> ProgressEdits:
+    import time as _time
+
+    tracker = ProgressTracker(engine="codex")
+    edits = ProgressEdits(
+        transport=FakeTransport(),
+        presenter=MarkdownPresenter(),
+        channel_id=123,
+        progress_ref=MessageRef(channel_id=123, message_id=1),
+        tracker=tracker,
+        started_at=0.0,
+        clock=_time.monotonic,
+        last_rendered=None,
+    )
+    edits.pid = pid
+    edits._CANCEL_ESCALATION_S = 0.1
+    edits._CANCEL_ESCALATION_POLL_S = 0.01
+    edits._CANCEL_SIGKILL_GRACE_S = 0.1
+    return edits
+
+
+@pytest.mark.anyio
+@pytest.mark.cancel_enforcement
+async def test_593_cancel_enforcement_escalates_to_direct_kill(monkeypatch) -> None:
+    """If the subprocess is still alive after the escalation window, the
+    bridge kills it directly instead of trusting the generator unwind
+    (observed 14m52s gap between stall_auto_cancel and handle.cancelled)."""
+    from structlog.testing import capture_logs
+
+    alive = {"v": True}
+    signals: list[int] = []
+
+    def fake_probe(pid: int, sig: int) -> None:
+        if sig == 0 and not alive["v"]:
+            raise ProcessLookupError
+
+    def fake_group_kill(pid: int, sig) -> None:
+        signals.append(int(sig))
+        if int(sig) == 15:
+            alive["v"] = False  # SIGTERM obeyed
+
+    monkeypatch.setattr("untether.runner_bridge.os.kill", fake_probe)
+    monkeypatch.setattr("untether.utils.subprocess.signal_pid_group", fake_group_kill)
+
+    edits = _enforcement_edits(pid=88888)
+    with capture_logs() as logs:
+        await edits._enforce_cancel_teardown()
+
+    assert 15 in signals  # SIGTERM delivered
+    assert 9 not in signals  # died within grace — no SIGKILL
+    assert any(r.get("event") == "progress_edits.cancel_escalated" for r in logs)
+
+
+@pytest.mark.anyio
+@pytest.mark.cancel_enforcement
+async def test_593_cancel_enforcement_noop_when_teardown_succeeds(
+    monkeypatch,
+) -> None:
+    """Subprocess dies during the escalation window → no direct kill."""
+    calls: list[int] = []
+
+    def fake_probe(pid: int, sig: int) -> None:
+        raise ProcessLookupError  # already dead
+
+    monkeypatch.setattr("untether.runner_bridge.os.kill", fake_probe)
+    monkeypatch.setattr(
+        "untether.utils.subprocess.signal_pid_group",
+        lambda pid, sig: calls.append(int(sig)),
+    )
+
+    edits = _enforcement_edits(pid=88889)
+    await edits._enforce_cancel_teardown()
+
+    assert calls == []
+
+
+@pytest.mark.anyio
+@pytest.mark.cancel_enforcement
+async def test_593_cancel_enforcement_without_pid_logs_and_returns() -> None:
+    """No PID was ever learned — nothing to enforce against; log it."""
+    from structlog.testing import capture_logs
+
+    edits = _enforcement_edits(pid=None)
+    with capture_logs() as logs:
+        await edits._enforce_cancel_teardown()
+
+    assert any(
+        r.get("event") == "progress_edits.cancel_enforcement_no_pid" for r in logs
+    )


### PR DESCRIPTION
## Summary

The remaining two watchdog gaps from the fleet-audit lifecycle cluster.

**#592 — watchdog dead zone: run that never emits a result idles forever**
- New `[watchdog] pre_result_silence_timeout` (default 3600s, 0=off). The post-result watchdog's pre-result branch now bounds the "alive-but-silent forever, no result yet" case (the 8-day mac zombie: silence after rate-limit events, 3,441 idle ticks/48h, leaked MCP children + held session lock).
- Kill is descendant-aware (SIGTERM → grace → SIGKILL); **suppressed** while permission/ask requests are pending (plan-approval waits are by design, #526/#527) or live background work exists. The reason is threaded into `stderr_capture` so the resulting error message says "pre-result silence cap hit" instead of a bare rc=143.

**#593 — stall_auto_cancel decided but teardown took 15 minutes; pid=None diagnostics**
- `ClaudeRunner.run_impl` now sets `self.last_pid` (the base runner did; the override didn't) — the bridge's early PID poll works for Claude, so stall diagnostics have a PID even when no StartedEvent ever arrives (`no_pid_no_events` blind spot).
- Auto-cancel now **enforces** teardown: `_enforce_cancel_teardown` polls up to 30s for natural death after `cancel_event.set()`, then kills directly (descendant-aware, shielded, early-exit poll keeps the normal path cheap). Logs `progress_edits.cancel_escalated`.

## Tests
- 7 new: silence cap kills + reason in stderr, suppressed by pending request / live wakeup, 0 disables; enforcement escalates / no-ops on natural death / no-pid logs.
- Safety: autouse fixture neutralises enforcement in the existing auto-cancel tests (fake PIDs like 12345 must never probe/kill real host processes); dedicated tests opt out via the registered `cancel_enforcement` marker.
- Full suite: 2826 passed, coverage 82.7%.

## Integration (dev bot)
- Normal Claude run unaffected: watchdog starts, result delivered at 14.5s, clean exit.
- #569 constraint honoured: the SIGTERM safety net is extended, not weakened; #568 auto-continue untouched.

fixes #592, fixes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)