### PR TITLE
fix(claude): rc8 W4 — one-owner-per-session serialisation (#633)

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -361,7 +361,9 @@ State is persisted to `active_loops.json` (sibling of your `untether.toml`) so l
 
 Auto-continue detects when Claude Code exits after receiving tool results without processing them (upstream bugs [#34142](https://github.com/anthropics/claude-code/issues/34142), [#30333](https://github.com/anthropics/claude-code/issues/30333)) and automatically resumes the session. Detection is based on a protocol invariant: normal sessions always end with `last_event_type=result`, while premature exits show `last_event_type=user`.
 
-Auto-continue is suppressed on signal deaths (rc=143/SIGTERM, rc=137/SIGKILL) to prevent death spirals under memory pressure.
+Auto-continue only fires on a clean exit (`rc=0`). Signal deaths (rc=143/SIGTERM, rc=137/SIGKILL) and ordinary failures are excluded, to prevent death spirals under memory pressure ([#640](https://github.com/littlebearapps/untether/issues/640)).
+
+This section also carries the empty-resume recovery and session-ownership knobs, since they mitigate the same upstream turn-state family.
 
 === "toml"
 
@@ -369,12 +371,26 @@ Auto-continue is suppressed on signal deaths (rc=143/SIGTERM, rc=137/SIGKILL) to
     [auto_continue]
     enabled = true
     max_retries = 1
+    resend_empty_resume = true
+    empty_resume_fresh = true
+    quarantine_on_forced_teardown = true
+    serialize_session_owner = true
+    session_handoff_timeout_s = 30.0
     ```
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
 | `enabled` | bool | `true` | Enable automatic session continuation for Claude Code. |
-| `max_retries` | int | `1` | Maximum consecutive auto-continue attempts per run (1–5). |
+| `max_retries` | int | `1` | Maximum consecutive auto-continue attempts per run (0–3). |
+| `resend_empty_resume` | bool | `true` | ([#596](https://github.com/littlebearapps/untether/issues/596)) Auto-resend the original prompt once when a resume returns an empty 0-turn / $0 result, instead of asking the user to resend. Single-shot. |
+| `empty_resume_fresh` | bool | `true` | ([#631](https://github.com/littlebearapps/untether/issues/631) W1) Make that retry a **fresh** session rather than the same one — the original session is poisoned, so resending into it can no-op again. |
+| `quarantine_on_forced_teardown` | bool | `true` | ([#632](https://github.com/littlebearapps/untether/issues/632) W2) Mark sessions force-killed after a result as unsafe to resume, so the *next* message diverts fresh before any empty result is seen. |
+| `serialize_session_owner` | bool | `true` | ([#633](https://github.com/littlebearapps/untether/issues/633) W4) Never resume a session whose previous subprocess is still alive. Before spawning `--resume`, wait (bounded) for the prior owner to exit; if it will not, quarantine and start fresh rather than racing it. Two concurrent owners of one session id is what leaves the upstream turn dangling and produces the 0-turn empty resume. Set `false` for exact pre-0.35.4rc8 behaviour. Claude only. |
+| `session_handoff_timeout_s` | float | `30.0` | Upper bound on that wait (0–300). Condition-based, so it resolves the instant the prior subprocess exits — this is only the give-up point. Keep comfortably above the post-result SIGTERM grace so a normal teardown wins the race. |
+
+!!! tip "Layered defence"
+
+    `serialize_session_owner` is *proactive* (stop the session being poisoned); `quarantine_on_forced_teardown` and `empty_resume_fresh` are *reactive* (recover once it has been). Leave all three on unless you are bisecting a regression.
 
 ### `[security]`
 

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -3229,6 +3229,69 @@ async def handle_message(
                     logger.debug("session.clear_failed", exc_info=True)
             resume_token = None
 
+    # #633 (W4): one-owner-per-session serialisation. rc7 recovers *after* a
+    # session is poisoned; this stops it happening. If a subprocess for this
+    # session is still alive (typically lingering in post-result limbo holding
+    # MCP children open), spawning `--resume` now would give one session id two
+    # concurrent owners — the exact race that leaves the upstream turn dangling
+    # on an unresolved tool_use and makes the next resume return 0 turns / $0.
+    #
+    # The wait is condition-based and bounded: it returns the moment the prior
+    # owner deregisters, and on timeout we quarantine and go fresh rather than
+    # racing. Claude-only — no other engine has the limbo behaviour, and
+    # `wait_for_session_handoff` is Claude's registry.
+    if resume_token is not None and runner.engine == "claude":
+        _ac_cfg = _load_auto_continue_settings()
+        if getattr(_ac_cfg, "serialize_session_owner", True):
+            try:
+                from untether.runners.claude import wait_for_session_handoff
+
+                _handoff = await wait_for_session_handoff(
+                    resume_token.value,
+                    getattr(_ac_cfg, "session_handoff_timeout_s", 30.0),
+                )
+            except Exception:  # noqa: BLE001 — never block message handling
+                # Fail CLOSED. The entire point of this gate is to never resume
+                # a session that might still be owned; treating a broken check
+                # as "safe to resume" would silently reinstate the race it
+                # exists to prevent. Logged at WARNING (not debug) so a
+                # persistent failure surfaces as degraded continuity instead of
+                # quietly making every resume fresh.
+                logger.warning("session.handoff_check_failed", exc_info=True)
+                _handoff = "timed_out"
+            if _handoff != "free":
+                logger.info(
+                    "session.handoff",
+                    engine=runner.engine,
+                    session_id=resume_token.value,
+                    outcome=_handoff,
+                )
+            if _handoff == "timed_out":
+                # The prior owner is still alive. Start fresh rather than
+                # racing it.
+                #
+                # Deliberately NOT quarantined: a handoff timeout means the
+                # session is *busy*, not that it is known-corrupt, and a
+                # quarantine marker persists for 7 days and permanently
+                # diverts the session — too destructive for "the previous run
+                # was slow to tear down". Clearing the stored token is enough,
+                # because nothing will reference the old id afterwards. If that
+                # process does go on to be force-killed after a result, the
+                # existing W2 path (`quarantine_on_forced_teardown`) quarantines
+                # it at the point we actually have evidence of poisoning.
+                logger.warning(
+                    "session.resume_diverted_fresh",
+                    engine=runner.engine,
+                    session_id=resume_token.value,
+                    reason="handoff_timeout",
+                )
+                if on_resume_failed is not None:
+                    try:
+                        await on_resume_failed(resume_token)
+                    except Exception:  # noqa: BLE001
+                        logger.debug("session.clear_failed", exc_info=True)
+                resume_token = None
+
     started_at = clock()
     is_resume_line = runner.is_resume_line
     resume_strip = strip_resume_line or is_resume_line

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -225,6 +225,54 @@ def is_session_alive(session_id: str) -> bool:
     return session_id in _SESSION_STDIN
 
 
+SESSION_HANDOFF_POLL_S: float = 0.25
+
+
+async def wait_for_session_handoff(
+    session_id: str,
+    timeout_s: float,
+    *,
+    poll_s: float = SESSION_HANDOFF_POLL_S,
+) -> str:
+    """Wait for any live subprocess owning ``session_id`` to exit.
+
+    Returns ``"free"`` immediately if no subprocess owns the session,
+    ``"exited"`` if one did and it exited within ``timeout_s``, or
+    ``"timed_out"`` if it was still alive when the budget elapsed.
+
+    #633 (W4) — one-owner-per-session serialisation. A follow-up message can
+    otherwise spawn ``--resume <sid>`` while the previous subprocess for that
+    same session is still alive in post-result limbo (the reproductions show a
+    resume 6 s after the prior process was SIGTERM'd). Two owners of one
+    session id is exactly what corrupts the upstream turn/queue state and
+    produces the 0-turn empty resume that rc7 could only recover from after
+    the fact.
+
+    This is condition-based, not a fixed sleep: it resolves the instant the
+    prior owner deregisters, so the common case (already exited) costs one
+    dict lookup and the contended case costs only as long as the handoff
+    actually takes. The wait is always bounded — on ``"timed_out"`` the caller
+    quarantines the session and starts fresh rather than racing the resume.
+
+    Liveness is read from ``_SESSION_STDIN`` via :func:`is_session_alive`,
+    which ``run_impl``'s finally block clears. Note the runner's own
+    ``session_locks`` cannot serve this purpose: it is a
+    ``WeakValueDictionary``, so entries disappear as soon as nothing holds a
+    reference to the semaphore.
+    """
+    if not is_session_alive(session_id):
+        return "free"
+    deadline = time.monotonic() + max(0.0, timeout_s)
+    while time.monotonic() < deadline:
+        await anyio.sleep(poll_s)
+        if not is_session_alive(session_id):
+            return "exited"
+    # Final probe: the loop can overshoot the deadline by up to ``poll_s``, and
+    # an owner that exited during that last sleep should be reported as
+    # "exited" rather than being penalised for our polling granularity.
+    return "exited" if not is_session_alive(session_id) else "timed_out"
+
+
 def pending_control_requests_for_session(session_id: str | None) -> int:
     """Return how many control requests for ``session_id`` are still awaiting
     a response (approval buttons or AskUserQuestion).

--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -365,6 +365,16 @@ class AutoContinueSettings(BaseModel):
     # resume — quarantine them so resuming on the next message spins up a new
     # session rather than re-entering the poisoned state.
     quarantine_on_forced_teardown: bool = True
+    # #633 (W4): never resume a session whose previous subprocess is still
+    # alive. rc7's quarantine-and-fresh recovers AFTER a session is poisoned;
+    # this prevents the poisoning. Before spawning a `--resume`, wait (bounded)
+    # for the prior owner to exit; if it does not, quarantine and start fresh
+    # rather than racing it. Set False for exact pre-rc8 behaviour.
+    serialize_session_owner: bool = True
+    # Upper bound on that wait. Condition-based, so it resolves the instant the
+    # prior subprocess exits — this is only the give-up point. Kept comfortably
+    # above the post-result SIGTERM grace so a normal teardown wins the race.
+    session_handoff_timeout_s: float = Field(default=30.0, ge=0.0, le=300.0)
 
 
 class WatchdogSettings(BaseModel):

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -7690,3 +7690,236 @@ async def test_640_claude_runner_records_proc_returncode() -> None:
         "_is_signal_death() always sees None and auto-continue can resume a "
         "SIGTERM'd (poisoned) session. See #640."
     )
+
+
+# ---------------------------------------------------------------------------
+# #633 (W4) — bridge-level serialisation gate.
+# ---------------------------------------------------------------------------
+
+CLAUDE_ENGINE = "claude"
+
+
+@pytest.mark.anyio
+async def test_633_handoff_timeout_quarantines_and_starts_fresh(
+    quarantine_store, monkeypatch
+) -> None:
+    """A prior subprocess that will not die must divert the follow-up to a
+    FRESH session and quarantine the old one — resuming it is the documented
+    path into the poisoned 0-turn state."""
+    from structlog.testing import capture_logs
+
+    from untether.runners import claude as claude_mod
+
+    async def _stuck(session_id, timeout_s, *, poll_s=0.25):
+        return "timed_out"
+
+    monkeypatch.setattr(claude_mod, "wait_for_session_handoff", _stuck)
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CLAUDE_ENGINE, resume_value="sid-fresh", answer="fresh answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+    cleared: list[str] = []
+
+    async def on_resume_failed(tok: ResumeToken) -> None:
+        cleared.append(tok.value)
+
+    with capture_logs() as logs:
+        await handle_message(
+            cfg,
+            runner=runner,
+            incoming=IncomingMessage(channel_id=123, message_id=10, text="hi"),
+            resume_token=ResumeToken(engine=CLAUDE_ENGINE, value="sid-live"),
+            on_resume_failed=on_resume_failed,
+        )
+
+    # (a) went fresh rather than racing the live owner
+    assert len(runner.calls) == 1
+    assert runner.calls[0][1] is None
+    # (b) NOT quarantined — a busy session is not a known-corrupt one, and a
+    # quarantine marker persists 7 days and permanently diverts the session.
+    # Clearing the token is sufficient; if that process is later force-killed
+    # after a result, the W2 path quarantines it on real evidence.
+    assert quarantine_store.is_quarantined(CLAUDE_ENGINE, "sid-live") is False
+    # (c) stored token cleared, structured reason logged
+    assert "sid-live" in cleared
+    assert any(
+        r.get("event") == "session.resume_diverted_fresh"
+        and r.get("reason") == "handoff_timeout"
+        for r in logs
+    )
+    # (d) the user still gets a real answer
+    assert "fresh answer" in transport.edit_calls[-1]["message"].text
+
+
+@pytest.mark.anyio
+async def test_633_handoff_exit_resumes_normally(quarantine_store, monkeypatch) -> None:
+    """If the prior owner exits within the window we resume as usual — W4 must
+    not turn a normal follow-up into a fresh session."""
+    from untether.runners import claude as claude_mod
+
+    async def _exits(session_id, timeout_s, *, poll_s=0.25):
+        return "exited"
+
+    monkeypatch.setattr(claude_mod, "wait_for_session_handoff", _exits)
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CLAUDE_ENGINE, resume_value="sid-a", answer="resumed answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=11, text="hi"),
+        resume_token=ResumeToken(engine=CLAUDE_ENGINE, value="sid-a"),
+    )
+
+    assert len(runner.calls) == 1
+    assert runner.calls[0][1] is not None
+    assert runner.calls[0][1].value == "sid-a"
+    assert quarantine_store.is_quarantined(CLAUDE_ENGINE, "sid-a") is False
+
+
+@pytest.mark.anyio
+async def test_633_non_claude_engines_skip_the_gate(
+    quarantine_store, monkeypatch
+) -> None:
+    """Only Claude has the post-result limbo behaviour; other engines must not
+    pay the handoff check at all."""
+    from untether.runners import claude as claude_mod
+
+    called = False
+
+    async def _tracker(session_id, timeout_s, *, poll_s=0.25):
+        nonlocal called
+        called = True
+        return "timed_out"
+
+    monkeypatch.setattr(claude_mod, "wait_for_session_handoff", _tracker)
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CODEX_ENGINE, resume_value="sid-c", answer="codex answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=12, text="hi"),
+        resume_token=ResumeToken(engine=CODEX_ENGINE, value="sid-c"),
+    )
+
+    assert called is False
+    assert runner.calls[0][1] is not None
+
+
+@pytest.mark.anyio
+async def test_633_flag_off_restores_pre_rc8_behaviour(
+    quarantine_store, monkeypatch
+) -> None:
+    """Rollback path: serialize_session_owner=False must skip the gate entirely
+    even when a live owner would otherwise time out."""
+    import untether.runner_bridge as rb
+    from untether.runners import claude as claude_mod
+    from untether.settings import AutoContinueSettings
+
+    called = False
+
+    async def _tracker(session_id, timeout_s, *, poll_s=0.25):
+        nonlocal called
+        called = True
+        return "timed_out"
+
+    monkeypatch.setattr(claude_mod, "wait_for_session_handoff", _tracker)
+    monkeypatch.setattr(
+        rb,
+        "_load_auto_continue_settings",
+        lambda: AutoContinueSettings(serialize_session_owner=False),
+    )
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CLAUDE_ENGINE, resume_value="sid-x", answer="answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=13, text="hi"),
+        resume_token=ResumeToken(engine=CLAUDE_ENGINE, value="sid-x"),
+    )
+
+    assert called is False
+    assert runner.calls[0][1] is not None
+    assert runner.calls[0][1].value == "sid-x"
+
+
+@pytest.mark.anyio
+async def test_633_probe_failure_fails_closed(quarantine_store, monkeypatch) -> None:
+    """If the ownership check itself breaks we must NOT resume — that would
+    silently reinstate the very race the gate exists to prevent. Fail closed
+    (fresh session) and log at WARNING so the degradation is visible."""
+    from structlog.testing import capture_logs
+
+    from untether.runners import claude as claude_mod
+
+    async def _explode(session_id, timeout_s, *, poll_s=0.25):
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(claude_mod, "wait_for_session_handoff", _explode)
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CLAUDE_ENGINE, resume_value="sid-fresh", answer="fresh answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+
+    with capture_logs() as logs:
+        await handle_message(
+            cfg,
+            runner=runner,
+            incoming=IncomingMessage(channel_id=123, message_id=14, text="hi"),
+            resume_token=ResumeToken(engine=CLAUDE_ENGINE, value="sid-broken"),
+        )
+
+    assert runner.calls[0][1] is None  # went fresh, did not resume
+    assert any(
+        r.get("event") == "session.handoff_check_failed"
+        and r.get("log_level") == "warning"
+        for r in logs
+    ), "a broken ownership probe must be visible, not silently degrade"
+
+
+@pytest.mark.anyio
+async def test_633_gate_does_not_stall_a_just_exited_session() -> None:
+    """Regression guard for recursive re-entry (auto-continue / auto-resend):
+    handle_message re-enters with a resume token while the just-finished
+    subprocess is tearing down. Because run_impl's finally deregisters the
+    session before the run generator is exhausted, the gate must return "free"
+    immediately rather than burning the full handoff budget on every
+    auto-continue."""
+    import time as _time
+
+    from untether.runners.claude import wait_for_session_handoff
+
+    t0 = _time.monotonic()
+    outcome = await wait_for_session_handoff("sid-already-gone", 30.0)
+    elapsed = _time.monotonic() - t0
+
+    assert outcome == "free"
+    assert elapsed < 0.5, f"gate stalled {elapsed:.2f}s on a non-live session"

--- a/tests/test_exec_runner.py
+++ b/tests/test_exec_runner.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncIterator
 
 import anyio
 import pytest
+from pydantic import ValidationError
 
 from untether.model import (
     ActionEvent,
@@ -1035,3 +1036,102 @@ async def test_base_iter_jsonl_breaks_on_did_emit_completed() -> None:
 
     assert stream.did_emit_completed is True
     assert any(isinstance(e, CompletedEvent) for e in events)
+
+
+# ---------------------------------------------------------------------------
+# #633 (W4) — one-owner-per-session serialisation.
+#
+# rc7's quarantine-and-fresh recovers AFTER a session is poisoned. W4 prevents
+# the poisoning: never spawn `--resume <sid>` while a subprocess for that same
+# sid is still alive. Two concurrent owners of one session id is what leaves
+# the upstream turn dangling on an unresolved tool_use.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_633_handoff_free_when_no_owner() -> None:
+    """The common case must be a single dict lookup with no sleep."""
+    from untether.runners.claude import wait_for_session_handoff
+
+    assert await wait_for_session_handoff("no-such-session", 5.0) == "free"
+
+
+@pytest.mark.anyio
+async def test_633_handoff_exits_when_prior_owner_deregisters() -> None:
+    """Condition-based: resolves the instant the prior owner goes away, well
+    before the timeout budget elapses."""
+    import anyio
+
+    from untether.runners import claude as claude_mod
+    from untether.runners.claude import wait_for_session_handoff
+
+    sid = "sess-handoff-exit"
+    claude_mod._SESSION_STDIN[sid] = object()
+    try:
+        result: list[str] = []
+
+        async with anyio.create_task_group() as tg:
+
+            async def waiter() -> None:
+                result.append(await wait_for_session_handoff(sid, 10.0, poll_s=0.01))
+
+            async def releaser() -> None:
+                await anyio.sleep(0.05)
+                claude_mod._SESSION_STDIN.pop(sid, None)
+
+            tg.start_soon(waiter)
+            tg.start_soon(releaser)
+
+        assert result == ["exited"]
+    finally:
+        claude_mod._SESSION_STDIN.pop(sid, None)
+
+
+@pytest.mark.anyio
+async def test_633_handoff_times_out_and_is_bounded() -> None:
+    """A prior owner that will not die must NOT deadlock the follow-up
+    message — the wait is bounded and always resolves."""
+    from untether.runners import claude as claude_mod
+    from untether.runners.claude import wait_for_session_handoff
+
+    sid = "sess-handoff-stuck"
+    claude_mod._SESSION_STDIN[sid] = object()
+    try:
+        assert await wait_for_session_handoff(sid, 0.05, poll_s=0.01) == "timed_out"
+    finally:
+        claude_mod._SESSION_STDIN.pop(sid, None)
+
+
+@pytest.mark.anyio
+async def test_633_never_two_live_owners_for_one_session() -> None:
+    """The core invariant. While one owner holds the session, a second caller
+    must never be told the session is free to resume."""
+    from untether.runners import claude as claude_mod
+    from untether.runners.claude import is_session_alive, wait_for_session_handoff
+
+    sid = "sess-single-owner"
+    claude_mod._SESSION_STDIN[sid] = object()
+    try:
+        assert is_session_alive(sid) is True
+        assert await wait_for_session_handoff(sid, 0.05, poll_s=0.01) == "timed_out"
+    finally:
+        claude_mod._SESSION_STDIN.pop(sid, None)
+    # Once the owner deregisters the session is immediately resumable again.
+    assert await wait_for_session_handoff(sid, 1.0) == "free"
+
+
+def test_633_settings_default_on_and_bounded() -> None:
+    from untether.settings import AutoContinueSettings
+
+    s = AutoContinueSettings()
+    assert s.serialize_session_owner is True
+    assert s.session_handoff_timeout_s == 30.0
+    # Flag off must be expressible for an exact pre-rc8 rollback.
+    assert (
+        AutoContinueSettings(serialize_session_owner=False).serialize_session_owner
+        is False
+    )
+    with pytest.raises(ValidationError):
+        AutoContinueSettings(session_handoff_timeout_s=-1.0)
+    with pytest.raises(ValidationError):
+        AutoContinueSettings(session_handoff_timeout_s=10_000.0)


### PR DESCRIPTION
Recreates #643, which GitHub auto-closed when its base branch (`fix/rc8-batch-a`) was deleted on merge of #642. Same commit, rebased onto `dev`; no content change.

rc7 shipped quarantine-and-fresh, which recovers *after* a session is poisoned by the upstream dangling-`tool_use` defect. W4 stops the poisoning happening.

## The race

A follow-up message can spawn `--resume <sid>` while the previous subprocess for that session is still alive in post-result limbo — the reproductions show a resume **6 s** after the prior process was SIGTERM'd. Two concurrent owners of one session id is exactly what leaves the upstream turn dangling on an unresolved `tool_use`, so the next resume returns 0 turns / $0 / empty with `rc=0`. The user just sees nothing happen.

## Implementation

`wait_for_session_handoff(sid, timeout_s)` → `"free" | "exited" | "timed_out"`. Condition-based rather than a fixed sleep: the common case is one dict lookup, the contended case costs only as long as the handoff actually takes, and the wait is always bounded.

- Liveness reuses the existing `is_session_alive` / `_SESSION_STDIN` (already used by the loop scheduler) — **no new registry**.
- `SessionLockMixin.session_locks` *cannot* serve this purpose: it's a `WeakValueDictionary`, so entries vanish as soon as nothing references the semaphore.

The gate lives in the **bridge**, extending the existing W2 quarantine-divert block, rather than at the `--resume` argv site in the runner. That keeps it beside the recovery helpers it composes with and applies uniformly to recursive auto-continue / auto-resend re-entries.

Config: `[auto_continue] serialize_session_owner` (default `true`), `session_handoff_timeout_s` (default `30`, bounded 0–300). Flag off ⇒ exact pre-rc8 behaviour.

## Four corrections from adversarial review

Reviewed with `gpt-5.6-sol` via pal MCP; all four findings applied:

1. **Fail closed, not open.** A probe exception now diverts fresh instead of resuming — treating a broken ownership check as "safe to resume" would silently reinstate the race. Logged at WARNING so persistent failure surfaces as degraded continuity rather than quietly making every resume fresh.

2. **Do NOT quarantine on timeout** — *this deviates from the plan doc.* A handoff timeout means the session is **busy**, not known-corrupt. A quarantine marker persists 7 days and permanently diverts the session, far too destructive for "the previous run was slow to tear down". Clearing the stored token is sufficient. If that process is later force-killed after a result, the existing W2 path quarantines it at the point we actually have evidence of poisoning.

3. **Final liveness probe after the loop.** The poll can overshoot the deadline by up to `poll_s`; an owner that exited during that last sleep is now `"exited"` rather than penalised for our polling granularity.

4. **Recursive-re-entry stall** was flagged as a risk — auto-continue re-enters `handle_message` while the just-finished subprocess tears down, which would burn the full 30 s budget *on every auto-continue* if the session were still registered. Verified empirically that it isn't: `run_impl`'s `finally` deregisters before the run generator is exhausted, and the real-subprocess harness completes in **2.7 s**. Locked in with an explicit regression test.

## Testing

11 new tests: handoff free/exit/timeout/boundedness, the never-two-owners invariant, settings defaults + bounds, bridge-level divert-on-timeout, resume-normally-on-exit, non-Claude engines skipping the gate, flag-off rollback, fail-closed on probe failure, and the no-stall guard.

Full suite: **2942 passed**, coverage 83.0%. The one failure under coverage is #641, a pre-existing timing-based deadline flake reproduced on clean `dev`.

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)