### PR TITLE
chore: staging 0.35.4rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.4rc2"
+version = "0.35.4rc3"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.4rc2"
+version = "0.35.4rc3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Version bump so TestPyPI publishes an rc carrying today's fleet-audit fixes (#602–#608, #585, #604). No code changes. rc versions need no changelog entry per release-discipline; the 0.35.4 stable changelog lands with the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)