### PR TITLE
fix: post-result UX batch (0.35.4rc11) — #655 busy-aware limbo grace, #653 limbo_detected level, #654 queued-wait notice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.4rc10"
+version = "0.35.4rc11"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/src/untether/runners/claude.py
+++ b/src/untether/runners/claude.py
@@ -267,6 +267,25 @@ def session_live_bg_count(session_id: str) -> int:
     return max(1, count)
 
 
+def session_linger_info(session_id: str) -> tuple[bool, int] | None:
+    """Return ``(post_result, live_bg_count)`` for the still-running
+    subprocess that owns ``session_id``, or ``None`` when there is no live
+    owner.
+
+    #654: consumed by the Telegram loop's queued-progress path. A follow-up
+    that arrives while the prior owner lingers post-result (finishing
+    background work) queues silently behind it — this tells the queued
+    message WHY it is waiting. ``post_result`` distinguishes that linger
+    window from a normal mid-run queue, where the active progress message
+    already explains itself.
+    """
+    if not is_session_alive(session_id):
+        return None
+    state = _SESSION_BG_STATE.get(session_id)
+    post_result = state is not None and state.result_received_at is not None
+    return post_result, session_live_bg_count(session_id)
+
+
 SESSION_HANDOFF_POLL_S: float = 0.25
 
 
@@ -3836,7 +3855,19 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 # which is DIRECT children only and misses the npx→node
                 # grandchild that actually leaks.
                 _capture_orphan_descendants(state, source="limbo", pid=proc.pid)
-                run_logger.warning(
+                # #653: the level reflects the assessed state, not the
+                # transition into it. Live background work — or a
+                # demonstrably busy process tree — lingering after the
+                # result is healthy, expected behaviour under the
+                # liveness-aware ceiling (#646/#647): INFO. WARNING is
+                # reserved for limbo with no evidence of work, the
+                # genuinely-stuck case the warning was written for.
+                limbo_log = (
+                    run_logger.info
+                    if (live_bg or cpu_active is True or tree_active is True)
+                    else run_logger.warning
+                )
+                limbo_log(
                     "runner.limbo_detected",
                     engine="claude",
                     pid=proc.pid,
@@ -3847,6 +3878,9 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                         if state.result_received_at is not None
                         else None
                     ),
+                    live_background_work=live_bg,
+                    cpu_active=cpu_active,
+                    tree_active=tree_active,
                     mcp_child_pids=list(diag.child_pids) if diag else [],
                     rss_kb=diag.rss_kb if diag else None,
                     tcp_total=diag.tcp_total if diag else None,
@@ -3865,9 +3899,25 @@ class ClaudeRunner(ResumeTokenMixin, JsonlSubprocessRunner):
             # fully quiescent — no live background work means nothing can
             # legitimately produce output any more (pending requests/asks
             # were handled above via the re-arm branch).
+            #
+            # #655: `not live_bg` alone is NOT quiescence — it only means no
+            # *registered* background handle. A process can be busy with
+            # direct work (waiting on a build, a slow MCP call, a poll loop)
+            # with live_bg False. Consult the same liveness signals the
+            # extension gate below uses, so a demonstrably-busy process falls
+            # through to the full ``timeout_s``. Tri-state: both signals are
+            # None on the first poll (no prev_diag); `is True` keeps unknown
+            # liveness from blocking the grace cap, preserving #591's fast
+            # reap of genuinely quiescent husks.
+            demonstrably_busy = cpu_active is True or tree_active is True
             effective_deadline = deadline
             limbo_grace_applied = False
-            if grace_deadline is not None and grace_deadline < deadline and not live_bg:
+            if (
+                grace_deadline is not None
+                and grace_deadline < deadline
+                and not live_bg
+                and not demonstrably_busy
+            ):
                 effective_deadline = grace_deadline
                 limbo_grace_applied = True
 

--- a/src/untether/telegram/loop.py
+++ b/src/untether/telegram/loop.py
@@ -1188,6 +1188,45 @@ async def _wait_for_resume(running_task) -> ResumeToken | None:
     return resume
 
 
+def _queued_wait_note(resume_token: ResumeToken) -> str | None:
+    """Explain WHY a queued follow-up is waiting, when knowable (#654).
+
+    A follow-up that queues behind a Claude session lingering post-result
+    (finishing background work under the liveness-aware ceiling, #646/#647)
+    previously sat on a bare "queued" progress message for the whole hold —
+    observed at 5m36s, permitted up to 30 min — with nothing telling the
+    user why, or that /cancel was available. Returns ``None`` for non-Claude
+    engines, unknown sessions, and normal mid-run queues (where the active
+    progress message above already explains itself).
+    """
+    if resume_token.engine != "claude":
+        return None
+    try:
+        from ..runners.claude import session_linger_info
+
+        info = session_linger_info(resume_token.value)
+    except Exception:  # noqa: BLE001 — the note is best-effort decoration;
+        # a registry hiccup must never break the queued send itself.
+        logger.debug("queued_note.linger_info_failed", exc_info=True)
+        return None
+    if info is None:
+        return None
+    post_result, bg_count = info
+    if not post_result:
+        return None
+    if bg_count > 0:
+        plural = "s" if bg_count != 1 else ""
+        return (
+            f"⏳ Queued behind the previous run's {bg_count} background "
+            f"task{plural} — starts when they finish, with context carried "
+            f"over. /cancel to drop it."
+        )
+    return (
+        "⏳ Queued — the previous run is still finishing up. Starts "
+        "when it completes, with context carried over. /cancel to drop it."
+    )
+
+
 async def _send_queued_progress(
     cfg: TelegramBridgeConfig,
     *,
@@ -1206,6 +1245,14 @@ async def _send_queued_progress(
         elapsed_s=0.0,
         label="queued",
     )
+    # #654: when the queue reason is knowable (Claude session lingering
+    # post-result over background work), say so instead of a bare "queued".
+    note = _queued_wait_note(resume_token)
+    if note is not None:
+        message = RenderedMessage(
+            text=f"{message.text}\n\n{note}",
+            extra=message.extra,
+        )
     reply_ref = MessageRef(
         channel_id=chat_id,
         message_id=user_msg_id,

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -5337,6 +5337,113 @@ async def test_655_limbo_grace_still_applies_when_cpu_inactive(monkeypatch) -> N
     assert sigterm_logs and sigterm_logs[0].get("limbo_grace_applied") is True
 
 
+@pytest.mark.anyio
+async def test_655_limbo_grace_real_busy_subprocess_survives() -> None:
+    """End-to-end #655 with a REAL subprocess and REAL /proc CPU accounting —
+    no monkeypatched diag. A genuinely busy process with no registered
+    background handles must survive well past the limbo grace; the eventual
+    kill is the full-timeout path, not the grace."""
+    import contextlib
+    import os
+    import subprocess as _subprocess
+
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.1
+    runner._subcountdown_limbo_detect_threshold_s = 0.2
+    runner._subcountdown_sigterm_grace_s = 0.3
+    runner._subcountdown_sigterm_grace_poll_s = 0.05
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="grace-sess-655c"))
+    state.result_received_at = time.monotonic() - 0.5
+    stream = JsonlStreamState(expected_session=None)
+
+    # A real CPU-busy child in its own process group, exactly as the runner
+    # spawns the CLI (start_new_session=True → pid == pgid).
+    proc = _subprocess.Popen(  # noqa: ASYNC220 — fork+exec is instant; the
+        # test needs Popen.poll() semantics for the ProcView adapter below.
+        ["sh", "-c", "while :; do :; done"],
+        start_new_session=True,
+        stdout=_subprocess.DEVNULL,
+        stderr=_subprocess.DEVNULL,
+    )
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    class ProcView:
+        """Popen adapter exposing the pid/returncode surface the watchdog
+        polls (Popen.returncode only updates via poll())."""
+
+        pid = proc.pid
+
+        @property
+        def returncode(self) -> int | None:
+            return proc.poll()
+
+    grace_s = 0.4
+    timeout_s = 2.5
+    try:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                runner._post_result_idle_watchdog,
+                state,
+                FakeStdin(),
+                reader_done,
+                logger,
+                timeout_s,
+                ProcView(),
+                stream,
+                grace_s,
+            )
+            # Well past the grace: the busy process must still be alive and
+            # un-signalled — pre-#655 it was SIGTERM'd at the grace.
+            await anyio.sleep(grace_s * 3)
+            assert proc.poll() is None, (
+                "busy subprocess must survive past the limbo grace"
+            )
+            assert not any(
+                e == "claude.post_result_idle.sigterm_after_timeout"
+                for _, e, _ in logger.records
+            )
+            # Let the full timeout fire and the watchdog return.
+            with anyio.move_on_after(timeout_s * 3):
+                while proc.poll() is None:
+                    await anyio.sleep(0.05)
+            tg.cancel_scope.cancel()
+    finally:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5)
+
+    sigterm_logs = [
+        kw
+        for lvl, e, kw in logger.records
+        if e == "claude.post_result_idle.sigterm_after_timeout"
+    ]
+    assert sigterm_logs, "full timeout should eventually reap the process"
+    assert sigterm_logs[0].get("limbo_grace_applied") is False
+    assert sigterm_logs[0].get("cpu_active") is True
+    assert sigterm_logs[0].get("elapsed_s", 0.0) >= timeout_s * 0.8
+
+
 def _limbo_level_records(logger: "_RecordingLogger") -> list[tuple[str, dict]]:
     return [(lvl, kw) for lvl, e, kw in logger.records if e == "runner.limbo_detected"]
 

--- a/tests/test_claude_runner.py
+++ b/tests/test_claude_runner.py
@@ -5156,6 +5156,328 @@ async def test_591_limbo_grace_deferred_by_live_background_work(monkeypatch) -> 
 
 
 @pytest.mark.anyio
+async def test_655_limbo_grace_deferred_by_cpu_active(monkeypatch) -> None:
+    """A post-result process that is demonstrably busy (rising CPU counters)
+    but has NO registered background handles must not be reaped at the limbo
+    grace — `not live_bg` alone is not quiescence (#655). It falls through to
+    the full ``timeout_s`` instead."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+    from untether.utils.proc_diag import ProcessDiag
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.02
+    runner._subcountdown_limbo_detect_threshold_s = 0.05
+    runner._subcountdown_sigterm_grace_s = 0.1
+    runner._subcountdown_sigterm_grace_poll_s = 0.02
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="grace-sess-655a"))
+    state.result_received_at = time.monotonic() - 0.5
+    # No live_bg_agents / live_bg_bashes / live_wakeups — live_bg stays False.
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=52427, returncode=None)
+    killed_signals: list[int] = []
+    monkeypatch.setattr("os.killpg", lambda pgid, sig: killed_signals.append(sig))
+    # #590: signal_pid_group snapshots real /proc descendants before
+    # signalling — neutralise it so tests never touch live processes.
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
+
+    # Monotonically rising CPU counters: is_cpu_active / is_tree_cpu_active
+    # become True from the second poll onward (first poll has no prev_diag
+    # and yields None — the tri-state the gate must tolerate).
+    calls = {"n": 0}
+
+    def _fake_diag(pid: int) -> ProcessDiag:
+        calls["n"] += 1
+        ticks = calls["n"] * 10
+        return ProcessDiag(
+            pid=pid,
+            alive=True,
+            cpu_utime=ticks,
+            cpu_stime=0,
+            tree_cpu_utime=ticks,
+            tree_cpu_stime=0,
+        )
+
+    monkeypatch.setattr("untether.utils.proc_diag.collect_proc_diag", _fake_diag)
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            30.0,  # full timeout — far beyond the observation window
+            proc,
+            stream,
+            0.1,  # limbo_grace_s — must NOT fire against a busy process
+        )
+        await anyio.sleep(1.0)  # ~10x the grace
+        tg.cancel_scope.cancel()
+
+    assert killed_signals == [], (
+        "grace must not fire while the process is demonstrably busy"
+    )
+    sigterm_logs = [
+        kw
+        for lvl, e, kw in logger.records
+        if e == "claude.post_result_idle.sigterm_after_timeout"
+    ]
+    assert not any(kw.get("limbo_grace_applied") is True for kw in sigterm_logs)
+
+
+@pytest.mark.anyio
+async def test_655_limbo_grace_still_applies_when_cpu_inactive(monkeypatch) -> None:
+    """The other side of the #655 boundary: flat CPU counters (demonstrably
+    idle) with no registered background work still reaps at the grace —
+    #591's fast reap of genuinely quiescent husks is preserved."""
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+    from untether.utils.proc_diag import ProcessDiag
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.02
+    runner._subcountdown_limbo_detect_threshold_s = 0.05
+    runner._subcountdown_sigterm_grace_s = 0.1
+    runner._subcountdown_sigterm_grace_poll_s = 0.02
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value="grace-sess-655b"))
+    state.result_received_at = time.monotonic() - 0.5
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=52428, returncode=None)
+    killed_signals: list[int] = []
+
+    def _fake_killpg(pgid: int, sig: int) -> None:
+        killed_signals.append(sig)
+        proc.returncode = -15
+
+    monkeypatch.setattr("os.killpg", _fake_killpg)
+    # #590: signal_pid_group snapshots real /proc descendants before
+    # signalling — neutralise it so tests never touch live processes.
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
+
+    # Flat CPU counters: is_cpu_active / is_tree_cpu_active are False from
+    # the second poll onward — demonstrably idle.
+    def _fake_diag(pid: int) -> ProcessDiag:
+        return ProcessDiag(
+            pid=pid,
+            alive=True,
+            cpu_utime=100,
+            cpu_stime=0,
+            tree_cpu_utime=100,
+            tree_cpu_stime=0,
+        )
+
+    monkeypatch.setattr("untether.utils.proc_diag.collect_proc_diag", _fake_diag)
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            30.0,
+            proc,
+            stream,
+            0.1,  # limbo_grace_s — SHOULD fire against an idle process
+        )
+        with anyio.move_on_after(3.0):
+            while signal.SIGTERM not in killed_signals:
+                await anyio.sleep(0.02)
+        tg.cancel_scope.cancel()
+
+    assert signal.SIGTERM in killed_signals, (
+        "grace should still reap a demonstrably idle process"
+    )
+    sigterm_logs = [
+        kw
+        for lvl, e, kw in logger.records
+        if e == "claude.post_result_idle.sigterm_after_timeout"
+    ]
+    assert sigterm_logs and sigterm_logs[0].get("limbo_grace_applied") is True
+
+
+def _limbo_level_records(logger: "_RecordingLogger") -> list[tuple[str, dict]]:
+    return [(lvl, kw) for lvl, e, kw in logger.records if e == "runner.limbo_detected"]
+
+
+async def _run_limbo_level_scenario(
+    monkeypatch,
+    *,
+    session_value: str,
+    pid: int,
+    live_bg: bool,
+    rising_cpu: bool,
+) -> "_RecordingLogger":
+    """Drive the subcountdown to its limbo tick and capture the log records.
+
+    Grace is disabled (0.0) so the loop lingers long enough to observe the
+    one-shot ``runner.limbo_detected`` without any kill path interfering.
+    """
+    import anyio
+
+    from untether.runner import JsonlStreamState
+    from untether.runners.claude import (
+        _PENDING_ASK_REQUESTS,
+        _REQUEST_TO_SESSION,
+        ClaudeRunner,
+    )
+    from untether.utils.proc_diag import ProcessDiag
+
+    _REQUEST_TO_SESSION.clear()
+    _PENDING_ASK_REQUESTS.clear()
+
+    runner = ClaudeRunner(claude_cmd="claude")
+    runner._subcountdown_poll_interval_s = 0.02
+    runner._subcountdown_limbo_detect_threshold_s = 0.05
+
+    state = ClaudeStreamState()
+    state.factory.started(ResumeToken(engine="claude", value=session_value))
+    state.result_received_at = time.monotonic() - 0.5
+    if live_bg:
+        state.live_wakeups["toolu_653"] = time.monotonic() + 3600.0
+    stream = JsonlStreamState(expected_session=None)
+
+    proc = _FakeProc(pid=pid, returncode=None)
+    monkeypatch.setattr("os.killpg", lambda pgid, sig: None)
+    monkeypatch.setattr("untether.utils.subprocess.find_descendants", lambda pid: [])
+
+    calls = {"n": 0}
+
+    def _fake_diag(diag_pid: int) -> ProcessDiag:
+        calls["n"] += 1
+        ticks = calls["n"] * 10 if rising_cpu else 100
+        return ProcessDiag(
+            pid=diag_pid,
+            alive=True,
+            cpu_utime=ticks,
+            cpu_stime=0,
+            tree_cpu_utime=ticks,
+            tree_cpu_stime=0,
+        )
+
+    monkeypatch.setattr("untether.utils.proc_diag.collect_proc_diag", _fake_diag)
+
+    logger = _RecordingLogger()
+    reader_done = anyio.Event()
+    reader_done.set()
+
+    class FakeStdin:
+        async def aclose(self) -> None:
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(
+            runner._post_result_idle_watchdog,
+            state,
+            FakeStdin(),
+            reader_done,
+            logger,
+            30.0,
+            proc,
+            stream,
+            0.0,  # grace disabled — we only want the limbo tick
+        )
+        with anyio.move_on_after(3.0):
+            while "runner.limbo_detected" not in logger.events():
+                await anyio.sleep(0.02)
+        tg.cancel_scope.cancel()
+
+    return logger
+
+
+@pytest.mark.anyio
+async def test_653_limbo_detected_info_when_background_work_live(monkeypatch) -> None:
+    """#653: limbo with live background work is healthy, expected behaviour
+    under the liveness-aware ceiling (#646/#647) — the one-shot
+    ``runner.limbo_detected`` logs at INFO, not WARNING."""
+    logger = await _run_limbo_level_scenario(
+        monkeypatch,
+        session_value="limbo-lvl-1",
+        pid=52430,
+        live_bg=True,
+        rising_cpu=False,
+    )
+    records = _limbo_level_records(logger)
+    assert records, "limbo_detected should have fired"
+    assert all(lvl == "info" for lvl, _ in records)
+    assert records[0][1].get("live_background_work") is True
+
+
+@pytest.mark.anyio
+async def test_653_limbo_detected_info_when_cpu_active(monkeypatch) -> None:
+    """#653/#655: limbo with no registered handles but a demonstrably busy
+    process (rising CPU) is also healthy — INFO, not WARNING."""
+    logger = await _run_limbo_level_scenario(
+        monkeypatch,
+        session_value="limbo-lvl-2",
+        pid=52431,
+        live_bg=False,
+        rising_cpu=True,
+    )
+    records = _limbo_level_records(logger)
+    assert records, "limbo_detected should have fired"
+    assert all(lvl == "info" for lvl, _ in records)
+    assert records[0][1].get("live_background_work") is False
+
+
+@pytest.mark.anyio
+async def test_653_limbo_detected_warning_when_quiescent(monkeypatch) -> None:
+    """#653: limbo with no background work and a flat CPU counter is the
+    genuinely-stuck case the warning was written for — stays WARNING."""
+    logger = await _run_limbo_level_scenario(
+        monkeypatch,
+        session_value="limbo-lvl-3",
+        pid=52432,
+        live_bg=False,
+        rising_cpu=False,
+    )
+    records = _limbo_level_records(logger)
+    assert records, "limbo_detected should have fired"
+    assert all(lvl == "warning" for lvl, _ in records)
+
+
+@pytest.mark.anyio
 async def test_591_limbo_grace_zero_disables_shortcut(monkeypatch) -> None:
     """limbo_grace_s=0 disables the shortcut — the full timeout applies."""
     import anyio
@@ -5856,3 +6178,38 @@ def test_647_session_live_bg_count_reads_registry() -> None:
         assert session_live_bg_count("bg-count-sess") == 0
     finally:
         _SESSION_BG_STATE.pop("bg-count-sess", None)
+
+
+def test_654_session_linger_info_reads_registries() -> None:
+    """#654: `session_linger_info` reports (post_result, bg_count) for a
+    live session owner so the queued-progress path can explain the wait."""
+    from untether.runners.claude import (
+        _SESSION_BG_STATE,
+        _SESSION_STDIN,
+        session_linger_info,
+    )
+
+    sid = "linger-sess-1"
+    state = ClaudeStreamState()
+    try:
+        # No live owner at all.
+        assert session_linger_info(sid) is None
+
+        # Live owner, result not yet delivered — normal mid-run queue.
+        _SESSION_STDIN[sid] = object()
+        _SESSION_BG_STATE[sid] = state
+        assert session_linger_info(sid) == (False, 0)
+
+        # Post-result with a live background handle.
+        state.result_received_at = time.monotonic() - 1.0
+        state.live_bg_agents.add("toolu_654")
+        state.bg_agent_deadlines["toolu_654"] = time.monotonic() + 3600.0
+        assert session_linger_info(sid) == (True, 1)
+
+        # Post-result, handles aged out (the #655 shape) — still reported
+        # as post-result so the note can explain the wait generically.
+        state.bg_agent_deadlines["toolu_654"] = time.monotonic() - 1.0
+        assert session_linger_info(sid) == (True, 0)
+    finally:
+        _SESSION_STDIN.pop(sid, None)
+        _SESSION_BG_STATE.pop(sid, None)

--- a/tests/test_loop_coverage.py
+++ b/tests/test_loop_coverage.py
@@ -762,3 +762,86 @@ class TestInitQuarantineStore:
             assert any(r.get("event") == "quarantine.startup_init_failed" for r in logs)
         finally:
             set_quarantine_store(None)
+
+
+# ---------------------------------------------------------------------------
+# #654 — queued-behind-background-work wait note
+# ---------------------------------------------------------------------------
+
+
+class TestQueuedWaitNote:
+    """#654: `_queued_wait_note` explains WHY a queued follow-up is waiting
+    when it queues behind a Claude session lingering post-result."""
+
+    @staticmethod
+    def _token(engine: str = "claude", value: str = "sess-654"):
+        from untether.model import ResumeToken
+
+        return ResumeToken(engine=engine, value=value)
+
+    def test_non_claude_engine_returns_none(self) -> None:
+        from untether.telegram.loop import _queued_wait_note
+
+        assert _queued_wait_note(self._token(engine="codex")) is None
+
+    def test_no_live_owner_returns_none(self, monkeypatch) -> None:
+        from untether.telegram.loop import _queued_wait_note
+
+        monkeypatch.setattr(
+            "untether.runners.claude.session_linger_info", lambda sid: None
+        )
+        assert _queued_wait_note(self._token()) is None
+
+    def test_mid_run_owner_returns_none(self, monkeypatch) -> None:
+        """A session that has not delivered its result yet is a normal
+        mid-run queue — the active progress message already explains it."""
+        from untether.telegram.loop import _queued_wait_note
+
+        monkeypatch.setattr(
+            "untether.runners.claude.session_linger_info", lambda sid: (False, 0)
+        )
+        assert _queued_wait_note(self._token()) is None
+
+    def test_post_result_with_background_tasks(self, monkeypatch) -> None:
+        from untether.telegram.loop import _queued_wait_note
+
+        monkeypatch.setattr(
+            "untether.runners.claude.session_linger_info", lambda sid: (True, 2)
+        )
+        note = _queued_wait_note(self._token())
+        assert note is not None
+        assert "2 background task" in note
+        assert "/cancel" in note
+
+    def test_post_result_single_task_singular(self, monkeypatch) -> None:
+        from untether.telegram.loop import _queued_wait_note
+
+        monkeypatch.setattr(
+            "untether.runners.claude.session_linger_info", lambda sid: (True, 1)
+        )
+        note = _queued_wait_note(self._token())
+        assert note is not None
+        assert "1 background task" in note
+        assert "1 background tasks" not in note
+
+    def test_post_result_no_registered_tasks(self, monkeypatch) -> None:
+        """#655 shape: busy post-result session with no registered handles
+        still gets an explanatory note, without a task count."""
+        from untether.telegram.loop import _queued_wait_note
+
+        monkeypatch.setattr(
+            "untether.runners.claude.session_linger_info", lambda sid: (True, 0)
+        )
+        note = _queued_wait_note(self._token())
+        assert note is not None
+        assert "background task" not in note
+        assert "/cancel" in note
+
+    def test_linger_info_failure_returns_none(self, monkeypatch) -> None:
+        from untether.telegram.loop import _queued_wait_note
+
+        def _boom(sid: str):
+            raise RuntimeError("registry unavailable")
+
+        monkeypatch.setattr("untether.runners.claude.session_linger_info", _boom)
+        assert _queued_wait_note(self._token()) is None

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.4rc10"
+version = "0.35.4rc11"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes the three findings from fleet-monitor run `20260719T051727Z` (all in the post-result subcountdown lifecycle), staged as **0.35.4rc11**.

### #655 (MAJOR) — limbo grace kills CPU-active sessions at 60s
The #591 grace cap gated on `not live_bg` alone, but `live_bg` only tracks *registered* background handles — a strict subset of "doing work". A post-result process busy with direct work (polling a build, slow MCP call) was SIGTERM'd at 60s, quarantined, and the user's next message diverted to a fresh contextless session (observed: total context loss on a 23m52s/38-step turn; 7×/24h pre-rc10 baseline on nsd).

Fix: the grace cap now consults the same `cpu_active`/`tree_active` signals the extension gate already uses — a `demonstrably_busy` process falls through to the full `timeout_s`. Tri-state `is True` keeps unknown liveness from blocking the cap, preserving #591's fast reap of genuinely quiescent husks.

### #653 (ENH) — limbo_detected WARNING on healthy sessions
`runner.limbo_detected` now logs **INFO** when the same evaluation shows live background work or a busy tree, **WARNING** only for the genuinely-stuck quiescent case; event enriched with `live_background_work`/`cpu_active`/`tree_active`.

### #654 (ENH) — silent queued-during-background-work holds
The queued progress message now explains the wait when a follow-up queues behind a lingering post-result Claude session: `⏳ Queued behind the previous run's N background tasks — starts when they finish, with context carried over. /cancel to drop it.` (`/cancel` genuinely drops queued jobs via `cancel_queued`). New `session_linger_info()` helper; mid-run queues unchanged.

## Tests

- TDD: all fixes test-first; failing tests observed before each fix
- New: 2× #655 gate tests, 1× #655 **real-subprocess e2e** (real busy child, real /proc CPU accounting, no mocked diag), 3× #653 level tests, 7× #654 note tests, 1× `session_linger_info` registry test
- Full suite: **2991 passed, 2 skipped, coverage 83.03%** (gate 80%); ruff clean, formatted
- Regressions pinned: `test_591_*` unchanged and green

## Integration (per docs/reference/integration-testing.md, on @untether_dev_bot)

- #654 verified live: queued notice with correct count (2 bg subagents) + /cancel hint; fast-dispatch path edits into normal run progress as designed
- #653 verified live ×2: `runner.limbo_detected` at INFO with `live_background_work=True cpu_active=True`
- rc10 regressions green: bg-agent registration (2 agents/9 children), 600s liveness countdown, silent clean reap, queued follow-up dispatched on the **same session** 60ms after linger end, answered correctly
- Organic bonus: an upstream empty-resume (0-turn/$0, #596-class, `sigterm_sent=False`) occurred and the #631/#632 quarantine-and-fresh recovery handled it as designed (announced retry, fresh session answered ok) — unrelated to this change
- `/ping` smoke ok; error sweep clean
- Attestation marker written: `~/.untether-dev/integration-test-pass-0.35.4rc11.json`

## Upstream check

Claude Code CLI is at 2.1.215; v2.1.214 (Jul 18) fixed SIGTERM child-tree cleanup and a stream-json drain race — helpful but unrelated to the linger-after-result behaviour, which remains (upstream #53328 still open). claude-agent-sdk-python has no recent post-result-exit changes. All three Untether-side fixes remain necessary.

rc: no changelog entry per release-discipline (stable 0.35.4 will carry them).

Closes #655. Addresses #653, #654 (close after fleet verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)