### PR TITLE
fix(bridge): #618 raise delivery shield bound to 60s

### DIFF
--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -2881,8 +2881,13 @@ async def run_runner_with_cancel(
                                     # render a spurious "cancelled" message
                                     # on top of the delivered answer. Bounded
                                     # so a wedged transport can't hold the
-                                    # cancel hostage.
-                                    with anyio.move_on_after(15, shield=True):
+                                    # cancel hostage. #618: 60s, not less —
+                                    # a 4-chunk final under group-chat outbox
+                                    # pacing takes 15s+ on its own, and a
+                                    # timeout that fires between the last
+                                    # chunk and the sent-flag re-creates the
+                                    # spurious-cancelled artifact.
+                                    with anyio.move_on_after(60, shield=True):
                                         await on_completed(evt, outcome)
                                 except Exception:  # noqa: BLE001
                                     logger.warning(


### PR DESCRIPTION
## Summary

Fixes #618 (follow-up to #615, found during the 0.35.4rc4 integration gate). The 15s shield bound on the early final delivery expired between the last chunk of a 4-chunk answer hitting the wire and the sent-flag being recorded, re-creating the spurious "cancelled" render for deliveries longer than 15s. Raised to 60s — covers multi-chunk finals under group-chat outbox pacing plus a 429 retry, while still bounding a genuinely wedged transport.

Evidence in #618 (dev journal 10:41:25–10:41:46Z: all 4 chunks delivered, shield held through the /cancel, timeout fired at the flag-set boundary → `handle.cancelled` + fallback trailer).

## Testing

- `tests/test_exec_bridge.py`: 214 passed (includes both #614 regression tests)
- ruff clean
- Live rc5 re-gate on `@untether_dev_bot` to follow before fleet rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)