### PR TITLE
fix(fleet): add --refresh to uv tool install in fleet-rollout.sh

### DIFF
--- a/scripts/fleet-rollout.sh
+++ b/scripts/fleet-rollout.sh
@@ -277,7 +277,7 @@ build_install_cmd() {
     local host="$1" mgr="$2"
     case "$mgr" in
         uv)
-            INSTALL_CMD[$host]="ssh ${host} 'PATH=${REMOTE_PATH} uv tool install --force ${UV_INDEX_ARGS} ${PACKAGE}==${VERSION}'"
+            INSTALL_CMD[$host]="ssh ${host} 'PATH=${REMOTE_PATH} uv tool install --force --refresh ${UV_INDEX_ARGS} ${PACKAGE}==${VERSION}'"
             ;;
         pipx)
             INSTALL_CMD[$host]="ssh ${host} 'PATH=${REMOTE_PATH} pipx install --force --pip-args=\"${PIP_ARGS}\" ${PACKAGE}==${VERSION}'"


### PR DESCRIPTION
uv's local HTTP cache serves a stale copy of the TestPyPI simple index, so uv-managed hosts (sl, mac) fail with `no version of untether==X` for minutes after a publish — hit at rc6 (manual workaround) and again at the rc10 roll today (both uv hosts FAILED while all pipx hosts landed). `--refresh` forces revalidation of cached index metadata on each invocation.

Script-only change — no wheel impact, no version bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)