### PR TITLE
feat(fleet): fleet-status.sh + rollout attestation guardrails + ping playbook

### DIFF
--- a/docs/reference/fleet-ping-verification.md
+++ b/docs/reference/fleet-ping-verification.md
@@ -1,0 +1,81 @@
+# Post-rollout `/ping` verification playbook
+
+`scripts/fleet-rollout.sh` confirms each host's **service** is active/running, but a
+running service is not proof the **bot answers**. The last-mile check is a `/ping`
+sweep of all five bots — expecting `🏓 pong` from each.
+
+A shell script can't do this: the Telegram MCP tools (`send_message`, `get_history`,
+…) live **inside Claude Code**, not in a standalone shell. So this is a documented,
+Claude-driven step run once after a rollout — not a pure-shell postcheck. (Do **not**
+build a shell Telegram client for it; the MCP path already exists and the fleet is
+small.)
+
+## When to run
+
+Immediately after `scripts/fleet-rollout.sh <version>` reports all hosts `OK`, and
+after `scripts/fleet-status.sh` shows every host on the target version. Version-on-disk
++ service-active + `🏓 pong` together mean the rollout truly landed.
+
+## The five bots
+
+| Host | Bot | Primary chat to ping |
+|---|---|---|
+| lba-1 | `@hetz_lba1_bot` | the lba-1 staging chat |
+| nsd | `@hetz_nsd_bot` | nsd supergroup `-1003953881142` |
+| channelo | `@hetz_channelo_bot` | owner DM `8351408485` |
+| sl | `@hetz_sl_bot` | owner DM `8351408485` (or group `-5115715467`) |
+| mac | `@local_mb_bot` | owner DM `8351408485` |
+
+> Chat IDs are the current known routes (mirrored from `~/.config/monitor/untether-*.toml`
+> and the per-host memory files). If one has changed, resolve it with the Telegram MCP
+> `resolve_username`/`get_chats` first. These are the **production** bots — distinct from
+> the `@untether_dev_bot` chats used for pre-release integration testing.
+
+## The sweep (Claude Code, one pass)
+
+For each bot in the table:
+
+1. `send_message(chat_id=<chat>, message="/ping")`
+2. Wait ~3–5s, then `get_history(chat_id=<chat>, limit=3)`
+3. **PASS** if the newest bot message is `🏓 pong` (optionally with a version/mode footer).
+   **FAIL** if there's no reply within ~15s, an error, or a stale/oversized response.
+
+Report a one-line-per-host result, e.g.:
+
+```
+/ping sweep — 0.35.4rc5
+  lba-1     🏓 pong   ✓
+  nsd       🏓 pong   ✓
+  channelo  🏓 pong   ✓
+  sl        🏓 pong   ✓
+  mac       🏓 pong   ✓
+```
+
+Any FAIL → investigate that host (`journalctl --user -u untether` / `scripts/fleet-status.sh
+--only <host>`) and, if needed, roll it back: `scripts/fleet-rollback.sh <prev> --only <host>`.
+
+## Optional: record ping verification in the state file
+
+`scripts/fleet-rollout.sh` writes `~/.untether-dev/fleet-rollout-state.json`. After a
+clean sweep you can annotate it so `fleet-status.sh`/audits can later see the rollout was
+bot-verified, not just service-verified:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+p = pathlib.Path.home()/".untether-dev/fleet-rollout-state.json"
+s = json.loads(p.read_text())
+s["ping_verified"] = True            # set False (or omit) if any host failed the sweep
+p.write_text(json.dumps(s, indent=2))
+PY
+```
+
+This is a convention, not enforced machinery — the sweep result in the run log is the
+authoritative record.
+
+## Relationship to other tooling
+
+- `scripts/fleet-rollout.sh` — installs + restarts + confirms **service** state.
+- `scripts/fleet-status.sh` — one-shot **version + service** view (no bot check).
+- **This playbook** — the **bot-answers** last mile, Claude-driven via Telegram MCP.
+- `scripts/healthcheck.sh` — deeper single-host post-deploy check (systemd, version, logs, Bot API).

--- a/scripts/fleet-rollout.sh
+++ b/scripts/fleet-rollout.sh
@@ -45,6 +45,7 @@ DRY_RUN=0
 SKIP_TEST_GATE=0
 FORCE_DOWNGRADE=0
 ONLY_HOST=""
+CLEAN_MARKERS=0
 
 usage() {
     cat <<EOF
@@ -60,6 +61,7 @@ Options:
   --only HOST          Roll only one host (lba-1 | nsd | channelo | sl | mac)
   --skip-test-gate     Bypass the integration-test attestation precondition
   --force-downgrade    Allow installing an older version than the current state
+  --clean-markers      Delete attestation markers older than 30 days, then exit
 
 The integration-test attestation marker must exist at:
   ${ATTESTATION_DIR}/integration-test-pass-VERSION.json
@@ -87,6 +89,10 @@ while [[ $# -gt 0 ]]; do
             FORCE_DOWNGRADE=1
             shift
             ;;
+        --clean-markers)
+            CLEAN_MARKERS=1
+            shift
+            ;;
         --only)
             ONLY_HOST="${2:?--only requires a host name}"
             shift 2
@@ -106,6 +112,15 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Housekeeping action — remove stale markers and exit (no VERSION needed).
+# Markers are never auto-cleaned otherwise (finding F); this is opt-in.
+if (( CLEAN_MARKERS == 1 )); then
+    echo "Cleaning attestation markers older than 30 days in ${ATTESTATION_DIR}..."
+    find "$ATTESTATION_DIR" -maxdepth 1 -name 'integration-test-pass-*.json' -mtime +30 -print -delete 2>/dev/null || true
+    echo "Done."
+    exit 0
+fi
 
 [[ -n "$VERSION" ]] || { echo "VERSION argument is required." >&2; usage 1; }
 
@@ -146,6 +161,24 @@ EOF
         exit 2
     fi
     echo "Attestation marker found: $ATTESTATION_MARKER"
+
+    # Guardrail 1 — version-match. The marker's JSON "version" must equal VERSION.
+    # Catches rolling with a copied/renamed marker, or a stale marker whose
+    # filename matches but whose content attests a different version.
+    MARKER_VER=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('version',''))" "$ATTESTATION_MARKER" 2>/dev/null || echo "")
+    if [[ -z "$MARKER_VER" ]]; then
+        echo "WARN: could not read a \"version\" field from $ATTESTATION_MARKER — proceeding (hand-written marker?)." >&2
+    elif [[ "$MARKER_VER" != "$VERSION" ]]; then
+        echo "ERROR: attestation marker version ($MARKER_VER) != rollout version ($VERSION) — wrong marker?" >&2
+        echo "Write the right one with scripts/run-integration-tests.sh ${VERSION} --manual, or pass --skip-test-gate to override." >&2
+        exit 6
+    fi
+
+    # Guardrail 2 — staleness (warn, never block). A genuinely-unchanged rc is
+    # fine to re-roll weeks later; a changed one should be re-tested first.
+    if [[ -n "$(find "$ATTESTATION_MARKER" -mtime +14 2>/dev/null)" ]]; then
+        echo "WARN: attestation marker for $VERSION is >14 days old — re-test if code changed since." >&2
+    fi
 else
     echo "WARN: --skip-test-gate set; attestation gate bypassed."
 fi
@@ -489,13 +522,16 @@ PY
 cat <<EOF
 
 Next steps:
-  - Verify each upgraded bot responds to /ping via Telegram.
+  - Confirm versions landed:  scripts/fleet-status.sh   (all 5 hosts, one shot)
+  - Verify each bot answers:  run the /ping sweep in
+      docs/reference/fleet-ping-verification.md  (Claude-driven via Telegram MCP)
   - Inspect per-host logs in $LOG_DIR for any unexpected output.
   - If a host failed: investigate and either roll forward (rerun this script)
     or roll that host back: scripts/fleet-rollback.sh <prev> --only <host>
 
 NOT done automatically:
-  - Telegram /ping checks (you have to send them yourself via Telegram).
+  - Telegram /ping checks (send them via the playbook above — the MCP tools live
+    inside Claude Code, not this shell).
   - Rollback of successful hosts on partial failure.
 EOF
 

--- a/scripts/fleet-status.sh
+++ b/scripts/fleet-status.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Fleet status for Untether — a one-shot, READ-ONLY view of what version and
+# service state every host is on right now.
+#
+# Companion to:
+#   scripts/fleet-rollout.sh    — parallel upgrade (writes state)
+#   scripts/fleet-rollback.sh   — parallel revert
+#   scripts/healthcheck.sh      — single-host post-deploy health check
+#
+# Unlike rollout/rollback this NEVER installs or restarts anything. It only reads,
+# over the tailnet SSH mesh, per host:
+#   - installed version   (`untether --version`, uv/pipx-agnostic)
+#   - service state       (systemctl --user is-active | launchctl state on Mac)
+#   - last restart / since (systemctl ActiveEnterTimestamp | ps lstart on Mac)
+#
+# Every remote ssh carries `-o ConnectTimeout=8 -o BatchMode=yes` so a down or
+# asleep host is reported as "unreachable" in ~8s instead of hanging the sweep.
+#
+# The host list, REMOTE_PATH, and Mac launchctl label mirror fleet-rollout.sh so
+# the three scripts agree on what "the fleet" is. Kept in sync intentionally,
+# exactly as fleet-rollout.sh <-> fleet-rollback.sh already are (three small
+# independent scripts, no shared sourcing).
+#
+# Usage:
+#   scripts/fleet-status.sh                # table for all 5 hosts
+#   scripts/fleet-status.sh --only sl      # one host
+#   scripts/fleet-status.sh --json         # machine-readable (for /monitor, CI)
+#
+# Strategic plan: docs/plans/fleet/03-phase3-fleet-ops-hardening.md (3a)
+
+set -euo pipefail
+
+JSON=0
+ONLY_HOST=""
+
+usage() {
+    cat <<EOF
+Usage: fleet-status.sh [--only HOST] [--json]
+
+Read-only version + service-state view of the Untether fleet
+(lba-1, nsd, channelo, sl, mac).
+
+Options:
+  --only HOST   Show only one host (lba-1 | nsd | channelo | sl | mac)
+  --json        Emit machine-readable JSON instead of a table
+  --help, -h    Show this help
+EOF
+    exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h) usage 0 ;;
+        --json) JSON=1; shift ;;
+        --only) ONLY_HOST="${2:?--only requires a host name}"; shift 2 ;;
+        -*) echo "Unknown option: $1" >&2; usage 1 ;;
+        *) echo "Unexpected argument: $1" >&2; usage 1 ;;
+    esac
+done
+
+# Host list + remote PATH + Mac launchctl label mirror fleet-rollout.sh.
+ALL_HOSTS=(lba-1 nsd channelo sl mac)
+MAC_LABEL='com.littlebearapps.untether'
+SSH_OPTS=(-o ConnectTimeout=8 -o BatchMode=yes)
+
+if [[ -n "$ONLY_HOST" ]]; then
+    valid=0
+    for h in "${ALL_HOSTS[@]}"; do [[ "$h" == "$ONLY_HOST" ]] && valid=1; done
+    if (( valid == 0 )); then
+        echo "ERROR: --only $ONLY_HOST: unknown host. Choose: ${ALL_HOSTS[*]}" >&2
+        exit 4
+    fi
+    HOSTS=("$ONLY_HOST")
+else
+    HOSTS=("${ALL_HOSTS[@]}")
+fi
+
+# ── Probe scripts (single-quoted so $/" stay literal until they run on the host;
+#    $HOME expands wherever the snippet executes — local for lba-1, remote via ssh).
+
+read -r -d '' LINUX_PROBE <<'PROBE' || true
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+v=$(untether --version 2>/dev/null | grep -oE "[0-9]+[.][0-9]+[.][0-9]+[a-z0-9]*" | head -1)
+s=$(systemctl --user is-active untether 2>/dev/null || true)
+t=$(systemctl --user show untether -p ActiveEnterTimestamp --value 2>/dev/null || true)
+printf "%s|%s|%s" "${v:-?}" "${s:-inactive}" "${t:-?}"
+PROBE
+
+read -r -d '' MAC_PROBE <<'PROBE' || true
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+v=$(untether --version 2>/dev/null | grep -oE "[0-9]+[.][0-9]+[.][0-9]+[a-z0-9]*" | head -1)
+label=gui/$(id -u)/com.littlebearapps.untether
+info=$(launchctl print "$label" 2>/dev/null || true)
+s=$(printf "%s\n" "$info" | sed -n "s/^[[:space:]]*state = //p" | head -1)
+pid=$(printf "%s\n" "$info" | sed -n "s/^[[:space:]]*pid = //p" | head -1)
+t="?"
+if [ -n "$pid" ]; then t=$(ps -o lstart= -p "$pid" 2>/dev/null | sed "s/^[[:space:]]*//;s/[[:space:]]*$//"); fi
+printf "%s|%s|%s" "${v:-?}" "${s:-not-loaded}" "${t:-?}"
+PROBE
+
+# probe_host <host> → echoes "VERSION|SERVICE|SINCE"; SERVICE=unreachable if ssh fails.
+probe_host() {
+    local host="$1" out rc=0
+    if [[ "$host" == "lba-1" ]]; then
+        out=$(bash -c "$LINUX_PROBE" 2>/dev/null) || rc=$?
+    elif [[ "$host" == "mac" ]]; then
+        out=$(ssh "${SSH_OPTS[@]}" "$host" "$MAC_PROBE" 2>/dev/null) || rc=$?
+    else
+        out=$(ssh "${SSH_OPTS[@]}" "$host" "$LINUX_PROBE" 2>/dev/null) || rc=$?
+    fi
+    if (( rc != 0 )) || [[ -z "$out" ]]; then
+        echo "?|unreachable|?"
+    else
+        echo "$out"
+    fi
+}
+
+# ── Fire all probes in parallel, collect into temp files (read-only, fast).
+TMP=$(mktemp -d -t untether-fleet-status-XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+declare -A PIDS
+for host in "${HOSTS[@]}"; do
+    ( probe_host "$host" >"$TMP/$host" ) &
+    PIDS[$host]=$!
+done
+for host in "${HOSTS[@]}"; do wait "${PIDS[$host]}" 2>/dev/null || true; done
+
+# ── Render.
+if (( JSON == 1 )); then
+    # Build JSON with python3 for correct escaping.
+    python3 - "$TMP" "${HOSTS[@]}" <<'PY'
+import json, sys, os
+tmp = sys.argv[1]; hosts = sys.argv[2:]
+rows = []
+for h in hosts:
+    try:
+        v, s, t = (x.strip() for x in open(os.path.join(tmp, h)).read().split("|", 2))
+    except Exception:
+        v, s, t = "?", "unreachable", "?"
+    rows.append({"host": h, "version": v, "service": s, "since": t})
+print(json.dumps({"hosts": rows}, indent=2))
+PY
+else
+    printf "%-10s %-14s %-13s %s\n" "HOST" "VERSION" "SERVICE" "SINCE"
+    for host in "${HOSTS[@]}"; do
+        IFS='|' read -r v s t <"$TMP/$host" || { v="?"; s="unreachable"; t="?"; }
+        printf "%-10s %-14s %-13s %s\n" "$host" "${v:-?}" "${s:-?}" "${t:-?}"
+    done
+fi


### PR DESCRIPTION
## Summary

Phase 3 (in-repo portion) of `docs/plans/fleet/` — fleet-ops hardening. Closes the observability and safety-net gaps in the fleet release scripts; the core rollout mechanism was already solid.

- **`scripts/fleet-status.sh` (new)** — read-only, parallel SSH fan-out printing each host's installed version + service state + last-restart across all 5 hosts (lba-1, nsd, channelo, sl, mac). `-o ConnectTimeout=8` so a down/asleep host is reported `unreachable` in ~8s instead of hanging the sweep. Flags: `--only HOST`, `--json`. Self-contained (mirrors `fleet-rollout.sh`'s host list / launchctl label, kept in sync intentionally — same convention as rollout↔rollback).
- **`scripts/fleet-rollout.sh`** — two attestation-gate guardrails (finding F):
  1. **version-match** — aborts (exit 6) if the marker's JSON `"version"` ≠ rollout `VERSION` (catches copied/renamed/stale markers).
  2. **staleness** — warns (never blocks) if the marker is >14 days old.
  Plus a `--clean-markers` housekeeping flag (deletes markers >30 days). `--skip-test-gate` still bypasses. "Next steps" output now points at `fleet-status.sh` and the ping playbook.
- **`docs/reference/fleet-ping-verification.md` (new)** — documented Claude-driven `/ping` sweep of the 5 bots (the "bot answers" last mile a shell script can't do — the Telegram MCP tools live inside Claude Code), with an optional `ping_verified` state-file convention.

## Testing

- `fleet-status.sh` run live against all 5 hosts: correct version/state/since in ~4s; `--only` and `--json` verified; unreachable-host path returns fast (`rc=255`) → `unreachable`.
- Rollout guardrails: version-match happy path proceeds; mismatch aborts with exit 6; >14-day marker prints the staleness warning and proceeds; `--skip-test-gate` bypasses; `--clean-markers` tested via a `HOME` override (deletes only >30-day markers) — real markers untouched.
- `bash -n` clean on both scripts. Zero Python changes, so the `pytest` suite is unaffected.

## Scope notes

- **Phases 1–2 are out-of-repo** (`~/.config/monitor/*`, `~/.claude/commands/monitor*`, memory) and not in this PR: sl `/monitor` integration + 5-host fan-out with ConnectTimeout, milestone routing fix + dynamic resolution, `_shared.toml` overlay, fleet fan-out derived from `sub_targets`, stray-config archival, schema freshening. All applied and tested live.
- `docs/plans/` is gitignored, so the plan docs and the 2026-05-13 supersession banner stay local.
- A pre-existing unstaged change in `docs/reference/changelog.md` was left untouched.
- No tracking issue was filed (the plan's suggested Phase 3 issue is "fleet-status.sh + attestation-gate guardrails — enhancement"); say the word and I'll file it and link it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
