### PR TITLE
fix(bridge): #614 close runner generator in pump task + shield early final delivery

### DIFF
--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -2822,8 +2822,9 @@ async def run_runner_with_cancel(
         async with anyio.create_task_group() as tg:
 
             async def run_runner() -> None:
+                events = runner.run(prompt, resume_token)
                 try:
-                    async for evt in runner.run(prompt, resume_token):
+                    async for evt in events:
                         _log_runner_event(evt)
                         if isinstance(evt, StartedEvent):
                             outcome.resume = evt.resume
@@ -2872,7 +2873,17 @@ async def run_runner_with_cancel(
                                     evt, outcome.resume, channel_id=channel_id
                                 )
                                 try:
-                                    await on_completed(evt, outcome)
+                                    # #614: shield the delivery — a /cancel
+                                    # landing mid-send would otherwise cancel
+                                    # this await AFTER the message hit the
+                                    # wire but BEFORE final_delivery["sent"]
+                                    # was recorded, so handle_message would
+                                    # render a spurious "cancelled" message
+                                    # on top of the delivered answer. Bounded
+                                    # so a wedged transport can't hold the
+                                    # cancel hostage.
+                                    with anyio.move_on_after(15, shield=True):
+                                        await on_completed(evt, outcome)
                                 except Exception:  # noqa: BLE001
                                     logger.warning(
                                         "final.early_delivery_failed",
@@ -2883,6 +2894,22 @@ async def run_runner_with_cancel(
                         _record_export_event(evt, outcome.resume, channel_id=channel_id)
                         await edits.on_event(evt)
                 finally:
+                    # #614: close the runner generator in THIS task. When the
+                    # async-for is abandoned mid-body (e.g. /cancel lands
+                    # while on_completed is awaiting), the generator is left
+                    # suspended at a yield and would be finalized later by
+                    # the event loop's async-generator hook in a DIFFERENT
+                    # task — and run_impl's anyio task group then raises
+                    # "Attempted to exit cancel scope in a different task
+                    # than it was entered in" as an unretrieved task
+                    # exception. Shielded so the pending bridge-level
+                    # cancellation can't interrupt generator teardown
+                    # (subprocess kill, registry cleanup); bounded so a
+                    # wedged teardown can't hang the bridge.
+                    aclose = getattr(events, "aclose", None)
+                    if aclose is not None:
+                        with anyio.move_on_after(30, shield=True):
+                            await aclose()
                     tg.cancel_scope.cancel()
 
             async def wait_cancel(task: RunningTask) -> None:

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -15,6 +15,7 @@ from untether.runner_bridge import (
     ExecBridgeConfig,
     IncomingMessage,
     ProgressEdits,
+    RunOutcome,
     _format_run_cost,
     handle_message,
     register_ephemeral_message,
@@ -6530,4 +6531,180 @@ async def test_593_cancel_enforcement_without_pid_logs_and_returns() -> None:
 
     assert any(
         r.get("event") == "progress_edits.cancel_enforcement_no_pid" for r in logs
+    )
+
+
+# ---------------------------------------------------------------------------
+# #614: cancel during early final delivery — generator teardown + delivery
+# ---------------------------------------------------------------------------
+
+
+class _TaskGroupHoldOpenRunner:
+    """Mimics ClaudeRunner.run_impl's shape: yields events from inside an
+    anyio task group, then holds the generator open after CompletedEvent
+    (the #591/#592 post-result idle window).
+
+    Records which asyncio task consumed the generator and which task ran
+    its cleanup, so tests can assert teardown happened in the pump task
+    rather than in the event loop's async-generator finalizer.
+    """
+
+    engine = CODEX_ENGINE
+
+    def __init__(self) -> None:
+        self.consume_task: object = None
+        self.cleanup_task: object = None
+        self.cleanup_ran = anyio.Event()
+        self.taskgroup_exit_error: BaseException | None = None
+        self._token = ResumeToken(
+            engine=CODEX_ENGINE, value="019b66fc-64c2-7a71-81cd-081c504cfeb2"
+        )
+
+    def format_resume(self, token: ResumeToken) -> str:
+        return f"codex resume {token.value}"
+
+    async def run(self, prompt: str, resume: ResumeToken | None):
+        import asyncio
+
+        from untether.model import StartedEvent
+
+        hold = anyio.Event()
+        try:
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(anyio.sleep_forever)
+                self.consume_task = asyncio.current_task()
+                yield StartedEvent(
+                    engine=CODEX_ENGINE, resume=self._token, title="codex"
+                )
+                yield CompletedEvent(
+                    engine=CODEX_ENGINE,
+                    ok=True,
+                    answer="done",
+                    resume=self._token,
+                )
+                # Post-result hold-open: generator stays suspended here (or
+                # at the yield above) until closed.
+                await hold.wait()
+        except BaseException as exc:
+            self.taskgroup_exit_error = exc
+            raise
+        finally:
+            import asyncio
+
+            self.cleanup_task = asyncio.current_task()
+            self.cleanup_ran.set()
+
+
+async def _drive_cancel_mid_delivery(
+    runner: _TaskGroupHoldOpenRunner,
+    blocking_deliver,
+    running_task,
+) -> RunOutcome:
+    """Run run_runner_with_cancel and fire /cancel while on_completed is
+    suspended, so the runner generator is parked at its yield when the
+    pump task unwinds."""
+    from untether.runner_bridge import run_runner_with_cancel
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    edits = _make_edits(transport, presenter)
+    outcome_box: list = []
+
+    async def drive() -> None:
+        outcome_box.append(
+            await run_runner_with_cancel(
+                runner,  # type: ignore[arg-type]
+                prompt="p",
+                resume_token=None,
+                edits=edits,
+                running_task=running_task,
+                on_thread_known=None,
+                channel_id=123,
+                on_completed=blocking_deliver,
+            )
+        )
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(drive)
+        with anyio.fail_after(2):
+            await blocking_deliver.in_delivery.wait()
+        running_task.cancel_requested.set()
+        # Let wait_cancel fire and the cancellation propagate before
+        # releasing the delivery, so the pre-fix behaviour (delivery
+        # cancelled mid-flight) is exercised deterministically.
+        for _ in range(20):
+            await anyio.lowlevel.checkpoint()
+        blocking_deliver.release.set()
+
+    assert outcome_box, "run_runner_with_cancel did not return"
+    return outcome_box[0]
+
+
+def _make_blocking_deliver():
+    class _Deliver:
+        in_delivery = anyio.Event()
+        release = anyio.Event()
+        completed = anyio.Event()
+
+        async def __call__(self, evt, outcome) -> None:
+            self.in_delivery.set()
+            await self.release.wait()
+            self.completed.set()
+
+    return _Deliver()
+
+
+@pytest.mark.anyio
+async def test_cancel_mid_delivery_closes_generator_in_pump_task() -> None:
+    """#614: a /cancel landing while the pump awaits on_completed abandons
+    the async-for with the runner generator suspended at a yield inside an
+    anyio task group. The generator must be closed explicitly in the pump
+    task — otherwise the event loop's asyncgen finalizer throws
+    GeneratorExit from a foreign task and the task group raises
+    'Attempted to exit cancel scope in a different task than it was
+    entered in' as an unretrieved task exception."""
+    from untether.runner_bridge import RunningTask
+
+    runner = _TaskGroupHoldOpenRunner()
+    deliver = _make_blocking_deliver()
+    running_task = RunningTask()
+
+    outcome = await _drive_cancel_mid_delivery(runner, deliver, running_task)
+
+    assert outcome.cancelled
+    # Teardown must have happened by the time run_runner_with_cancel
+    # returned — not left to the GC/asyncgen-finalizer.
+    assert runner.cleanup_ran.is_set(), (
+        "runner generator was abandoned without aclose(); teardown left to "
+        "the event loop's async-generator finalizer"
+    )
+    # ...and in the SAME task that consumed the generator, so the anyio
+    # task group's cancel scope exits in the task that entered it.
+    assert runner.cleanup_task is runner.consume_task, (
+        "generator cleanup ran in a different task than the pump — anyio "
+        "cancel scopes must exit in their owning task"
+    )
+    assert not isinstance(runner.taskgroup_exit_error, RuntimeError)
+
+
+@pytest.mark.anyio
+async def test_cancel_mid_delivery_lets_final_delivery_finish() -> None:
+    """#614 (companion symptom): the early final delivery (#591) must be
+    shielded from the bridge cancel scope. Unshielded, a /cancel landing
+    mid-send cancels on_completed AFTER the Telegram send hit the wire but
+    BEFORE final_delivery['sent'] was recorded — so handle_message takes
+    the plain 'cancelled' branch and renders a spurious 'cancelled'
+    message on top of the already-delivered answer."""
+    from untether.runner_bridge import RunningTask
+
+    runner = _TaskGroupHoldOpenRunner()
+    deliver = _make_blocking_deliver()
+    running_task = RunningTask()
+
+    outcome = await _drive_cancel_mid_delivery(runner, deliver, running_task)
+
+    assert outcome.cancelled
+    assert deliver.completed.is_set(), (
+        "on_completed was cancelled mid-delivery; final answer delivery "
+        "must be shielded so the sent-flag matches what reached the wire"
     )


### PR DESCRIPTION
## Summary

Fixes #614 — the cancel-during-post-result-window race found during 0.35.4rc3 integration testing.

**Part 1 — generator teardown in the pump task.** `run_runner` now holds the `runner.run()` generator and `aclose()`s it in a shielded scope (bounded 30s) in its `finally`. Previously, a `/cancel` landing while the pump was suspended in the loop body (e.g. awaiting the #591 early final delivery) abandoned the async-for with the generator parked at a `yield` inside `run_impl`'s anyio task group; the event loop's async-generator finalizer then threw `GeneratorExit` from a foreign task and the task group raised `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in` as an unretrieved task exception.

**Part 2 — shielded early delivery.** The #591 early final delivery is wrapped in `move_on_after(15, shield=True)`, so a `/cancel` landing mid-send can no longer cancel the delivery after the message hit the wire but before `final_delivery["sent"]` was recorded — which previously made `handle_message` take the plain `cancelled` branch and render a spurious "cancelled" message on top of the already-delivered answer (via the #598 edit-failed fallback).

## Testing

- **Regression tests** (`test_cancel_mid_delivery_closes_generator_in_pump_task`, `test_cancel_mid_delivery_lets_final_delivery_finish`) reproduce the exact production traceback pre-fix and pass post-fix.
- Full suite: 2850 passed, coverage 82.78%; ruff clean.
- **Live on `@untether_dev_bot`** (dev service on this branch):
  - normal completion clean (the always-aclose path doesn't disturb ordinary runs)
  - `/cancel` mid multi-chunk final delivery (the exact #614 window — cancel landed between chunk 1 and 2 of a 3-chunk answer): delivery completed under the shield, `handle.cancelled_after_delivery`, **no RuntimeError, no spurious cancelled message**
  - `/cancel` 13s post-completion: `cancelled_after_delivery`, clean
  - genuine mid-run `/cancel` (sleep-60 tool call in flight): `handle.cancelled`, subprocess + bash child reaped, no orphans/zombies

🤖 Generated with [Claude Code](https://claude.com/claude-code)