### PR TITLE
docs: post-rc7 context refresh — 5-host fleet refs, empty-resume recovery docs, test counts

### DIFF
--- a/.claude/rules/runner-development.md
+++ b/.claude/rules/runner-development.md
@@ -21,6 +21,8 @@ After emitting `CompletedEvent`, drop all subsequent JSONL lines.
 
 When Claude Code exits with `last_event_type=user` (tool results sent but never processed), `runner_bridge.py` auto-resumes the session. Suppressed on signal deaths (rc=143/137) to prevent death spirals. Configure via `[auto_continue]` in `untether.toml` (`enabled`, `max_retries`).
 
+Empty-resume recovery (#631/#632, Claude only): a resume returning 0 turns/$0 quarantines the session (`session_quarantine.py`, persisted to `session_quarantine.json`) and auto-resends once on a fresh session; forced teardown after a result quarantines proactively and the next message diverts fresh. Flags: `empty_resume_fresh`, `quarantine_on_forced_teardown` (both default true). Never retry the same poisoned session.
+
 ## Event creation
 
 Use `EventFactory` (from `src/untether/events.py`) for all event construction:

--- a/.claude/skills/release-coordination/SKILL.md
+++ b/.claude/skills/release-coordination/SKILL.md
@@ -45,8 +45,8 @@ All seven (now-8) phases happen in a single branch (typically `master` for patch
 
 **Phase 5.5 (attestation)** is the gate that makes the fleet rollout safe.
 Without it, `scripts/fleet-rollout.sh` refuses to upgrade production hosts.
-**Phase 6 (staging + fleet rollout)** parallelises across all 4 hosts —
-lba-1 staging, nsd, channelo, mac — instead of staging on lba-1 alone.
+**Phase 6 (staging + fleet rollout)** parallelises across all 5 hosts —
+lba-1 staging, nsd, channelo, sl, mac — instead of staging on lba-1 alone.
 
 ## Phase 1: Issue audit
 
@@ -251,7 +251,7 @@ All integration test tiers are fully automated by Claude Code via Telegram MCP t
 
 ## Phase 5.5: Integration-test attestation marker
 
-After integration tests pass for a given version, write the attestation marker. This is the precondition for `scripts/fleet-rollout.sh` — without it, fleet rollout to nsd/channelo/mac is gated.
+After integration tests pass for a given version, write the attestation marker. This is the precondition for `scripts/fleet-rollout.sh` — without it, fleet rollout to nsd/channelo/sl/mac is gated.
 
 ```bash
 scripts/run-integration-tests.sh X.Y.ZrcN --manual \
@@ -270,9 +270,9 @@ rm ~/.untether-dev/integration-test-pass-X.Y.ZrcN.json
 
 `--skip-test-gate` exists on fleet-rollout as an escape hatch. It prints a loud warning and is not recommended for any change that touches production hosts.
 
-## Phase 6: Staging + fleet rollout (parallel across all 4 hosts)
+## Phase 6: Staging + fleet rollout (parallel across all 5 hosts)
 
-Before tagging a final release, publish a release candidate to TestPyPI and roll it to all 4 hosts in parallel. Both lba-1 staging AND nsd/channelo/mac upgrade together — the integration-test attestation from Phase 5.5 gates the rollout, replacing the previous lba-1-only dogfood window.
+Before tagging a final release, publish a release candidate to TestPyPI and roll it to all 5 hosts in parallel. Both lba-1 staging AND nsd/channelo/sl/mac upgrade together — the integration-test attestation from Phase 5.5 gates the rollout, replacing the previous lba-1-only dogfood window.
 
 ### Enter the rc cycle
 
@@ -289,14 +289,14 @@ git push origin dev          # dev push, NOT master — CI publishes to TestPyPI
 #   2. Write the attestation marker (Phase 5.5)
 #   3. Run fleet rollout (this phase)
 
-scripts/fleet-rollout.sh X.Y.Zrc1                    # all 4 hosts parallel
+scripts/fleet-rollout.sh X.Y.Zrc1                    # all 5 hosts parallel
 scripts/fleet-rollout.sh X.Y.Zrc1 --dry-run          # preview
 scripts/fleet-rollout.sh X.Y.Zrc1 --only mac         # one host
 ```
 
 ### During the rc cycle
 
-- All 4 bots run the same rc (lba-1, nsd, channelo, mac)
+- All 5 bots run the same rc (lba-1, nsd, channelo, sl, mac)
 - Each host's `untether-issue-watcher` daemon catches log-pattern bugs auto-tagged with `host:<name>`
 - `/monitor untether-fleet` runs cross-host audits in parallel for richer signal
 - If bugs found: fix → bump to `X.Y.Zrc2` → push → re-test → re-attest → re-roll
@@ -309,7 +309,7 @@ When the rc cycle is stable, bump to the final version (no rc suffix), follow th
 ```bash
 # Bump pyproject.toml to X.Y.Z, add CHANGELOG entry, then:
 scripts/run-integration-tests.sh X.Y.Z --manual --notes "Final cut; rc cycle stable"
-scripts/fleet-rollout.sh X.Y.Z                       # all 4 hosts parallel
+scripts/fleet-rollout.sh X.Y.Z                       # all 5 hosts parallel
 ```
 
 Then proceed to Phase 7 (Tag and publish).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Untether adds interactive permission control, plan mode support, and several UX 
 - **Pi context compaction** — `AutoCompactionStart`/`AutoCompactionEnd` events rendered as progress actions
 - **Stall diagnostics & liveness watchdog** — `/proc` process diagnostics (CPU, RSS, TCP, FDs), progressive stall warnings with Telegram notifications, liveness watchdog for alive-but-silent subprocesses, stall auto-cancel (dead process, no-PID zombie, absolute cap) with CPU-active suppression (sleeping-process aware — shows tool name when main process waiting on child), tool-active repeat suppression (first warning fires, repeats suppressed while child CPU-active), MCP tool-aware threshold (15 min for network-bound MCP calls vs 10 min for local tools) with contextual "MCP tool running: {server}" messaging, `session.summary` structured log; `[watchdog]` config section with configurable `tool_timeout` and `mcp_tool_timeout`
 - **Auto-continue** — detects Claude Code sessions that exit after receiving tool results without processing them (upstream bugs #34142, #30333) and auto-resumes; suppressed on signal deaths (rc=143/SIGTERM, rc=137/SIGKILL) to prevent death spirals under memory pressure; configurable via `[auto_continue]` with `enabled` (default true) and `max_retries` (default 1)
+- **Empty-resume recovery (quarantine-and-fresh)** (#631, #632) — a resume that returns 0 turns/$0 (upstream dangling-tool_use defect) quarantines the session in `session_quarantine.json` and auto-resends the message once on a fresh session; sessions SIGTERM'd after a result (`forced_teardown_after_result`) are quarantined proactively so the next message diverts to a fresh session before any empty result is seen; `[auto_continue]` flags `empty_resume_fresh` and `quarantine_on_forced_teardown` (both default true); structured events `runner.empty_result` → `session.quarantined` → `session.auto_resend_fresh`/`session.resume_diverted_fresh`; Claude runner only
 - **MCP catalog observability + proactive refresh** (#365) — `catalog_staleness.detected` structlog WARNING once per `(session, server, status)` tuple when Claude's `system.init` reports a non-`connected` MCP status (`detect_catalog_staleness`, default **on**); opt-in fire-and-forget `mcp_status` control_request after each `tool_result` to nudge Claude Code's catalog (`notify_catalog_refresh`, default **off**). Request IDs use the `ut_catalog_refresh_<session_id>_<seq>` namespace; drained via `ClaudeRunner._drain_catalog_refresh`. Logs `catalog.refresh_sent` INFO / `catalog.refresh_failed` WARN/ERROR. Claude runner only
 - **File upload deduplication** — auto-appends `_1`, `_2`, … when target file exists, instead of requiring `--force`; media groups without captions auto-save to `incoming/`
 - **Agent-initiated file delivery (outbox)** — agents write files to `.untether-outbox/` during a run; Untether sends them as Telegram documents on completion with `📎` captions; deny-glob security, size limits, file count cap, auto-cleanup; `[transports.telegram.files]` config
@@ -73,7 +74,8 @@ Telegram <-> TelegramPresenter <-> RunnerBridge <-> Runner (claude/codex/opencod
 | `runners/claude.py` | Claude Code runner, interactive features |
 | `runners/gemini.py` | Gemini CLI runner |
 | `runners/amp.py` | AMP CLI runner (Sourcegraph) |
-| `runner_bridge.py` | Connects runners to Telegram presenter, injects agent preamble, auto-continue with signal death suppression |
+| `runner_bridge.py` | Connects runners to Telegram presenter, injects agent preamble, auto-continue with signal death suppression, empty-resume quarantine-and-fresh recovery |
+| `session_quarantine.py` | Persistent QuarantineStore (`session_quarantine.json`): poisoned-session markers, forced-teardown quarantine, resume divert (#631/#632) |
 | `cost_tracker.py` | Per-run/daily cost tracking and budget alerts |
 | `commands/claude_control.py` | Approve/Deny/Discuss callback handler |
 | `commands/dispatch.py` | Callback dispatch and command routing |
@@ -187,11 +189,11 @@ Rules in `.claude/rules/` auto-load when editing matching files:
 
 ## Tests
 
-2910 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
+2914 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
 
 Key test files:
 
-- `test_claude_control.py` — 99 tests: control requests, response routing, registry lifecycle, auto-approve/auto-deny, tool auto-approve, custom deny messages, discuss action, early toast, progressive cooldown, auto permission mode, diff_preview plan bypass
+- `test_claude_control.py` — 109 tests: control requests, response routing, registry lifecycle, auto-approve/auto-deny, tool auto-approve, custom deny messages, discuss action, early toast, progressive cooldown, auto permission mode, diff_preview plan bypass
 - `test_callback_dispatch.py` — 26 tests: callback parsing, dispatch toast/ephemeral behaviour, early answering
 - `test_exec_bridge.py` — 230 tests: ephemeral notification cleanup, approval push notifications, progressive stall warnings, stall diagnostics, stall auto-cancel with CPU-active suppression (sleeping-process aware), tool-active repeat suppression, approval-aware stall threshold, MCP tool stall threshold, frozen ring buffer hung escalation, session summary, PID/stream threading, auto-continue detection, signal death suppression, empty-resume quarantine-and-fresh recovery, resume divert/clear, empty-result diagnostics
 - `test_ask_user_question.py` — 29 tests: AskUserQuestion control request handling, question extraction, pending request registry, answer routing, option button rendering, multi-question flows, structured answer responses, ask mode toggle auto-deny
@@ -363,7 +365,7 @@ Every bug fix and significant change MUST have a GitHub issue:
 - **Bugs found during debugging**: create an issue before or alongside the fix
 - **Issue body**: description, impact, affected files, fix reference
 - **Labels**: `bug`, `enhancement`, `documentation` as appropriate; severity on bugs via `severity:critical|major|minor|trivial`; `priority: low|medium|high` (note space) for human triage
-- **Auto-filed sources**: `auto:error-report` (untether-issue-watcher daemon, log-pattern errors — runs on lba-1, nsd, channelo, mac; each filing is host-tagged via the `HOST` env in the daemon's unit/plist) and `auto:monitor-audit` (`/monitor` command audit loop, bugs + enhancements — 4 per-host configs plus the `untether-fleet` meta-target for cross-host audits)
+- **Auto-filed sources**: `auto:error-report` (untether-issue-watcher daemon, log-pattern errors — runs on all 5 fleet hosts (lba-1, nsd, channelo, sl, mac); each filing is host-tagged via the `HOST` env in the daemon's unit/plist) and `auto:monitor-audit` (`/monitor` command audit loop, bugs + enhancements — 5 per-host configs plus the `untether-fleet` meta-target for cross-host audits)
 - **Closing**: reference the fixing PR or commit in a close comment
 
 ### Changelog

--- a/docs/reference/integration-testing.md
+++ b/docs/reference/integration-testing.md
@@ -345,7 +345,7 @@ Integration tests are run by Claude Code via Telegram MCP tools (see "Automated 
 
 14. If all pass: write the attestation marker, then fleet-roll the rc/stable
     scripts/run-integration-tests.sh X.Y.ZrcN --manual --tiers "tier7,tier1-claude,..." --notes "..."
-    scripts/fleet-rollout.sh X.Y.ZrcN          # parallel across lba-1/nsd/channelo/mac
+    scripts/fleet-rollout.sh X.Y.ZrcN          # parallel across lba-1/nsd/channelo/sl/mac
     See .claude/rules/release-discipline.md → Fleet rollout for the full gate + escape hatches.
 ```
 

--- a/scripts/fleet-rollout.sh
+++ b/scripts/fleet-rollout.sh
@@ -320,7 +320,7 @@ ALL_HOSTS=(lba-1 nsd channelo sl mac)
 
 if [[ -n "$ONLY_HOST" ]]; then
     # Validate the host name against ALL_HOSTS (lba-1 is always known;
-    # nsd/channelo/mac need to be in the static list).
+    # all non-lba-1 hosts need to be in the static list).
     valid=0
     for h in "${ALL_HOSTS[@]}"; do
         if [[ "$h" == "$ONLY_HOST" ]]; then valid=1; break; fi


### PR DESCRIPTION
Context-quality sweep after the 0.35.4rc7 fleet rollout (2026-07-18).

## Stale references fixed
- **release-coordination skill** — seven "4 hosts / nsd,channelo,mac" references updated to the 5-host fleet (sl joined 2026-07-14)
- **docs/reference/integration-testing.md** — fleet-rollout example host list now includes sl
- **scripts/fleet-rollout.sh** — stale host-list comment generalised

## rc7 documentation gaps closed
- **CLAUDE.md** — new *Empty-resume recovery (quarantine-and-fresh)* feature bullet (#631/#632) with flags and event names; `session_quarantine.py` added to Key files; `runner_bridge.py` purpose extended; issue-watcher host list includes sl; test count 2910→2914; `test_claude_control.py` count 99→109 (verified by collection)
- **.claude/rules/runner-development.md** — empty-resume recovery paragraph under Auto-continue

No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)