### PR TITLE
feat(fleet): add sl VPS as fifth fleet host

### DIFF
--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -85,7 +85,7 @@ systemctl --user restart untether
 
 ## Multi-host fleet rollout
 
-Once integration tests pass on `@untether_dev_bot`, the same rc/stable rolls to all 4 hosts (lba-1 staging, nsd, channelo, mac) in parallel — not just lba-1. The dev/staging separation rules above apply per-host; the fleet scripts wrap them.
+Once integration tests pass on `@untether_dev_bot`, the same rc/stable rolls to all 5 hosts (lba-1 staging, nsd, channelo, sl, mac) in parallel — not just lba-1. The dev/staging separation rules above apply per-host; the fleet scripts wrap them.
 
 ```bash
 scripts/run-integration-tests.sh X.Y.ZrcN --manual    # write attestation marker

--- a/.claude/rules/release-discipline.md
+++ b/.claude/rules/release-discipline.md
@@ -67,11 +67,11 @@ Pre-release versions (`X.Y.ZrcN`) are used for staging on `@hetz_lba1_bot` befor
 
 ## Fleet rollout (rc and stable)
 
-Untether ships from one repo to **four hosts**: lba-1 staging, nsd VPS, channelo VPS, and Nathan's Mac. As of 2026-05-13, all four hosts are rolled in parallel after integration tests pass (no separate dogfood window — the integration tests are the quality gate).
+Untether ships from one repo to **five hosts**: lba-1 staging, nsd VPS, channelo VPS, sl VPS, and Nathan's Mac. All hosts are rolled in parallel after integration tests pass (no separate dogfood window — the integration tests are the quality gate). sl was added to the fleet 2026-07-14; before that it was upgraded manually.
 
 ```bash
 scripts/run-integration-tests.sh 0.35.3rc14 --manual    # write attestation marker
-scripts/fleet-rollout.sh 0.35.3rc14                     # parallel upgrade across 4 hosts
+scripts/fleet-rollout.sh 0.35.3rc14                     # parallel upgrade across 5 hosts
 scripts/fleet-rollout.sh 0.35.3rc14 --dry-run           # preview without executing
 scripts/fleet-rollout.sh 0.35.3rc14 --only mac          # roll one host
 scripts/fleet-rollback.sh 0.35.2 --only mac             # revert one host to known-good
@@ -82,7 +82,7 @@ scripts/fleet-rollback.sh 0.35.2 --only mac             # revert one host to kno
 1. Push rc to dev → CI publishes to TestPyPI in ~3 min
 2. Run integration tests via `@untether_dev_bot` (Tier 7 + Tier 1 minimum)
 3. Write attestation marker (`scripts/run-integration-tests.sh ${VERSION} --manual`)
-4. Run fleet rollout (`scripts/fleet-rollout.sh ${VERSION}`) — all 4 hosts in parallel
+4. Run fleet rollout (`scripts/fleet-rollout.sh ${VERSION}`) — all 5 hosts in parallel
 5. Verify each host's bot responds to `/ping` via Telegram
 
 **Partial failure handling:** if one host fails (network glitch, SSH timeout, etc.), the script reports the failure but does NOT roll back successful hosts. Operator decides whether to roll forward (rerun) or roll back the failed host (`fleet-rollback.sh <prev> --only <host>`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,8 +246,8 @@ Two instances run on lba-1 — staging (PyPI/TestPyPI) and dev (local editable s
 ### 3-phase release workflow (MANDATORY)
 
 1. **Dev** — fix code, run unit tests, test via `@untether_dev_bot` (6 engine chats), run integration tests
-2. **Fleet rollout (rc)** — bump to `X.Y.ZrcN`, merge feature branches to `dev` → CI publishes to TestPyPI, attest tests via `scripts/run-integration-tests.sh ${VERSION} --manual`, then `scripts/fleet-rollout.sh ${VERSION}` rolls the rc to all 4 hosts (lba-1 staging + nsd VPS + channelo VPS + Mac) in parallel
-3. **Release** — bump to `X.Y.Z`, write changelog, PR from `dev` → `master`. After merge, `scripts/fleet-rollout.sh ${VERSION}` rolls the stable PyPI build to all 4 hosts in parallel. `release.yml` publishes to PyPI automatically; the master PR merge IS the approval.
+2. **Fleet rollout (rc)** — bump to `X.Y.ZrcN`, merge feature branches to `dev` → CI publishes to TestPyPI, attest tests via `scripts/run-integration-tests.sh ${VERSION} --manual`, then `scripts/fleet-rollout.sh ${VERSION}` rolls the rc to all 5 hosts (lba-1 staging + nsd VPS + channelo VPS + sl VPS + Mac) in parallel
+3. **Release** — bump to `X.Y.Z`, write changelog, PR from `dev` → `master`. After merge, `scripts/fleet-rollout.sh ${VERSION}` rolls the stable PyPI build to all 5 hosts in parallel. `release.yml` publishes to PyPI automatically; the master PR merge IS the approval.
 
 **Branch model:** `feature/*` → PR → `dev` (TestPyPI) → PR → `master` (PyPI). Master always matches the latest PyPI release.
 
@@ -308,7 +308,7 @@ journalctl --user -u untether-dev -f
 scripts/staging.sh install X.Y.ZrcN
 systemctl --user restart untether
 
-# Fleet rollout to all 4 hosts (lba-1 + nsd + channelo + mac)
+# Fleet rollout to all 5 hosts (lba-1 + nsd + channelo + sl + mac)
 scripts/run-integration-tests.sh X.Y.ZrcN --manual    # attest via @untether_dev_bot
 scripts/fleet-rollout.sh X.Y.ZrcN                     # parallel upgrade
 scripts/fleet-rollout.sh X.Y.ZrcN --dry-run           # preview

--- a/docs/reference/dev-instance.md
+++ b/docs/reference/dev-instance.md
@@ -2,7 +2,7 @@
 
 Untether runs two isolated instances on lba-1: **staging** (PyPI/TestPyPI release) and **dev** (local editable source). They use separate Telegram bots, separate configs, and separate state — zero crosstalk.
 
-> **Fleet context:** lba-1 staging is one of **four production-ish hosts** (lba-1, nsd, channelo, mac). Multi-host upgrades use `scripts/fleet-rollout.sh` — see [release-discipline.md → Fleet rollout](../../.claude/rules/release-discipline.md). This page covers the lba-1 staging/dev pair specifically.
+> **Fleet context:** lba-1 staging is one of **five production-ish hosts** (lba-1, nsd, channelo, sl, mac). Multi-host upgrades use `scripts/fleet-rollout.sh` — see [release-discipline.md → Fleet rollout](../../.claude/rules/release-discipline.md). This page covers the lba-1 staging/dev pair specifically.
 
 ## How it works
 

--- a/scripts/fleet-rollback.sh
+++ b/scripts/fleet-rollback.sh
@@ -2,14 +2,14 @@
 # Fleet rollback helper for Untether — parallel revert to a known-good version.
 #
 # Used when a fleet-rollout went wrong and you need to step back to the
-# previous version on all four hosts (or one host with --only).
+# previous version on all five hosts (or one host with --only).
 #
 # Mirrors scripts/fleet-rollout.sh's parallel SSH pattern but skips the
 # attestation gate (we're going BACK to a known-good version, not forward
 # to an untested one).
 #
 # Usage:
-#   scripts/fleet-rollback.sh 0.35.2                # revert all 4 hosts to 0.35.2
+#   scripts/fleet-rollback.sh 0.35.2                # revert all 5 hosts to 0.35.2
 #   scripts/fleet-rollback.sh 0.35.3rc13 --only mac # revert only mac
 #   scripts/fleet-rollback.sh 0.35.2 --dry-run      # preview commands
 
@@ -26,7 +26,7 @@ usage() {
     cat <<EOF
 Usage: fleet-rollback.sh VERSION [--dry-run] [--only HOST]
 
-Revert Untether to VERSION on all 4 hosts in parallel (or one host with --only).
+Revert Untether to VERSION on all 5 hosts in parallel (or one host with --only).
 
 The attestation gate is intentionally SKIPPED — rollbacks go to a known-good
 version, not a new one. If VERSION is itself a prerelease (rcN/aN/bN), use
@@ -34,7 +34,7 @@ TestPyPI as the index; otherwise use PyPI.
 
 Options:
   --dry-run            Print install/restart commands per host without executing
-  --only HOST          Roll only one host (lba-1 | nsd | channelo | mac)
+  --only HOST          Roll only one host (lba-1 | nsd | channelo | sl | mac)
 EOF
     exit "${1:-1}"
 }
@@ -119,10 +119,13 @@ POSTCHECK_CMD[nsd]="ssh nsd 'systemctl --user is-active untether'"
 RESTART_CMD[channelo]="ssh channelo 'systemctl --user restart untether'"
 POSTCHECK_CMD[channelo]="ssh channelo 'systemctl --user is-active untether'"
 
+RESTART_CMD[sl]="ssh sl 'systemctl --user restart untether'"
+POSTCHECK_CMD[sl]="ssh sl 'systemctl --user is-active untether'"
+
 RESTART_CMD[mac]='ssh mac "launchctl kickstart -k gui/\$(id -u)/com.littlebearapps.untether"'
 POSTCHECK_CMD[mac]='ssh mac "launchctl print gui/\$(id -u)/com.littlebearapps.untether | grep -E \"^\\s*(state|last exit code)\""'
 
-ALL_HOSTS=(lba-1 nsd channelo mac)
+ALL_HOSTS=(lba-1 nsd channelo sl mac)
 
 if [[ -n "$ONLY_HOST" ]]; then
     valid=0

--- a/scripts/fleet-rollout.sh
+++ b/scripts/fleet-rollout.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Fleet rollout helper for Untether — single-stage parallel upgrade across all
-# four production-ish hosts (lba-1 staging, nsd, channelo, mac).
+# five production-ish hosts (lba-1 staging, nsd, channelo, sl, mac).
 #
 # Companion scripts:
 #   scripts/fleet-rollback.sh             — same parallel pattern, install previous version
@@ -9,8 +9,8 @@
 # Strategic plan: docs/plans/2026-05-13-fleet-monitoring-and-upgrades.md
 #
 # Usage:
-#   scripts/fleet-rollout.sh 0.35.3rc14                # rc -> TestPyPI rollout, 4 hosts parallel
-#   scripts/fleet-rollout.sh 0.35.3                    # stable -> PyPI rollout, 4 hosts parallel
+#   scripts/fleet-rollout.sh 0.35.3rc14                # rc -> TestPyPI rollout, 5 hosts parallel
+#   scripts/fleet-rollout.sh 0.35.3                    # stable -> PyPI rollout, 5 hosts parallel
 #   scripts/fleet-rollout.sh 0.35.3rc14 --dry-run      # print commands without executing
 #   scripts/fleet-rollout.sh 0.35.3rc14 --only mac     # only roll one host
 #   scripts/fleet-rollout.sh 0.35.3rc14 --skip-test-gate
@@ -50,14 +50,14 @@ usage() {
     cat <<EOF
 Usage: fleet-rollout.sh VERSION [--dry-run] [--only HOST] [--skip-test-gate] [--force-downgrade]
 
-Single-stage parallel rollout of Untether to lba-1, nsd, channelo, mac.
+Single-stage parallel rollout of Untether to lba-1, nsd, channelo, sl, mac.
 
 Required:
   VERSION              Target version (e.g. 0.35.3rc14 or 0.35.3)
 
 Options:
   --dry-run            Print install/restart commands per host without executing
-  --only HOST          Roll only one host (lba-1 | nsd | channelo | mac)
+  --only HOST          Roll only one host (lba-1 | nsd | channelo | sl | mac)
   --skip-test-gate     Bypass the integration-test attestation precondition
   --force-downgrade    Allow installing an older version than the current state
 
@@ -183,7 +183,7 @@ fi
 #
 # lba-1: local install via existing scripts/staging.sh helper (always pipx-
 #        based, parity with the single-host workflow)
-# nsd / channelo / mac: install manager auto-detected at runtime via
+# nsd / channelo / sl / mac: install manager auto-detected at runtime via
 #        detect_install_manager() — supports both pipx and uv tool. The
 #        detection probes the EXISTING install (uv tool list / pipx list)
 #        first; if untether isn't installed at all, falls back to whichever
@@ -273,6 +273,9 @@ POSTCHECK_CMD[nsd]="ssh nsd 'systemctl --user is-active untether'"
 RESTART_CMD[channelo]="ssh channelo 'systemctl --user restart untether'"
 POSTCHECK_CMD[channelo]="ssh channelo 'systemctl --user is-active untether'"
 
+RESTART_CMD[sl]="ssh sl 'systemctl --user restart untether'"
+POSTCHECK_CMD[sl]="ssh sl 'systemctl --user is-active untether'"
+
 RESTART_CMD[mac]='ssh mac "launchctl kickstart -k gui/\$(id -u)/com.littlebearapps.untether"'
 POSTCHECK_CMD[mac]='ssh mac "launchctl print gui/\$(id -u)/com.littlebearapps.untether | grep -E \"^\\s*(state|last exit code)\""'
 
@@ -280,7 +283,7 @@ POSTCHECK_CMD[mac]='ssh mac "launchctl print gui/\$(id -u)/com.littlebearapps.un
 # Host selection
 # ────────────────────────────────────────────────────────────────────────────
 
-ALL_HOSTS=(lba-1 nsd channelo mac)
+ALL_HOSTS=(lba-1 nsd channelo sl mac)
 
 if [[ -n "$ONLY_HOST" ]]; then
     # Validate the host name against ALL_HOSTS (lba-1 is always known;
@@ -338,6 +341,7 @@ if (( DRY_RUN == 1 )); then
     echo "  @hetz_lba1_bot    (lba-1)"
     echo "  @hetz_nsd_bot     (nsd)"
     echo "  @hetz_channelo_bot (channelo)"
+    echo "  @hetz_sl_bot      (sl)"
     echo "  @local_mb_bot     (mac)"
     exit 0
 fi

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -126,7 +126,7 @@ cat <<EOF
 The fleet rollout gate is now satisfied for version ${VERSION}.
 
 Next steps:
-  scripts/fleet-rollout.sh ${VERSION}              # roll to all 4 hosts in parallel
+  scripts/fleet-rollout.sh ${VERSION}              # roll to all 5 hosts in parallel
   scripts/fleet-rollout.sh ${VERSION} --dry-run    # preview without executing
   scripts/fleet-rollout.sh ${VERSION} --only mac   # roll a single host
 


### PR DESCRIPTION
## Summary

Adds the sl VPS (`@hetz_sl_bot`, semantic-librarian) to the fleet rollout/rollback scripts and updates all host enumerations from 4 to 5 hosts. sl was previously outside the fleet workflow and required manual upgrades (it was skipped by the scripted 0.35.4rc3 rollout until this change).

## Changes

- `scripts/fleet-rollout.sh` / `scripts/fleet-rollback.sh` — `sl` added to `ALL_HOSTS` with Linux systemd restart/postcheck; install manager auto-detected (uv on sl); dry-run bot list includes `@hetz_sl_bot`
- `scripts/run-integration-tests.sh`, `CLAUDE.md`, `.claude/rules/release-discipline.md`, `.claude/rules/dev-workflow.md`, `docs/reference/dev-instance.md` — host-count and enumeration updates

## Testing

- `bash -n` clean on both scripts
- `fleet-rollout.sh 0.35.4rc3 --only sl --dry-run` shows correct uv install + systemd restart commands
- **Live run**: `fleet-rollout.sh 0.35.4rc3 --only sl` upgraded sl from 0.35.3rc20 → 0.35.4rc3; `@hetz_sl_bot` confirmed ready (v0.35.4rc3) and answering `/ping` with its cron intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)