### PR TITLE
fix(telegram): #598 surface failure reason in transport.edit.failed; not-modified as no-op

### DIFF
--- a/src/untether/telegram/bridge.py
+++ b/src/untether/telegram/bridge.py
@@ -365,11 +365,31 @@ class TelegramTransport:
         )
         if edited is None:
             if wait:
+                # #598: attach the recorded failure reason — previously the
+                # Telegram description was only visible in a separate,
+                # uncorrelated telegram.api_error line, making this warning
+                # undiagnosable from logs.
+                reason: str | None = None
+                pop = getattr(self._bot, "pop_edit_error", None)
+                if callable(pop):
+                    reason = pop(chat_id, message_id)
+                if reason is not None and "message is not modified" in reason:
+                    # #598/#364 family: Telegram rejects edits whose text AND
+                    # markup match the current message — the edit's intent is
+                    # already satisfied, so this is a no-op, not a failure.
+                    logger.info(
+                        "transport.edit.noop",
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        has_reply_markup=reply_markup is not None,
+                    )
+                    return ref
                 logger.warning(
                     "transport.edit.failed",
                     chat_id=chat_id,
                     message_id=message_id,
                     has_reply_markup=reply_markup is not None,
+                    error=reason,
                 )
                 return None
             logger.debug(

--- a/src/untether/telegram/client.py
+++ b/src/untether/telegram/client.py
@@ -240,6 +240,14 @@ class TelegramClient:
             chat_id=chat_id,
         )
 
+    def pop_edit_error(self, chat_id: int, message_id: int) -> str | None:
+        """#598: fetch-and-clear the recorded ``editMessageText`` failure
+        reason for a message, so ``transport.edit.failed`` can say WHY."""
+        pop = getattr(self._client, "pop_last_api_error", None)
+        if callable(pop):
+            return pop("editMessageText", chat_id, message_id)
+        return None
+
     async def edit_message_text(
         self,
         chat_id: int,

--- a/src/untether/telegram/client_api.py
+++ b/src/untether/telegram/client_api.py
@@ -150,10 +150,38 @@ class HttpBotClient:
         self._file_base = f"https://api.telegram.org/file/bot{token}"
         self._http_client = http_client or httpx.AsyncClient(timeout=timeout_s)
         self._owns_http_client = http_client is None
+        # #598: last failure reason per (method, chat_id, message_id). The
+        # queued call chain returns bare ``None`` on failure, so upper
+        # layers (e.g. ``transport.edit.failed``) previously could not say
+        # WHY an edit failed — the Telegram description was only visible in
+        # a separate, uncorrelated ``telegram.api_error`` line. Bounded
+        # insertion-ordered dict; entries are popped on read.
+        self._last_api_errors: dict[tuple[str, Any, Any], str] = {}
 
     async def close(self) -> None:
         if self._owns_http_client:
             await self._http_client.aclose()
+
+    def _record_api_error(
+        self,
+        method: str,
+        request_payload: Any,
+        description: str,
+    ) -> None:
+        """#598: remember why a request failed, keyed for later correlation."""
+        chat_id = message_id = None
+        if isinstance(request_payload, dict):
+            chat_id = request_payload.get("chat_id")
+            message_id = request_payload.get("message_id")
+        self._last_api_errors[(method, chat_id, message_id)] = description
+        while len(self._last_api_errors) > 64:
+            self._last_api_errors.pop(next(iter(self._last_api_errors)))
+
+    def pop_last_api_error(
+        self, method: str, chat_id: Any, message_id: Any
+    ) -> str | None:
+        """#598: fetch-and-clear the recorded failure reason for a request."""
+        return self._last_api_errors.pop((method, chat_id, message_id), None)
 
     def _parse_telegram_envelope(
         self,
@@ -161,6 +189,7 @@ class HttpBotClient:
         method: str,
         resp: httpx.Response,
         payload: Any,
+        request_payload: Any = None,
     ) -> Any | None:
         if not isinstance(payload, dict):
             logger.error(
@@ -169,6 +198,7 @@ class HttpBotClient:
                 url=_safe_url(resp.request.url),
                 payload=payload,
             )
+            self._record_api_error(method, request_payload, "invalid payload")
             return None
 
         if not payload.get("ok"):
@@ -187,6 +217,11 @@ class HttpBotClient:
                 method=method,
                 url=_safe_url(resp.request.url),
                 payload=payload,
+            )
+            self._record_api_error(
+                method,
+                request_payload,
+                str(payload.get("description") or payload.get("error_code") or "?"),
             )
             return None
 
@@ -225,6 +260,9 @@ class HttpBotClient:
                 error=str(exc),
                 error_type=exc.__class__.__name__,
             )
+            self._record_api_error(
+                method, request_payload, f"network error: {exc.__class__.__name__}"
+            )
             return None
 
         try:
@@ -261,6 +299,9 @@ class HttpBotClient:
                 error=str(exc),
                 body=body,
             )
+            self._record_api_error(
+                method, request_payload, f"http {resp.status_code}: {body[:200]}"
+            )
             return None
 
         try:
@@ -282,6 +323,7 @@ class HttpBotClient:
             method=method,
             resp=resp,
             payload=response_payload,
+            request_payload=request_payload,
         )
 
     def _decode_result(

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -3858,3 +3858,92 @@ async def test_run_main_loop_mentions_only_skips_voice_and_files(
     assert calls["voice"] == 0
     assert calls["file"] == 0
     assert runner.calls == []
+
+
+# ---------------------------------------------------------------------------
+# #598 — transport.edit.failed carries the failure reason
+# ---------------------------------------------------------------------------
+
+
+class _FailingEditBot:
+    """Minimal bot double: edits always fail; reason is retrievable."""
+
+    def __init__(self, reason: str | None) -> None:
+        self._reason = reason
+        self.pop_calls: list[tuple[int, int]] = []
+
+    async def edit_message_text(self, **kwargs: Any) -> None:
+        return None
+
+    def pop_edit_error(self, chat_id: int, message_id: int) -> str | None:
+        self.pop_calls.append((chat_id, message_id))
+        return self._reason
+
+
+@pytest.mark.anyio
+async def test_598_edit_failed_log_includes_reason() -> None:
+    from structlog.testing import capture_logs
+
+    from untether.telegram.bridge import TelegramTransport
+
+    bot = _FailingEditBot("Bad Request: message to edit not found")
+    transport = TelegramTransport(bot)  # type: ignore[arg-type]
+    ref = MessageRef(channel_id=123, message_id=916)
+
+    with capture_logs() as logs:
+        result = await transport.edit(
+            ref=ref,
+            message=RenderedMessage(
+                text="cleared", extra={"reply_markup": {"inline_keyboard": []}}
+            ),
+        )
+
+    assert result is None
+    assert bot.pop_calls == [(123, 916)]
+    rec = next(r for r in logs if r.get("event") == "transport.edit.failed")
+    assert rec["error"] == "Bad Request: message to edit not found"
+    assert rec["has_reply_markup"] is True
+
+
+@pytest.mark.anyio
+async def test_598_not_modified_treated_as_noop() -> None:
+    """'message is not modified' means the edit's intent is already
+    satisfied — an info-level no-op, not a warning."""
+    from structlog.testing import capture_logs
+
+    from untether.telegram.bridge import TelegramTransport
+
+    bot = _FailingEditBot("Bad Request: message is not modified")
+    transport = TelegramTransport(bot)  # type: ignore[arg-type]
+    ref = MessageRef(channel_id=123, message_id=916)
+
+    with capture_logs() as logs:
+        result = await transport.edit(
+            ref=ref, message=RenderedMessage(text="same text")
+        )
+
+    assert result == ref
+    assert not any(r.get("event") == "transport.edit.failed" for r in logs)
+    assert any(r.get("event") == "transport.edit.noop" for r in logs)
+
+
+@pytest.mark.anyio
+async def test_598_edit_failed_tolerates_bot_without_pop() -> None:
+    """Bots/doubles without pop_edit_error still log (error=None)."""
+    from structlog.testing import capture_logs
+
+    from untether.telegram.bridge import TelegramTransport
+
+    class _PlainFailingBot:
+        async def edit_message_text(self, **kwargs: Any) -> None:
+            return None
+
+    transport = TelegramTransport(_PlainFailingBot())  # type: ignore[arg-type]
+    ref = MessageRef(channel_id=123, message_id=917)
+
+    with capture_logs() as logs:
+        result = await transport.edit(ref=ref, message=RenderedMessage(text="x"))
+
+    assert result is None
+    rec = next(r for r in logs if r.get("event") == "transport.edit.failed")
+    assert rec["error"] is None

--- a/tests/test_telegram_client_api.py
+++ b/tests/test_telegram_client_api.py
@@ -275,3 +275,40 @@ async def test_download_file_rejects_path_with_scheme_or_traversal(
         assert client.got_called is False
     finally:
         await client.close()
+
+
+# ---------------------------------------------------------------------------
+# #598 — failure reasons recorded for later correlation
+# ---------------------------------------------------------------------------
+
+
+def test_598_api_error_recorded_and_popped() -> None:
+    client = HttpBotClient("token", http_client=httpx.AsyncClient())
+    payload = {
+        "ok": False,
+        "error_code": 400,
+        "description": "Bad Request: message is not modified",
+    }
+    result = client._parse_telegram_envelope(
+        method="editMessageText",
+        resp=_response(),
+        payload=payload,
+        request_payload={"chat_id": 123, "message_id": 916, "text": "x"},
+    )
+    assert result is None
+    reason = client.pop_last_api_error("editMessageText", 123, 916)
+    assert reason == "Bad Request: message is not modified"
+    # pop clears the entry
+    assert client.pop_last_api_error("editMessageText", 123, 916) is None
+
+
+def test_598_error_store_is_bounded() -> None:
+    client = HttpBotClient("token", http_client=httpx.AsyncClient())
+    for i in range(80):
+        client._record_api_error(
+            "editMessageText", {"chat_id": 1, "message_id": i}, f"err {i}"
+        )
+    assert len(client._last_api_errors) <= 64
+    # Oldest entries evicted, newest retained
+    assert client.pop_last_api_error("editMessageText", 1, 0) is None
+    assert client.pop_last_api_error("editMessageText", 1, 79) == "err 79"


### PR DESCRIPTION
## Summary

Stage 1 of #598, per the issue's own guidance ("FIRST add exception detail to the log site, THEN debug the race").

- `HttpBotClient` records the failure reason per `(method, chat_id, message_id)` on every failure path — API error description, HTTP status + body excerpt, network error class — in a bounded fetch-and-clear store. `TelegramClient.pop_edit_error()` exposes it.
- `transport.edit.failed` now carries `error=<reason>`. Previously the Telegram description was only visible in a separate, uncorrelated `telegram.api_error` line.
- `"message is not modified"` is normalised to info-level `transport.edit.noop` returning the original ref — the edit's intent is already satisfied (#364 family).

## Repro attempt

The sl 3/3-deterministic failure does **not** reproduce on `@untether_dev_bot`: full ask-mode flow verified live (question buttons → answer → `control_response.sent approved=True` → keyboard cleared → final answer delivered, zero `transport.edit.failed`). The race is environment-specific to sl (group chat / pacing). With this instrumentation, the next fleet occurrence pins the actual reason; if it's not-modified, the noop path already absorbs it. Follow-up diagnosis stays on #598.

## Tests
- 5 new: reason recorded + popped, store bounded at 64, failed-edit log carries error, not-modified noop returns ref, bot doubles without `pop_edit_error` still log.
- Full suite: 2824 passed, coverage 82.7%.

Refs #598 (instrumentation + benign-noop handling; leave open pending fleet evidence of the underlying reason)

🤖 Generated with [Claude Code](https://claude.com/claude-code)