### PR TITLE
chore: staging 0.35.4rc9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.4rc8"
+version = "0.35.4rc9"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.4rc8"
+version = "0.35.4rc9"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bumps to `0.35.4rc9` so the #646 fix (PR #648) actually reaches TestPyPI.

The rc8 merge left the version unchanged, so the TestPyPI upload returned `400 File already exists ('untether-0.35.4rc8-py3-none-any.whl')`. `skip-existing: true` swallowed it and the job reported success — but the rc8 wheel on TestPyPI is still the 2026-07-18T15:12 build, predating the fix.

No changelog entry — `validate_release.py` skips pre-releases.

Contents vs rc8: #646 only (default-background subagent registration).

Fleet note: this supersedes rc8. Rollout still needs the usual attestation marker via `scripts/run-integration-tests.sh 0.35.4rc9 --manual` before `scripts/fleet-rollout.sh`.