### PR TITLE
fix(claude): register default-background subagents (#646)

### DIFF
--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -325,7 +325,9 @@ DISCUSS_COOLDOWN_BASE_SECONDS: float = 30.0
 DISCUSS_COOLDOWN_MAX_SECONDS: float = 120.0
 
 # #374 (rc7): bounded keep for background-agent handles (Agent/Task
-# tool_use with run_in_background=True). An interim tool_result no longer
+# tool_use that runs in the background — #646: that is the *default*
+# upstream, i.e. every Agent/Task except an explicit run_in_background=False;
+# see `_agent_runs_in_background`). An interim tool_result no longer
 # clears the handle immediately (see `_is_terminal_tool_result`), but every
 # "keep the handle" branch MUST have a bounded age-out — a handle that
 # never clears wedges the post-result idle watchdog into a permanent hang.
@@ -405,8 +407,9 @@ class ClaudeStreamState:
     # #347 per-session background-task tracking. Claude Code v2.1.72+ has
     # primitives that arm long-running work and return the subprocess to
     # "ready" state while the primitive continues in the background:
-    # `Monitor`, `Bash run_in_background=true`, `Agent run_in_background=true`,
-    # `ScheduleWakeup`, `RemoteTrigger`. Untether tracks them so (a) #346's
+    # `Monitor`, `Bash run_in_background=true`, `Agent`/`Task` (background by
+    # default upstream — #646), `ScheduleWakeup`, `RemoteTrigger`. Untether
+    # tracks them so (a) #346's
     # wedge detector can gate SIGTERM on "do we still have armed work?",
     # (b) progress footers can show "⏳ N watchers · M bg tasks", and (c)
     # a future `/background` command can enumerate the handles.
@@ -701,6 +704,38 @@ def _tool_action(
     return Action(id=tool_id, kind=kind, title=title, detail=detail)
 
 
+def _agent_runs_in_background(raw_input: dict) -> bool:
+    """Decide whether an Agent/Task tool_use launches a *background* subagent (#646).
+
+    Claude Code runs subagents in the background **by default**: the tool
+    contract reads "Subagents run in the background by default; ... Pass
+    ``run_in_background: false`` for a synchronous run." The flag is therefore
+    normally ABSENT from `input` — the observed shape is just
+    ``{"description": ..., "subagent_type": ...}``.
+
+    The pre-#646 predicate was ``bool(raw_input.get("run_in_background"))``,
+    which read an omitted key as *foreground*. That inverted the upstream
+    default and missed every real background subagent (measured: 11/11 Agent
+    calls across the 5 sessions quarantined on nsd 2026-07-18 omit the key).
+    An unregistered handle leaves `has_live_background_work()` False, so the
+    post-result idle watchdog applies the 60s limbo grace instead of the full
+    timeout, SIGTERMs a subprocess whose subagents are still working, and the
+    #632 forced-teardown path then quarantines a perfectly healthy session —
+    so the user's next message diverts to a fresh, contextless one.
+
+    Hence: background unless the caller *explicitly* opted out with literal
+    ``False``. Anything else (absent, None, true, or a malformed value) counts
+    as background — over-registering is the safe direction, because a stale
+    handle only forfeits the 60s shortcut while the 600s post-result ceiling
+    and the 900s ``BG_AGENT_MAX_KEEP_S`` age-out both still bound teardown.
+    Under-registering force-kills live work and poisons the session.
+
+    Deliberately NOT applied to ``Bash(run_in_background=...)``, whose flag is
+    genuinely opt-in upstream — see `_register_background_handle`.
+    """
+    return raw_input.get("run_in_background") is not False
+
+
 def _register_background_handle(
     state: ClaudeStreamState,
     content: claude_schema.StreamToolUseBlock,
@@ -741,7 +776,7 @@ def _register_background_handle(
         # (see ClaudeStreamState.last_bg_bash_launched_at docstring). Used by
         # the post-result idle watchdog tick log for observability only.
         state.last_bg_bash_launched_at = time.monotonic()
-    elif tool_name in ("Agent", "Task") and bool(raw_input.get("run_in_background")):
+    elif tool_name in ("Agent", "Task") and _agent_runs_in_background(raw_input):
         state.background_observed = True
         state.live_bg_agents.add(tool_id)
         # #374 (rc7): bounded keep — see BG_AGENT_MAX_KEEP_S and
@@ -852,8 +887,11 @@ def _is_terminal_tool_result(
       (``has_live_background_work`` already uses the same deadline to age the
       handle out — so no leak).
 
-    - **Agent/Task with ``run_in_background=True``** (rc7, #374) can likewise emit
-      an interim tool_result before the subagent actually finishes. Clearing
+    - **Agent/Task running in the background** (rc7, #374) — i.e. every Agent/Task
+      except an explicit ``run_in_background=False``, since background is the
+      upstream default (#646, ``_agent_runs_in_background``). These likewise emit
+      an interim tool_result (observed: ``"Async agent launched successfully."``
+      ~25ms after the tool_use) before the subagent actually finishes. Clearing
       ``live_bg_agents`` on that first result reintroduced the same premature-drain
       bug the Monitor fix addressed: it poisoned the "no live background work"
       signal the empty-resume detector relies on (#596). There is no reliable

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -15,6 +15,7 @@ from untether.runners.claude import (
     ENGINE,
     ClaudeRunner,
     ClaudeStreamState,
+    has_live_background_work,
     translate_claude_event,
 )
 from untether.schemas import claude as claude_schema
@@ -480,7 +481,9 @@ def test_bash_without_run_in_background_is_not_tracked() -> None:
     assert "toolu_B2" not in state.live_bg_bashes
 
 
-def test_agent_bg_tracked_only_when_run_in_background() -> None:
+def test_agent_bg_tracked_unless_explicitly_foreground() -> None:
+    """#646: background is the upstream default — only an explicit
+    ``run_in_background=False`` opts out."""
     state = ClaudeStreamState()
     translate_claude_event(
         _decode_event(
@@ -496,7 +499,11 @@ def test_agent_bg_tracked_only_when_run_in_background() -> None:
 
     state2 = ClaudeStreamState()
     translate_claude_event(
-        _decode_event(_make_tool_use_event("Agent", "toolu_A2", {"task": "..."})),
+        _decode_event(
+            _make_tool_use_event(
+                "Agent", "toolu_A2", {"task": "...", "run_in_background": False}
+            )
+        ),
         title="claude",
         state=state2,
         factory=state2.factory,
@@ -523,16 +530,110 @@ def test_374_task_tool_registers_background_handle() -> None:
 
 
 def test_374_task_tool_foreground_not_registered() -> None:
-    """#374: Task without run_in_background should NOT register in live_bg_agents
-    and should NOT set background_observed flag."""
+    """#374/#646: Task with an explicit run_in_background=False should NOT
+    register in live_bg_agents and should NOT set background_observed.
+
+    Pre-#646 this case was expressed by *omitting* the key; omission now means
+    background (the upstream default), so opting out must be explicit.
+    """
     state = ClaudeStreamState()
     translate_claude_event(
-        _decode_event(_make_tool_use_event("Task", "toolu_T2", {"task": "..."})),
+        _decode_event(
+            _make_tool_use_event(
+                "Task", "toolu_T2", {"task": "...", "run_in_background": False}
+            )
+        ),
         title="claude",
         state=state,
         factory=state.factory,
     )
     assert "toolu_T2" not in state.live_bg_agents
+    assert state.background_observed is False
+
+
+# ---------------------------------------------------------------------------
+# #646 — default-background subagent registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool_name", ["Agent", "Task"])
+@pytest.mark.parametrize(
+    ("raw_input", "expect_background"),
+    [
+        # The real shape emitted by Claude Code: no run_in_background key at
+        # all. 11/11 Agent calls across the 5 sessions quarantined on nsd
+        # 2026-07-18 looked exactly like this.
+        ({"description": "Explore canon doc", "subagent_type": "Explore"}, True),
+        # Explicit opt-in stays background.
+        ({"task": "...", "run_in_background": True}, True),
+        # Only a literal False opts out.
+        ({"task": "...", "run_in_background": False}, False),
+        # Malformed / null values fall back to the upstream default rather
+        # than silently forfeiting the handle — over-registering is bounded by
+        # BG_AGENT_MAX_KEEP_S, under-registering force-kills live work.
+        ({"task": "...", "run_in_background": None}, True),
+        ({"task": "...", "run_in_background": "false"}, True),
+        ({"task": "...", "run_in_background": 0}, True),
+    ],
+)
+def test_646_agent_background_registration_tristate(
+    tool_name: str, raw_input: dict, expect_background: bool
+) -> None:
+    """#646: an omitted ``run_in_background`` means BACKGROUND, not foreground.
+
+    The pre-#646 predicate was ``bool(raw_input.get("run_in_background"))``,
+    which read omission as foreground and so never registered a real subagent.
+    That left ``has_live_background_work()`` False, applied the 60s limbo grace
+    instead of the full post-result timeout, force-killed a subprocess whose
+    subagents were still working, and let the #632 forced-teardown path
+    quarantine a healthy session.
+    """
+    state = ClaudeStreamState()
+    tool_id = f"toolu_{tool_name}_646"
+    translate_claude_event(
+        _decode_event(_make_tool_use_event(tool_name, tool_id, raw_input)),
+        title="claude",
+        state=state,
+        factory=state.factory,
+    )
+    assert (tool_id in state.live_bg_agents) is expect_background
+    assert state.background_observed is expect_background
+    assert has_live_background_work(state) is expect_background
+    if expect_background:
+        # Registration must always come with a bounded age-out (#374).
+        assert state.bg_agent_deadlines[tool_id] > time.monotonic()
+
+
+def test_646_default_background_agent_is_bounded() -> None:
+    """#646: an implicitly-background handle still ages out at
+    BG_AGENT_MAX_KEEP_S — it must not pin the watchdog forever."""
+    state = ClaudeStreamState()
+    translate_claude_event(
+        _decode_event(
+            _make_tool_use_event("Agent", "toolu_A646", {"subagent_type": "Explore"})
+        ),
+        title="claude",
+        state=state,
+        factory=state.factory,
+    )
+    assert has_live_background_work(state) is True
+
+    # Expire the handle: past its deadline it no longer counts as live.
+    state.bg_agent_deadlines["toolu_A646"] = time.monotonic() - 1.0
+    assert has_live_background_work(state) is False
+
+
+def test_646_bash_still_requires_explicit_opt_in() -> None:
+    """#646 must not leak into Bash — its run_in_background flag is genuinely
+    opt-in upstream, so a plain command stays foreground."""
+    state = ClaudeStreamState()
+    translate_claude_event(
+        _decode_event(_make_tool_use_event("Bash", "toolu_B646", {"command": "ls"})),
+        title="claude",
+        state=state,
+        factory=state.factory,
+    )
+    assert "toolu_B646" not in state.live_bg_bashes
     assert state.background_observed is False
 
 


### PR DESCRIPTION
Fixes #646.

## Problem

When Claude Code hands work off to subagents, the user's next message came back with **zero knowledge of the previous session or the subagents' work**. Runs where Claude did everything directly were unaffected.

`_register_background_handle` gated Agent/Task registration on an explicitly truthy flag:

```python
elif tool_name in ("Agent", "Task") and bool(raw_input.get("run_in_background")):
```

But Claude Code runs subagents **in the background by default** — `run_in_background` is only present to opt *out*. So the key is normally absent, `bool(None)` is `False`, and the handle was never registered.

**Measured:** across the 5 sessions quarantined on nsd 2026-07-18, **11/11** Agent calls omit the key. Observed input is `{"description": …, "subagent_type": …}`; the tool_result ~25 ms later reads `"Async agent launched successfully."` — an interim ack, not completion.

## Failure chain

```
Agent(...)  # no run_in_background key
  → registration predicate False                    ← root cause
  → has_live_background_work() False
  → 60s limbo grace instead of the 600s timeout
  → SIGTERM while subagents are still working (rc=143)
  → session.quarantined reason=forced_teardown_after_result   (#632, working as designed)
  → next message: session.resume_diverted_fresh reason=quarantined
  → fresh spawn, resume=None → amnesia
```

## Fix

New `_agent_runs_in_background()` — background unless the caller explicitly passed literal `False`.

Over-registering is the safe direction: a stale handle only forfeits the 60s shortcut, while the 600s post-result ceiling and the 900s `BG_AGENT_MAX_KEEP_S` age-out both still bound teardown. Under-registering force-kills live work and poisons the session. **Bash is deliberately untouched** — its flag is genuinely opt-in upstream.

**Quarantine semantics unchanged.** Once a process has actually been force-killed after a result, the upstream turn may dangle regardless of whether the linger was explainable. Fixed at classification, not by weakening the safety net.

## Scope note

Distinct from #374/#573, which cover *terminal* detection and presuppose a registered handle — `_is_terminal_tool_result` finds Agents only via `bg_agent_deadlines`, so an unregistered agent bypassed that logic entirely.

Root cause independently validated with `gpt-5.6-sol` via `pal debug`.

## Tests

- Table-driven tri-state registration for **Agent and Task**: absent / `True` / `False` / `None` / `"false"` / `0`. Only literal `False` opts out.
- Boundedness: an implicitly-background handle still ages out at `BG_AGENT_MAX_KEEP_S`.
- Bash regression guard: a plain command stays foreground.
- Two pre-existing tests that locked in the inverted contract now express the foreground case with an explicit `run_in_background: False`.

`uv run pytest`: **2966 passed**, 1 failed — `test_run_main_loop_persists_topic_sessions_in_project_scope`, the known order-dependent failure (#641), confirmed failing identically on the clean base with this diff stashed. `ruff check` + `ruff format` clean.

## Integration test (@untether_dev_bot, 3 live background subagents)

Before (nsd, rc7): SIGTERM `rc=143` at the 60s grace → quarantine → fresh session.

After:
```
01:55:01 post_result_idle.reader_done_but_alive elapsed_since_result_s=19.3
01:55:31 runner.limbo_detected mcp_child_pids=[9 pids]
01:56:41 subprocess.state.exited rc=0
         reason=subprocess_exited_during_subcountdown
```
No `sigterm_after_timeout`, no `session.quarantined`, no `resume_diverted_fresh`. The subprocess passed through limbo untouched and **exited naturally** ~100 s after reader EOF — the old grace would have killed it ~40 s early.

Follow-up message resumed the same session (`--resume ce84f6bf…`, `num_turns=1`, $1.10) and correctly recalled **both** the codeword and all three subagents' findings.

## Follow-up

#647 tracks the remaining path to the same symptom: a follow-up sent *during* live background work can still divert fresh via `session_handoff_timeout_s` (30s default), logged `reason=handoff_timeout`. Not addressed here.

Post-rollout, watch `session.resume_diverted_fresh` grouped by `reason` — expect the `quarantined` cohort to vanish without a rise in `handoff_timeout`.
