### PR TITLE
chore: staging 0.35.4rc4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.4rc3"
+version = "0.35.4rc4"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.4rc3"
+version = "0.35.4rc4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Version bump to 0.35.4rc4 for TestPyPI + fleet rollout. Carries the two changes merged to dev today:

- #615 — fix(bridge): #614 close runner generator in pump task + shield early final delivery
- #616 — feat(fleet): add sl VPS as fifth fleet host

rc bumps need no changelog entry per release discipline. `uv lock` synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)