### PR TITLE
chore: staging 0.35.4rc5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.4rc4"
+version = "0.35.4rc5"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.4rc4"
+version = "0.35.4rc5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Version bump to 0.35.4rc5 for TestPyPI + fleet rollout. Supersedes rc4, which was published to TestPyPI but never fleet-rolled — the rc4 integration gate caught #618 (delivery shield bound too tight), fixed in #619. rc5 = rc3 + #615 (#614 cancel-race fix) + #616 (sl fleet host) + #619 (#618 shield bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)