### PR TITLE
fix: post-result lifecycle batch (0.35.4rc10) — #650 silent reap, #647/#646 liveness-aware ceiling + announced handoff, #593 diag enrichment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.4rc9"
+version = "0.35.4rc10"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/untether/runner_bridge.py
+++ b/src/untether/runner_bridge.py
@@ -1004,6 +1004,11 @@ class ProgressEdits:
         self._last_stall_warn_at: float = 0.0
         self._peak_idle: float = 0.0
         self._prev_diag: Any = None
+        # #650/#593: clock() timestamp of the last stall tick that observed
+        # the subprocess alive. Once the process is gone every /proc-derived
+        # liveness field collapses to None, so this is the only way the
+        # cancel-decision logs can say how recently the process existed.
+        self._last_alive_at: float | None = None
         self._stall_check_interval: float = 60.0
         self._stall_repeat_seconds: float = 180.0
         self._prev_recent_events: list[tuple[float, str]] | None = None
@@ -1291,6 +1296,8 @@ class ProgressEdits:
                 else None
             )
             self._prev_diag = diag
+            if diag is not None and diag.alive:
+                self._last_alive_at = self.clock()
 
             # Use longer threshold when waiting for user approval, running a
             # tool, or when child processes are active (Agent subagents).
@@ -1332,6 +1339,43 @@ class ProgressEdits:
                 reason=threshold_reason,
                 elapsed=round(elapsed, 1),
             )
+
+            # #650: a dead subprocess whose run already emitted its final
+            # CompletedEvent is a normally-completed run being reaped late,
+            # not a stalled one — the detector was racing the post-result
+            # subcountdown's 30 s returncode poll and won. Tear the run down
+            # through the same cancel machinery, but silently: no WARN and no
+            # user-facing "session appears stuck (process_dead)" notice.
+            # #614 made user-initiated cancelled-after-delivery the quiet
+            # path; this makes the watchdog-initiated variant actually quiet
+            # too. Downstream, handle.cancelled_after_delivery keeps the
+            # delivered answer untouched.
+            if (
+                diag is not None
+                and diag.alive is False
+                and bool(getattr(self.stream, "did_emit_completed", False))
+            ):
+                logger.info(
+                    "progress_edits.reaped_after_delivery",
+                    channel_id=self.channel_id,
+                    pid=self.pid,
+                    seconds_since_last_event=round(elapsed, 1),
+                    last_event_type=(
+                        self.stream.last_event_type if self.stream else None
+                    ),
+                    last_seen_alive_s=(
+                        round(self.clock() - self._last_alive_at, 1)
+                        if self._last_alive_at is not None
+                        else None
+                    ),
+                    event_seq=self.event_seq,
+                )
+                if self.cancel_event is not None:
+                    self.cancel_event.set()
+                await self._enforce_cancel_teardown()
+                self.signal_send.close()
+                return
+
             now = self.clock()
             if (
                 self._stall_warned
@@ -1478,6 +1522,11 @@ class ProgressEdits:
                     fd_count=diag.fd_count if diag else None,
                     cpu_active=cpu_active,
                     tree_active=tree_active,
+                    last_seen_alive_s=(
+                        round(now - self._last_alive_at, 1)
+                        if self._last_alive_at is not None
+                        else None
+                    ),
                     recent_events=[(round(t, 1), lbl) for t, lbl in recent[-5:]],
                     stderr_hint=stderr_hint,
                     approval_pending=False,
@@ -1556,6 +1605,14 @@ class ProgressEdits:
                     stall_warn_count=self._stall_warn_count,
                     pid=self.pid,
                     event_seq=self.event_seq,
+                    last_event_type=(
+                        self.stream.last_event_type if self.stream else None
+                    ),
+                    last_seen_alive_s=(
+                        round(now - self._last_alive_at, 1)
+                        if self._last_alive_at is not None
+                        else None
+                    ),
                 )
                 if self.cancel_event is not None:
                     self.cancel_event.set()
@@ -3222,6 +3279,22 @@ async def handle_message(
                 session_id=resume_token.value,
                 reason="quarantined",
             )
+            # #647: announce the divert. Without this the fresh session
+            # answers confidently with no context and no signal that
+            # continuity was lost (observed live: "The last session wrapped
+            # cleanly. Which thread should I 'continue'?").
+            with contextlib.suppress(Exception):
+                await cfg.transport.send(
+                    channel_id=incoming.channel_id,
+                    message=RenderedMessage(
+                        text=(
+                            "ℹ️ Starting a fresh session — the previous one "
+                            "ended in a state that can't be resumed safely, "
+                            "so its context isn't carried over."
+                        )
+                    ),
+                    options=SendOptions(thread_id=incoming.thread_id),
+                )
             if on_resume_failed is not None:
                 try:
                     await on_resume_failed(resume_token)
@@ -3244,12 +3317,54 @@ async def handle_message(
         _ac_cfg = _load_auto_continue_settings()
         if getattr(_ac_cfg, "serialize_session_owner", True):
             try:
-                from untether.runners.claude import wait_for_session_handoff
+                from untether.runners.claude import (
+                    session_live_bg_count,
+                    wait_for_session_handoff,
+                )
 
                 _handoff = await wait_for_session_handoff(
                     resume_token.value,
                     getattr(_ac_cfg, "session_handoff_timeout_s", 30.0),
                 )
+                # #647: the base timeout expired while the prior owner is
+                # still alive. If it is alive because it is legitimately
+                # finishing background work (default-background subagents,
+                # #646), don't silently abandon its context — tell the user
+                # why the reply is delayed and keep waiting. Still
+                # condition-based (resolves the instant the owner exits) and
+                # bounded by ``session_handoff_bg_timeout_s``.
+                if _handoff == "timed_out":
+                    _bg_count = session_live_bg_count(resume_token.value)
+                    _bg_budget = float(
+                        getattr(_ac_cfg, "session_handoff_bg_timeout_s", 600.0)
+                    )
+                    if _bg_count > 0 and _bg_budget > 0:
+                        logger.info(
+                            "session.handoff_bg_extended",
+                            engine=runner.engine,
+                            session_id=resume_token.value,
+                            live_bg_count=_bg_count,
+                            bg_timeout_s=_bg_budget,
+                        )
+                        _plural = "s" if _bg_count != 1 else ""
+                        with contextlib.suppress(Exception):
+                            await cfg.transport.send(
+                                channel_id=incoming.channel_id,
+                                message=RenderedMessage(
+                                    text=(
+                                        f"⏳ The previous session is still "
+                                        f"finishing {_bg_count} background "
+                                        f"task{_plural} — waiting up to "
+                                        f"{int(_bg_budget // 60)} min so your "
+                                        f"context carries over. Send /new to "
+                                        f"drop it and start fresh instead."
+                                    )
+                                ),
+                                options=SendOptions(thread_id=incoming.thread_id),
+                            )
+                        _handoff = await wait_for_session_handoff(
+                            resume_token.value, _bg_budget
+                        )
             except Exception:  # noqa: BLE001 — never block message handling
                 # Fail CLOSED. The entire point of this gate is to never resume
                 # a session that might still be owned; treating a broken check
@@ -3266,6 +3381,51 @@ async def handle_message(
                     session_id=resume_token.value,
                     outcome=_handoff,
                 )
+            if _handoff == "exited":
+                # #647: the owner may have exited because the post-result
+                # ceiling SIGTERM'd it and quarantined the session while we
+                # were waiting (the two paths interact — the incident that
+                # reproduced this issue carried reason=quarantined, not
+                # handoff_timeout). Re-check quarantine so the wait's outcome
+                # can't resume a session marked unsafe moments earlier — and
+                # announce the context loss instead of silently answering
+                # from a fresh session.
+                try:
+                    _q_after = (
+                        _qstore.is_quarantined(runner.engine, resume_token.value)
+                        if _qstore is not None
+                        else False
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.debug("session.quarantine_check_failed", exc_info=True)
+                    _q_after = False
+                if _q_after:
+                    logger.warning(
+                        "session.resume_diverted_fresh",
+                        engine=runner.engine,
+                        session_id=resume_token.value,
+                        reason="quarantined_during_handoff",
+                    )
+                    with contextlib.suppress(Exception):
+                        await cfg.transport.send(
+                            channel_id=incoming.channel_id,
+                            message=RenderedMessage(
+                                text=(
+                                    "⚠️ The previous session had to be "
+                                    "terminated while its background tasks "
+                                    "were still running — starting a fresh "
+                                    "session. Its context couldn't be "
+                                    "carried over."
+                                )
+                            ),
+                            options=SendOptions(thread_id=incoming.thread_id),
+                        )
+                    if on_resume_failed is not None:
+                        try:
+                            await on_resume_failed(resume_token)
+                        except Exception:  # noqa: BLE001
+                            logger.debug("session.clear_failed", exc_info=True)
+                    resume_token = None
             if _handoff == "timed_out":
                 # The prior owner is still alive. Start fresh rather than
                 # racing it.
@@ -3285,6 +3445,21 @@ async def handle_message(
                     session_id=resume_token.value,
                     reason="handoff_timeout",
                 )
+                # #647: never divert silently — a confidently contextless
+                # answer with no signal that continuity was lost is the worst
+                # outcome. One line, before the fresh run starts.
+                with contextlib.suppress(Exception):
+                    await cfg.transport.send(
+                        channel_id=incoming.channel_id,
+                        message=RenderedMessage(
+                            text=(
+                                "⚠️ The previous session was still busy after "
+                                "the wait — starting a fresh session. Its "
+                                "context couldn't be carried over."
+                            )
+                        ),
+                        options=SendOptions(thread_id=incoming.thread_id),
+                    )
                 if on_resume_failed is not None:
                     try:
                         await on_resume_failed(resume_token)

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -159,6 +159,13 @@ _ACTIVE_RUNNERS: dict[str, tuple[ClaudeRunner, float]] = {}
 # on the same runner instance (runner._proc_stdin would be overwritten).
 _SESSION_STDIN: dict[str, Any] = {}
 
+# #647: session_id -> live ClaudeStreamState for the owning run. Lets the
+# bridge's handoff wait (`handle_message`) ask "does the still-alive prior
+# owner have live background work?" without reaching into runner internals.
+# Registered alongside _SESSION_STDIN in _iter_jsonl_events; cleared in
+# _cleanup_session_registries (run_impl finally).
+_SESSION_BG_STATE: dict[str, ClaudeStreamState] = {}
+
 # Phase 2: Global registry mapping request_id -> session_id
 # This allows callbacks to find the right runner instance
 _REQUEST_TO_SESSION: dict[str, str] = {}
@@ -225,6 +232,41 @@ def is_session_alive(session_id: str) -> bool:
     return session_id in _SESSION_STDIN
 
 
+def session_live_bg_count(session_id: str) -> int:
+    """Return the number of live background handles held by the still-running
+    subprocess that owns ``session_id``, or 0 when there is no live owner or
+    no live background work.
+
+    #647: consumed by the bridge's handoff branch so a follow-up message that
+    arrives while the prior owner is legitimately finishing background
+    subagents can wait longer (and tell the user why) instead of silently
+    diverting to a fresh contextless session after the base 30 s timeout.
+    """
+    state = _SESSION_BG_STATE.get(session_id)
+    if state is None or not has_live_background_work(state):
+        return 0
+    count = (
+        _live_bg_agent_count(state)
+        + _live_bounded_handle_count(state.live_bg_bashes, state.bg_bash_deadlines)
+        + _live_bounded_handle_count(
+            state.live_remote_triggers, state.remote_trigger_deadlines
+        )
+        + sum(
+            1
+            for deadline in state.live_monitors.values()
+            if deadline == 0.0 or deadline > time.monotonic()
+        )
+        + sum(
+            1
+            for deadline in state.live_wakeups.values()
+            if deadline == 0.0 or deadline > time.monotonic()
+        )
+    )
+    # has_live_background_work() was True, so never report fewer than 1 even
+    # if the individual counts race to zero between the two reads.
+    return max(1, count)
+
+
 SESSION_HANDOFF_POLL_S: float = 0.25
 
 
@@ -262,15 +304,35 @@ async def wait_for_session_handoff(
     """
     if not is_session_alive(session_id):
         return "free"
-    deadline = time.monotonic() + max(0.0, timeout_s)
+    # #647 observability: the wait can absorb minutes of user-perceived
+    # latency (base timeout + background-aware extension), and previously
+    # left no trace in the journal — log entry and exit with elapsed.
+    started_at = time.monotonic()
+    logger.info(
+        "session.handoff_wait",
+        session_id=session_id,
+        timeout_s=timeout_s,
+        live_bg_count=session_live_bg_count(session_id),
+    )
+    deadline = started_at + max(0.0, timeout_s)
+    outcome = "timed_out"
     while time.monotonic() < deadline:
         await anyio.sleep(poll_s)
         if not is_session_alive(session_id):
-            return "exited"
+            outcome = "exited"
+            break
     # Final probe: the loop can overshoot the deadline by up to ``poll_s``, and
     # an owner that exited during that last sleep should be reported as
     # "exited" rather than being penalised for our polling granularity.
-    return "exited" if not is_session_alive(session_id) else "timed_out"
+    if outcome == "timed_out" and not is_session_alive(session_id):
+        outcome = "exited"
+    logger.info(
+        "session.handoff_wait_done",
+        session_id=session_id,
+        outcome=outcome,
+        elapsed_s=round(time.monotonic() - started_at, 1),
+    )
+    return outcome
 
 
 def pending_control_requests_for_session(session_id: str | None) -> int:
@@ -2586,6 +2648,18 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
     # hold the process (and its RSS/TCP) open. Cap the wait at this grace
     # instead. 0 disables the shortcut (full timeout always applies).
     _post_result_limbo_grace_s: float = 60.0
+    # #647/#646: liveness-aware extension of the post-result ceiling. When
+    # the subcountdown deadline expires while the session still has live
+    # background work and the process tree is not demonstrably idle, the
+    # SIGTERM is deferred (re-checked each poll) instead of killing live
+    # subagent work mid-flight — the kill quarantines the session and
+    # produces the fresh-session amnesia (#646/#647). Absolute bound on the
+    # deferral, measured from reader-EOF; background handles independently
+    # age out at BG_AGENT_MAX_KEEP_S. 0 disables the extension.
+    _post_result_bg_max_hold_s: float = 1800.0
+    # #650: cadence of the ``subcountdown_tick`` observability line. Class
+    # attr so tests can shrink it; production logs every ~30 s.
+    _subcountdown_tick_log_interval_s: float = 30.0
     # Floor for the post-result watchdog poll cadence (class attr so tests
     # can shrink it; production keeps the 5s floor).
     _watchdog_min_poll_s: float = 5.0
@@ -3005,6 +3079,10 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 ):
                     registered_session_id = evt.resume.value
                     _SESSION_STDIN[registered_session_id] = session_stdin
+                    # #647: expose this run's background-handle state to the
+                    # bridge's handoff wait. Cleared with the other
+                    # registries in _cleanup_session_registries.
+                    _SESSION_BG_STATE[registered_session_id] = state
                     logger.info(
                         "session_stdin.registered",
                         session_id=registered_session_id,
@@ -3279,6 +3357,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         stream: Any = None,
         limbo_grace_s: float | None = None,
         pre_result_silence_timeout_s: float = 3600.0,
+        bg_max_hold_s: float | None = None,
     ) -> None:
         """Close stdin once the bidirectional CLI has been idle past the result.
 
@@ -3357,6 +3436,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                         stream=stream,
                         session_id=sid_now,
                         limbo_grace_s=limbo_grace_s,
+                        bg_max_hold_s=bg_max_hold_s,
                     )
                     return
                 exit_reason = "reader_done"
@@ -3390,6 +3470,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                                 stream=stream,
                                 session_id=sid_now,
                                 limbo_grace_s=limbo_grace_s,
+                                bg_max_hold_s=bg_max_hold_s,
                             )
                             return
                         exit_reason = "reader_done"
@@ -3597,6 +3678,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         stream: Any = None,
         session_id: str | None = None,
         limbo_grace_s: float | None = None,
+        bg_max_hold_s: float | None = None,
     ) -> str:
         """Watch a stdout-closed-but-process-alive subprocess (#333 Tier 1).
 
@@ -3611,8 +3693,27 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
         alive and no real pending state references the session, emit
         ``runner.limbo_detected`` warning. ``untether-issue-watcher``
         picks this up automatically.
+
+        #647/#646: the deadline is liveness-aware — when it expires while the
+        session still has live background work (upstream runs subagents in
+        the background by default since Claude Code v2.1.198, and their
+        completion is NOT signalled on stream-json) and the process tree is
+        not demonstrably idle, the SIGTERM is deferred and re-checked each
+        poll, bounded by ``bg_max_hold_s``. Killing live subagent work
+        quarantines the session (#632) and produces fresh-session amnesia.
+
+        #650: every ~30 s of the countdown emits a
+        ``claude.post_result_idle.subcountdown_tick`` INFO — previously the
+        loop logged nothing between the one-shot ``limbo_detected`` and its
+        exit, a blackout window in which the bridge's independent stall
+        detector raced this loop's returncode poll and mislabelled a normal
+        post-result exit as ``process_dead``.
         """
-        from ..utils.proc_diag import collect_proc_diag
+        from ..utils.proc_diag import (
+            collect_proc_diag,
+            is_cpu_active,
+            is_tree_cpu_active,
+        )
 
         reader_done_at = time.monotonic()
         run_logger.info(
@@ -3658,6 +3759,14 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             else self._post_result_limbo_grace_s
         )
         grace_deadline = reader_done_at + grace if grace > 0 else None
+        bg_hold = (
+            bg_max_hold_s
+            if bg_max_hold_s is not None
+            else self._post_result_bg_max_hold_s
+        )
+        prev_diag = None
+        ceiling_extended_logged = False
+        last_tick_log_at = reader_done_at
         while True:
             await anyio.sleep(self._subcountdown_poll_interval_s)
             if proc.returncode is not None:
@@ -3701,6 +3810,17 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 continue
 
             elapsed = time.monotonic() - reader_done_at
+            # #650: per-poll liveness snapshot — feeds the limbo warning, the
+            # ~30 s ``subcountdown_tick`` observability line, and the
+            # #647/#646 liveness-aware ceiling below.
+            diag = collect_proc_diag(proc.pid)
+            cpu_active = is_cpu_active(prev_diag, diag) if prev_diag and diag else None
+            tree_active = (
+                is_tree_cpu_active(prev_diag, diag) if prev_diag and diag else None
+            )
+            prev_diag = diag
+            live_bg = has_live_background_work(state)
+
             # Tier 3: limbo detection — a one-shot warning surfacing the
             # condition for triage. ``untether-issue-watcher`` files this
             # automatically on the next sweep.
@@ -3709,7 +3829,6 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 and elapsed >= self._subcountdown_limbo_detect_threshold_s
             ):
                 limbo_logged = True
-                diag = collect_proc_diag(proc.pid)
                 # #590: refresh the orphan snapshot — children spawned AFTER
                 # the reader-done snapshot (the sl "late leaker" shape) are
                 # captured here so the post-exit sweep can reach them. Use the
@@ -3748,15 +3867,67 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             # were handled above via the re-arm branch).
             effective_deadline = deadline
             limbo_grace_applied = False
-            if (
-                grace_deadline is not None
-                and grace_deadline < deadline
-                and not has_live_background_work(state)
-            ):
+            if grace_deadline is not None and grace_deadline < deadline and not live_bg:
                 effective_deadline = grace_deadline
                 limbo_grace_applied = True
 
+            # #650 (defect 3): per-tick observability, throttled to ~30 s.
+            # Previously nothing logged between the one-shot limbo warning
+            # and the loop's exit — a blackout in which the bridge's stall
+            # detector raced this loop's returncode poll and won.
+            now_mono = time.monotonic()
+            if now_mono - last_tick_log_at >= self._subcountdown_tick_log_interval_s:
+                last_tick_log_at = now_mono
+                run_logger.info(
+                    "claude.post_result_idle.subcountdown_tick",
+                    session_id=sid,
+                    pid=proc.pid,
+                    elapsed_s=round(elapsed, 1),
+                    in_limbo=limbo_logged,
+                    live_background_work=live_bg,
+                    cpu_active=cpu_active,
+                    tree_active=tree_active,
+                    child_count=len(diag.child_pids) if diag else None,
+                    rss_kb=diag.rss_kb if diag else None,
+                    deadline_remaining_s=round(effective_deadline - now_mono, 1),
+                )
+
             if time.monotonic() >= effective_deadline:
+                # #647/#646: liveness-aware ceiling. Upstream runs subagents
+                # in the background by default (Claude Code ≥2.1.198) and
+                # never signals their completion on stream-json, so the only
+                # evidence is /proc. If background handles are still live and
+                # the process tree is not demonstrably idle, defer the
+                # SIGTERM — killing live subagent work quarantines the
+                # session (#632) and produces fresh-session amnesia. Bounded
+                # twice over: handles age out at BG_AGENT_MAX_KEEP_S, and the
+                # hold never exceeds ``bg_hold`` seconds past reader-EOF.
+                demonstrably_idle = (
+                    diag is not None
+                    and diag.alive
+                    and cpu_active is False
+                    and tree_active is False
+                )
+                if (
+                    bg_hold > 0
+                    and elapsed < bg_hold
+                    and live_bg
+                    and not demonstrably_idle
+                ):
+                    if not ceiling_extended_logged:
+                        ceiling_extended_logged = True
+                        run_logger.info(
+                            "claude.post_result_idle.ceiling_extended",
+                            session_id=sid,
+                            pid=proc.pid,
+                            elapsed_s=round(elapsed, 1),
+                            timeout_s=timeout_s,
+                            bg_max_hold_s=bg_hold,
+                            cpu_active=cpu_active,
+                            tree_active=tree_active,
+                            child_count=len(diag.child_pids) if diag else None,
+                        )
+                    continue
                 # #632 (W2): the process already emitted a valid result but
                 # is being force-killed while lingering (MCP children / hung
                 # background work) — its last upstream turn may be left
@@ -3794,6 +3965,14 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                     limbo_grace_applied=limbo_grace_applied,
                     limbo_grace_s=grace if limbo_grace_applied else None,
                     quarantined=quarantined,
+                    # #647: "background work was correctly tracked and killed
+                    # anyway" is identified by live_background_work=True here,
+                    # regardless of which resume-divert label lands later.
+                    live_background_work=live_bg,
+                    bg_hold_extended=ceiling_extended_logged,
+                    bg_max_hold_s=bg_hold,
+                    cpu_active=cpu_active,
+                    tree_active=tree_active,
                 )
                 if stream is not None:
                     self._transition_lifecycle(
@@ -4124,6 +4303,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 post_result_idle_timeout_s = 600.0
                 post_result_limbo_grace_s = self._post_result_limbo_grace_s
                 pre_result_silence_timeout_s = 3600.0
+                post_result_bg_max_hold_s = self._post_result_bg_max_hold_s
                 try:
                     result = load_settings_if_exists()
                     if result is not None:
@@ -4139,6 +4319,9 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                         )
                         pre_result_silence_timeout_s = float(
                             settings_obj.watchdog.pre_result_silence_timeout
+                        )
+                        post_result_bg_max_hold_s = float(
+                            settings_obj.watchdog.post_result_bg_max_hold
                         )
                 except Exception:  # noqa: BLE001 — settings errors must not block a run
                     run_logger.debug(
@@ -4177,6 +4360,7 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                             stream,
                             post_result_limbo_grace_s,
                             pre_result_silence_timeout_s,
+                            post_result_bg_max_hold_s,
                         )
                     async for evt in self._iter_jsonl_events(
                         stdout=proc.stdout,
@@ -4484,6 +4668,8 @@ def _cleanup_session_registries(session_id: str) -> None:
         cleaned.append("active_runners")
     if _SESSION_STDIN.pop(session_id, None) is not None:
         cleaned.append("session_stdin")
+    if _SESSION_BG_STATE.pop(session_id, None) is not None:
+        cleaned.append("session_bg_state")
     if session_id in _DISCUSS_COOLDOWN:
         cleaned.append("discuss_cooldown")
     clear_discuss_cooldown(session_id)

--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -375,6 +375,16 @@ class AutoContinueSettings(BaseModel):
     # prior subprocess exits — this is only the give-up point. Kept comfortably
     # above the post-result SIGTERM grace so a normal teardown wins the race.
     session_handoff_timeout_s: float = Field(default=30.0, ge=0.0, le=300.0)
+    # #647: extra wait budget when the base timeout expires while the prior
+    # owner still has LIVE background work (default-background subagents,
+    # #646). This is the realistic flow — the agent says "I'll report back
+    # when the subagents finish" and the user immediately asks for a progress
+    # report. Silently diverting to a fresh session loses all context; instead
+    # Untether tells the user it's waiting for the background work and keeps
+    # waiting up to this budget (still condition-based — resolves the instant
+    # the owner exits). On expiry the divert still happens but is announced
+    # rather than silent. 0 disables the extended wait. Range 0-30min.
+    session_handoff_bg_timeout_s: float = Field(default=600.0, ge=0.0, le=1800.0)
 
 
 class WatchdogSettings(BaseModel):
@@ -496,6 +506,19 @@ class WatchdogSettings(BaseModel):
     # instead of the full post_result_idle_timeout so the process (and its
     # RSS/TCP) is released promptly. 0 disables the shortcut. Range 0-600s.
     post_result_limbo_grace: float = Field(default=60.0, ge=0, le=600)
+
+    # #647/#646: liveness-aware extension of the post-result ceiling. Upstream
+    # runs Agent/Task subagents in the background by default (Claude Code
+    # ≥2.1.198) and their completion is never signalled on stream-json, so a
+    # fixed `post_result_idle_timeout` SIGTERMs live subagent work mid-flight —
+    # which quarantines the session (#632) and diverts the user's next message
+    # to a fresh contextless session. When the ceiling expires while background
+    # handles are still live and the process tree is not demonstrably idle
+    # (/proc CPU evidence), the SIGTERM is deferred and re-checked each poll.
+    # Bounded: background handles age out at 900 s from registration, and the
+    # total post-result hold never exceeds this cap. 0 disables the extension
+    # (pre-rc10 fixed-cap behaviour). Range 0-2h.
+    post_result_bg_max_hold: float = Field(default=1800.0, ge=0, le=7200)
 
     # #481: grace window for fresh Bash/BashOutput tool calls. When the most
     # recent action is Bash/BashOutput/KillShell and its age is less than

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -5217,7 +5217,6 @@ async def test_590_limbo_refreshes_orphan_snapshot(monkeypatch) -> None:
     RECURSIVE descendant walk (find_descendants) so late-spawned MCP leakers —
     including npx→node grandchildren, which diag.child_pids (direct children
     only) missed — are visible to the post-exit sweep."""
-    from types import SimpleNamespace
 
     import anyio
 
@@ -5243,10 +5242,15 @@ async def test_590_limbo_refreshes_orphan_snapshot(monkeypatch) -> None:
 
     proc = _FakeProc(pid=62424, returncode=None)
     # collect_proc_diag drives only the diagnostic log line now; the snapshot
-    # comes from the recursive find_descendants walk.
+    # comes from the recursive find_descendants walk. A real ProcessDiag is
+    # required since the #650 subcountdown tick feeds it to is_cpu_active.
+    from untether.utils.proc_diag import ProcessDiag
+
     monkeypatch.setattr(
         "untether.utils.proc_diag.collect_proc_diag",
-        lambda pid: SimpleNamespace(child_pids=[901], rss_kb=1000, tcp_total=3),
+        lambda pid: ProcessDiag(
+            pid=pid, alive=True, child_pids=[901], rss_kb=1000, tcp_total=3
+        ),
     )
     monkeypatch.setattr(
         "untether.utils.proc_diag.find_descendants",
@@ -5594,3 +5598,261 @@ def test_capture_orphan_descendants_swallows_oserror(monkeypatch) -> None:
     state.pid = 40002
     claude_runner._capture_orphan_descendants(state, source="result")
     assert state.orphan_pid_snapshot == []
+
+
+# ---------------------------------------------------------------------------
+# #647/#646 — liveness-aware post-result ceiling
+# ---------------------------------------------------------------------------
+
+
+def _bg_diag(pid: int):
+    """ProcessDiag stand-in: alive, has children, CPU data indeterminate —
+    the deterministic 'not demonstrably idle' shape for ceiling tests."""
+    from untether.utils.proc_diag import ProcessDiag
+
+    return ProcessDiag(pid=pid, alive=True, child_pids=[1234], rss_kb=1000)
+
+
+@pytest.mark.anyio
+async def test_647_subcountdown_extends_ceiling_while_bg_work_live(
+    monkeypatch,
+) -> None:
+    """Live background subagents defer the post-result SIGTERM past the fixed
+    deadline; the kill fires only once the background work is gone."""
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.02
+    runner._subcountdown_limbo_detect_threshold_s = 0.05
+    runner._subcountdown_sigterm_grace_s = 0.1
+    runner._subcountdown_sigterm_grace_poll_s = 0.02
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="bg-hold-sess-1"))
+    state.result_received_at = time.monotonic() - 0.5
+    # A live default-background Agent handle (#646 workload class).
+    state.live_bg_agents.add("toolu_bg_agent")
+    state.bg_agent_deadlines["toolu_bg_agent"] = time.monotonic() + 3600.0
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=54241, returncode=None)
+    killed_signals: list[int] = []
+
+    def _fake_killpg(pgid: int, sig: int) -> None:
+        killed_signals.append(sig)
+        proc.returncode = -15
+
+    monkeypatch.setattr("os.killpg", _fake_killpg)
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
+    monkeypatch.setattr("untether.utils.proc_diag.collect_proc_diag", _bg_diag)
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            0.1,  # timeout_s — the fixed deadline expires almost immediately
+            proc,
+            stream,
+            0.0,  # limbo_grace_s disabled — full deadline applies
+            3600.0,
+            30.0,  # bg_max_hold_s — generous, far beyond the test's patience
+        )
+        # Let several deadline evaluations pass with live background work.
+        await anyio.sleep(0.4)
+        assert killed_signals == [], (
+            "SIGTERM must be deferred while background work is live"
+        )
+        assert any(
+            e == "claude.post_result_idle.ceiling_extended"
+            for _, e, _ in logger.records
+        )
+        # Background work finishes — the next deadline check must fire.
+        state.live_bg_agents.clear()
+        state.bg_agent_deadlines.clear()
+        with anyio.move_on_after(3.0):
+            while signal.SIGTERM not in killed_signals:
+                await anyio.sleep(0.02)
+        tg.cancel_scope.cancel()
+
+    assert signal.SIGTERM in killed_signals, (
+        "SIGTERM should fire once background work is gone"
+    )
+
+
+@pytest.mark.anyio
+async def test_647_subcountdown_bg_hold_cap_bounds_extension(monkeypatch) -> None:
+    """The liveness-aware extension is bounded: past ``bg_max_hold_s`` the
+    SIGTERM fires even with live background work, and the log carries the
+    ``live_background_work=True`` marker #647 monitoring keys on."""
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.02
+    runner._subcountdown_limbo_detect_threshold_s = 0.05
+    runner._subcountdown_sigterm_grace_s = 0.1
+    runner._subcountdown_sigterm_grace_poll_s = 0.02
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="bg-hold-sess-2"))
+    state.result_received_at = time.monotonic() - 0.5
+    state.live_bg_agents.add("toolu_bg_agent")
+    state.bg_agent_deadlines["toolu_bg_agent"] = time.monotonic() + 3600.0
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=54242, returncode=None)
+    killed_signals: list[int] = []
+
+    def _fake_killpg(pgid: int, sig: int) -> None:
+        killed_signals.append(sig)
+        proc.returncode = -15
+
+    monkeypatch.setattr("os.killpg", _fake_killpg)
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
+    monkeypatch.setattr("untether.utils.proc_diag.collect_proc_diag", _bg_diag)
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            0.05,  # timeout_s
+            proc,
+            stream,
+            0.0,  # limbo_grace_s disabled
+            3600.0,
+            0.08,  # bg_max_hold_s — cap expires almost immediately
+        )
+        with anyio.move_on_after(3.0):
+            while signal.SIGTERM not in killed_signals:
+                await anyio.sleep(0.02)
+        tg.cancel_scope.cancel()
+
+    assert signal.SIGTERM in killed_signals, "cap must bound the extension"
+    sigterm_logs = [
+        kw
+        for _, e, kw in logger.records
+        if e == "claude.post_result_idle.sigterm_after_timeout"
+    ]
+    assert sigterm_logs and sigterm_logs[0].get("live_background_work") is True
+
+
+@pytest.mark.anyio
+async def test_650_subcountdown_ticks_are_logged(monkeypatch) -> None:
+    """#650 defect (3): the subcountdown loop must emit periodic
+    ``subcountdown_tick`` lines — previously it logged nothing between the
+    one-shot limbo warning and its exit, and the bridge's stall detector won
+    the race inside that blackout."""
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.02
+    runner._subcountdown_limbo_detect_threshold_s = 0.05
+    runner._subcountdown_tick_log_interval_s = 0.01
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="tick-sess-1"))
+    state.result_received_at = time.monotonic() - 0.5
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=54243, returncode=None)
+    monkeypatch.setattr("untether.utils.proc_diag.collect_proc_diag", _bg_diag)
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            30.0,  # far beyond the test window — the loop just idles
+            proc,
+            stream,
+            0.0,  # limbo_grace_s disabled so nothing fires
+            3600.0,
+        )
+        await anyio.sleep(0.3)
+        tg.cancel_scope.cancel()
+
+    ticks = [
+        kw
+        for _, e, kw in logger.records
+        if e == "claude.post_result_idle.subcountdown_tick"
+    ]
+    assert len(ticks) >= 2, "expected periodic subcountdown ticks"
+    # Once past the limbo threshold the ticks must keep coming and say so.
+    assert any(kw.get("in_limbo") is True for kw in ticks)
+
+
+def test_647_session_live_bg_count_reads_registry() -> None:
+    """The bridge-facing helper reports live background handles for a
+    registered session and 0 for unknown/idle sessions."""
+    from untether.runners.claude import (
+        _SESSION_BG_STATE,
+        session_live_bg_count,
+    )
+
+    state = ClaudeStreamState()
+    state.live_bg_agents.add("toolu_1")
+    state.bg_agent_deadlines["toolu_1"] = time.monotonic() + 3600.0
+    _SESSION_BG_STATE["bg-count-sess"] = state
+    try:
+        assert session_live_bg_count("bg-count-sess") == 1
+        assert session_live_bg_count("missing-sess") == 0
+        # Aged-out handle no longer counts.
+        state.bg_agent_deadlines["toolu_1"] = time.monotonic() - 1.0
+        assert session_live_bg_count("bg-count-sess") == 0
+    finally:
+        _SESSION_BG_STATE.pop("bg-count-sess", None)

--- a/tests/test_exec_bridge.py
+++ b/tests/test_exec_bridge.py
@@ -7950,3 +7950,321 @@ async def test_633_gate_does_not_stall_a_just_exited_session() -> None:
 
     assert outcome == "free"
     assert elapsed < 0.5, f"gate stalled {elapsed:.2f}s on a non-live session"
+
+
+# ---------------------------------------------------------------------------
+# #650 — process_dead auto-cancel must not alarm after a delivered result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_650_process_dead_after_delivery_reaps_silently() -> None:
+    """A dead subprocess whose run already emitted CompletedEvent is a
+    normally-completed run being reaped late: cancel machinery still runs,
+    but no WARN and no user-facing 'session appears stuck' notice."""
+    from unittest.mock import patch
+
+    from untether.runner import JsonlStreamState
+    from untether.utils.proc_diag import ProcessDiag
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits.pid = 99999
+    stream = JsonlStreamState(expected_session=None)
+    stream.did_emit_completed = True
+    stream.last_event_type = "result"
+    stream.proc_returncode = 0
+    edits.stream = stream
+    cancel_event = anyio.Event()
+    edits.cancel_event = cancel_event
+
+    dead_diag = ProcessDiag(pid=99999, alive=False)
+    with (
+        patch("untether.utils.proc_diag.collect_proc_diag", return_value=dead_diag),
+        structlog.testing.capture_logs() as logs,
+    ):
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                clock.set(100.1)
+                await anyio.sleep(0.1)
+                if not cancel_event.is_set():
+                    edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    assert cancel_event.is_set(), "the run must still be torn down"
+    assert not [
+        c for c in transport.send_calls if "Auto-cancelled" in c["message"].text
+    ], "no user-facing alarm after a delivered result"
+    assert any(r.get("event") == "progress_edits.reaped_after_delivery" for r in logs)
+    assert not any(r.get("event") == "progress_edits.stall_auto_cancel" for r in logs)
+
+
+@pytest.mark.anyio
+async def test_650_process_dead_without_delivery_still_alarms() -> None:
+    """Regression guard for the gate's direction: a dead process on a run
+    that never emitted CompletedEvent is a genuine crash — the alarm stays."""
+    from unittest.mock import patch
+
+    from untether.runner import JsonlStreamState
+    from untether.utils.proc_diag import ProcessDiag
+
+    transport = FakeTransport()
+    presenter = _KeyboardPresenter()
+    clock = _FakeClock(start=100.0)
+    edits = _make_edits(transport, presenter, clock=clock)
+    edits._stall_check_interval = 0.01
+    edits._STALL_THRESHOLD_SECONDS = 0.05
+    edits.pid = 99999
+    stream = JsonlStreamState(expected_session=None)
+    stream.did_emit_completed = False
+    edits.stream = stream
+    cancel_event = anyio.Event()
+    edits.cancel_event = cancel_event
+
+    dead_diag = ProcessDiag(pid=99999, alive=False)
+    with patch("untether.utils.proc_diag.collect_proc_diag", return_value=dead_diag):
+        async with anyio.create_task_group() as tg:
+
+            async def drive() -> None:
+                clock.set(100.1)
+                await anyio.sleep(0.1)
+                if not cancel_event.is_set():
+                    edits.signal_send.close()
+
+            tg.start_soon(edits.run)
+            tg.start_soon(drive)
+
+    assert cancel_event.is_set()
+    auto_cancel_msgs = [
+        c for c in transport.send_calls if "Auto-cancelled" in c["message"].text
+    ]
+    assert len(auto_cancel_msgs) == 1
+    assert "process_dead" in auto_cancel_msgs[0]["message"].text
+
+
+# ---------------------------------------------------------------------------
+# #647 — handoff during live background work: no silent contextless divert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_647_handoff_bg_extended_wait_then_resume(
+    quarantine_store, monkeypatch
+) -> None:
+    """Base timeout expires while the owner is finishing background work: the
+    user is told why, the wait extends, and when the owner exits the resume
+    proceeds with context intact."""
+    from structlog.testing import capture_logs
+
+    from untether.runners import claude as claude_mod
+
+    waits: list[float] = []
+
+    async def _timed_out_then_exited(session_id, timeout_s, *, poll_s=0.25):
+        waits.append(timeout_s)
+        return "timed_out" if len(waits) == 1 else "exited"
+
+    monkeypatch.setattr(claude_mod, "wait_for_session_handoff", _timed_out_then_exited)
+    monkeypatch.setattr(claude_mod, "session_live_bg_count", lambda sid: 2)
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CLAUDE_ENGINE, resume_value="sid-bg", answer="resumed answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+
+    with capture_logs() as logs:
+        await handle_message(
+            cfg,
+            runner=runner,
+            incoming=IncomingMessage(channel_id=123, message_id=20, text="progress?"),
+            resume_token=ResumeToken(engine=CLAUDE_ENGINE, value="sid-bg"),
+        )
+
+    # Two waits: base then background-extended.
+    assert len(waits) == 2
+    # Resume proceeded with the ORIGINAL session — no amnesia.
+    assert len(runner.calls) == 1
+    assert runner.calls[0][1] is not None
+    assert runner.calls[0][1].value == "sid-bg"
+    # The user was told about the wait.
+    wait_notices = [
+        c for c in transport.send_calls if "background task" in c["message"].text
+    ]
+    assert len(wait_notices) == 1
+    assert any(r.get("event") == "session.handoff_bg_extended" for r in logs)
+
+
+@pytest.mark.anyio
+async def test_647_handoff_bg_wait_exhausted_diverts_with_notice(
+    quarantine_store, monkeypatch
+) -> None:
+    """Both waits expire: divert fresh as before, but ANNOUNCE the context
+    loss instead of answering contextlessly in silence."""
+    from untether.runners import claude as claude_mod
+
+    async def _always_stuck(session_id, timeout_s, *, poll_s=0.25):
+        return "timed_out"
+
+    monkeypatch.setattr(claude_mod, "wait_for_session_handoff", _always_stuck)
+    monkeypatch.setattr(claude_mod, "session_live_bg_count", lambda sid: 3)
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CLAUDE_ENGINE, resume_value="sid-fresh2", answer="fresh answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=21, text="progress?"),
+        resume_token=ResumeToken(engine=CLAUDE_ENGINE, value="sid-busy"),
+    )
+
+    assert len(runner.calls) == 1
+    assert runner.calls[0][1] is None
+    divert_notices = [
+        c
+        for c in transport.send_calls
+        if "starting a fresh session" in c["message"].text.lower()
+    ]
+    assert len(divert_notices) == 1
+
+
+@pytest.mark.anyio
+async def test_647_handoff_timeout_without_bg_diverts_with_notice(
+    quarantine_store, monkeypatch
+) -> None:
+    """No live background work: the base timeout diverts immediately (no
+    extended wait), but the divert is still announced."""
+    from untether.runners import claude as claude_mod
+
+    waits: list[float] = []
+
+    async def _always_stuck(session_id, timeout_s, *, poll_s=0.25):
+        waits.append(timeout_s)
+        return "timed_out"
+
+    monkeypatch.setattr(claude_mod, "wait_for_session_handoff", _always_stuck)
+    monkeypatch.setattr(claude_mod, "session_live_bg_count", lambda sid: 0)
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CLAUDE_ENGINE, resume_value="sid-fresh3", answer="fresh answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=22, text="hi"),
+        resume_token=ResumeToken(engine=CLAUDE_ENGINE, value="sid-busy2"),
+    )
+
+    assert len(waits) == 1, "no extended wait without live background work"
+    assert len(runner.calls) == 1
+    assert runner.calls[0][1] is None
+    assert [
+        c
+        for c in transport.send_calls
+        if "starting a fresh session" in c["message"].text.lower()
+    ]
+
+
+@pytest.mark.anyio
+async def test_647_quarantined_during_handoff_diverts_with_notice(
+    quarantine_store, monkeypatch
+) -> None:
+    """The post-result ceiling can SIGTERM + quarantine the owner while the
+    handoff wait is in flight (the rc9 incident carried reason=quarantined).
+    The 'exited' outcome must re-check quarantine and announce the divert."""
+    from structlog.testing import capture_logs
+
+    from untether.runners import claude as claude_mod
+
+    async def _quarantines_then_exits(session_id, timeout_s, *, poll_s=0.25):
+        quarantine_store.quarantine(
+            CLAUDE_ENGINE, session_id, reason="forced_teardown_after_result"
+        )
+        return "exited"
+
+    monkeypatch.setattr(claude_mod, "wait_for_session_handoff", _quarantines_then_exits)
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CLAUDE_ENGINE, resume_value="sid-fresh4", answer="fresh answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+    cleared: list[str] = []
+
+    async def on_resume_failed(tok: ResumeToken) -> None:
+        cleared.append(tok.value)
+
+    with capture_logs() as logs:
+        await handle_message(
+            cfg,
+            runner=runner,
+            incoming=IncomingMessage(channel_id=123, message_id=23, text="continue"),
+            resume_token=ResumeToken(engine=CLAUDE_ENGINE, value="sid-mid-q"),
+            on_resume_failed=on_resume_failed,
+        )
+
+    assert len(runner.calls) == 1
+    assert runner.calls[0][1] is None, "must not resume a just-quarantined session"
+    assert "sid-mid-q" in cleared
+    assert any(
+        r.get("event") == "session.resume_diverted_fresh"
+        and r.get("reason") == "quarantined_during_handoff"
+        for r in logs
+    )
+    assert [
+        c
+        for c in transport.send_calls
+        if "starting a fresh session" in c["message"].text.lower()
+    ]
+
+
+@pytest.mark.anyio
+async def test_647_quarantine_divert_announces_to_user(quarantine_store) -> None:
+    """The pre-existing entry-time quarantine divert (reason=quarantined) is
+    no longer silent: the user is told context isn't carried over."""
+    quarantine_store.quarantine(
+        CODEX_ENGINE, "sess-known-poisoned", reason="forced_teardown_after_result"
+    )
+
+    transport = FakeTransport()
+    runner = _RecordingRunner(
+        engine=CODEX_ENGINE, resume_value="sid-fresh5", answer="fresh answer"
+    )
+    cfg = ExecBridgeConfig(
+        transport=transport, presenter=MarkdownPresenter(), final_notify=False
+    )
+
+    await handle_message(
+        cfg,
+        runner=runner,
+        incoming=IncomingMessage(channel_id=123, message_id=24, text="continue"),
+        resume_token=ResumeToken(engine=CODEX_ENGINE, value="sess-known-poisoned"),
+    )
+
+    assert len(runner.calls) == 1
+    assert runner.calls[0][1] is None
+    assert [
+        c for c in transport.send_calls if "fresh session" in c["message"].text.lower()
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.4rc9"
+version = "0.35.4rc10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes the post-result lifecycle cluster from the `20260719T022605Z` fleet audit: [#650](https://github.com/littlebearapps/untether/issues/650), [#647](https://github.com/littlebearapps/untether/issues/647), the unresolved outcome half of [#646](https://github.com/littlebearapps/untether/issues/646), and the remaining diagnostics gap of [#593](https://github.com/littlebearapps/untether/issues/593). Bumps to `0.35.4rc10`.

### #650 — watchdog auto-cancel alarmed the user after a successful delivery
- The `process_dead` auto-cancel arm in `ProgressEdits` now checks `stream.did_emit_completed` first. A dead subprocess whose run already emitted its CompletedEvent is a normally-completed run being reaped late (the bridge stall detector was racing the subcountdown's returncode poll) — it is now reaped through the same cancel machinery but **silently**: INFO `progress_edits.reaped_after_delivery`, no WARN, no user-facing *"Auto-cancelled: session appears stuck (process_dead)"*. #614 made the user-initiated cancelled-after-delivery path quiet; this makes the watchdog-initiated variant actually quiet.
- Defect (3) observability blackout: the subcountdown now emits `claude.post_result_idle.subcountdown_tick` every ~30s (elapsed, returncode, live bg work, cpu/tree activity, children, deadline remaining).

### #647 / #646-outcome — fixed 600s ceiling killed live subagent work
- Upstream runs Agent/Task subagents **in the background by default since Claude Code v2.1.198** and never signals their completion on stream-json (verified against the upstream changelog + Agent SDK docs), so /proc is the only evidence. The subcountdown deadline is now **liveness-aware**: while `has_live_background_work()` is true and the process tree is not demonstrably idle (CPU tick evidence), the SIGTERM is deferred and re-checked each poll. Bounded twice: bg handles age out at `BG_AGENT_MAX_KEEP_S` (900s) and the hold never exceeds new `watchdog.post_result_bg_max_hold` (default 1800s, 0 disables).
- `sigterm_after_timeout` now logs `live_background_work` / `bg_hold_extended` / `cpu_active` / `tree_active` — identifying the "tracked and killed anyway" cohort regardless of which resume-divert label lands (the audit's monitoring correction).

### #647 — no more silent fresh-session amnesia
- `wait_for_session_handoff` logs entry/exit (`session.handoff_wait` / `handoff_wait_done`) — the wait could previously absorb minutes with no journal trace.
- When the base 30s handoff wait times out and the owner has **live background work** (new `_SESSION_BG_STATE` registry + `session_live_bg_count()`), the user is told why the reply is delayed and the wait extends, bounded by new `auto_continue.session_handoff_bg_timeout_s` (default 600s).
- Every fresh-session divert is now **announced** to the user: `handoff_timeout`, entry-time `quarantined`, and the new `quarantined_during_handoff` re-check (the rc9 incident proved the ceiling can quarantine the owner while a wait is in flight; resuming it would poison the next turn).

### #593 — cancel decisions no longer diagnostically blind
- `last_seen_alive_s` tracked per stall tick and attached to `stall_detected` / `stall_auto_cancel`. (The pid-threading and teardown-enforcement halves were verified already fixed by #607 — the rc9 "still present" monitor comment was a misread: the incident's log carried `pid=390637`; the `None` fields were a consequence of the process already being gone.)

## Tests
- 11 new unit tests: ceiling extension + cap, subcountdown ticks, registry helper, process_dead delivery gate (both directions), 5 handoff-policy tests.
- Full suite: **2977 passed**; 1 failure is the known order-dependent `test_run_main_loop_persists_topic_sessions_in_project_scope` (#641), passes in isolation, identical on clean base.
- Live on `@untether_dev_bot` (session `cdee5077…`): 2 background Explore subagents held past the old 60s grace, natural exit rc=0, queued follow-up resumed the **same session** with codeword + findings recall; `subcountdown_tick` observability confirmed live with `cpu_active=True`. Long-hold test past the 600s ceiling in progress — results will be posted on the issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)