### PR TITLE
feat(scripts): SHA-bind the integration-test attestation marker (#674)

### DIFF
--- a/.claude/commands/qa.md
+++ b/.claude/commands/qa.md
@@ -146,12 +146,14 @@ hand), binding the exact commit SHA:
 HEAD_SHA=$(git rev-parse HEAD)
 scripts/run-integration-tests.sh <VERSION> --manual \
   --tiers "<the tiers actually run>" \
-  --notes "green on @untether_dev_bot; head_sha=${HEAD_SHA}; run-id qa-<stamp>"
+  --head-sha "${HEAD_SHA}" \
+  --notes "green on @untether_dev_bot; run-id qa-<stamp>"
 ```
 
-The marker MUST bind commit SHA + dev-bot identity + suite/tier set + outcome +
-actor + timestamp (SHA-binding of `run-integration-tests.sh` is a
-propose-to-Nathan enhancement — plan §9.2). **Writing the marker never invokes
+The marker binds commit SHA + dev-bot identity + suite/tier set + outcome +
+actor + timestamp — `run-integration-tests.sh` records `head_sha` + `dev_bot_id`
+as first-class fields (#674), and `fleet-rollout.sh` surfaces them at the gate.
+**Writing the marker never invokes
 rollout** — `fleet-rollout.sh` is the operator's step and verifies the marker
 matches the artifact. Idempotent: if a green marker for this exact
 VERSION+SHA already exists, do not rewrite it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Rules in `.claude/rules/` auto-load when editing matching files:
 
 ## Tests
 
-3010 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
+3015 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
 
 Key test files:
 
@@ -237,6 +237,7 @@ Key test files:
 - `test_sdnotify.py` — 7 tests: NOTIFY_SOCKET handling (absent/empty/filesystem/abstract-namespace), send error swallowing, UTF-8 encoding
 - `test_session_quarantine.py` — 7 tests: QuarantineStore round-trip persistence, engine isolation, malformed/corrupt state-file resilience, age-based pruning to disk, singleton accessor + injection (#631/#632)
 - `test_noop_resume_harness.py` — 3 tests: end-to-end no-op empty-resume reproduction via the fake-claude CLI (`tests/fake_clis/fake_claude_noop_resume.py`) — real ClaudeRunner + handle_message drive quarantine-and-fresh recovery, healthy-resume negative control, linger-scenario emission shape (#634)
+- `test_attestation_marker.py` — 5 tests: `scripts/run-integration-tests.sh` SHA-binding (#674) — `head_sha` auto-derived from the script repo, `--head-sha` + `UT_INTEGRATION_HEAD_SHA` overrides, `dev_bot_id` default + `UT_DEV_BOT_ID` override, tiers/notes preserved in the marker JSON
 
 ## Development
 

--- a/scripts/fleet-rollout.sh
+++ b/scripts/fleet-rollout.sh
@@ -179,6 +179,18 @@ EOF
     if [[ -n "$(find "$ATTESTATION_MARKER" -mtime +14 2>/dev/null)" ]]; then
         echo "WARN: attestation marker for $VERSION is >14 days old — re-test if code changed since." >&2
     fi
+
+    # Guardrail 3 — surface the SHA/dev-bot binding (#674). Informational, never
+    # a hard gate: the operator eyeballs that the marker was bound to the commit
+    # the artifact was built from and to the real dev bot. Markers written before
+    # #674 have no head_sha — warn so they can be re-attested if it matters.
+    MARKER_SHA=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('head_sha',''))" "$ATTESTATION_MARKER" 2>/dev/null || echo "")
+    MARKER_BOT=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('dev_bot_id') or d.get('dev_bot',''))" "$ATTESTATION_MARKER" 2>/dev/null || echo "")
+    if [[ -z "$MARKER_SHA" || "$MARKER_SHA" == "unknown" ]]; then
+        echo "WARN: attestation marker has no head_sha (pre-#674 or hand-written) — cannot confirm it binds this artifact's commit." >&2
+    else
+        echo "Attestation bound to head_sha ${MARKER_SHA} · dev_bot ${MARKER_BOT}."
+    fi
 else
     echo "WARN: --skip-test-gate set; attestation gate bypassed."
 fi

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -34,6 +34,11 @@ MODE="manual"
 TIERS=""
 NOTES=""
 TESTER="${UT_INTEGRATION_TESTER:-${USER}@$(hostname)}"
+# SHA-binding (#674): bind the attestation to the exact commit tested + a
+# machine-readable dev-bot identity, so the marker is not a reusable boolean.
+HEAD_SHA="${UT_INTEGRATION_HEAD_SHA:-}"
+DEV_BOT_ID="${UT_DEV_BOT_ID:-8678330610}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
     cat <<EOF
@@ -52,6 +57,14 @@ Options:
   --auto               Reserved for future — exit 1 with a notice.
   --tiers LIST         Comma-separated tier list run (e.g. "tier7,tier1-claude")
   --notes TEXT         Free-form notes about the test run
+  --head-sha SHA       Commit the tests were run against. Defaults to the
+                       script repo's HEAD (git rev-parse). Also settable via
+                       UT_INTEGRATION_HEAD_SHA. Binds the marker to an artifact.
+
+Environment:
+  UT_INTEGRATION_TESTER   Overrides the recorded tester (default: user@host)
+  UT_INTEGRATION_HEAD_SHA Overrides the recorded head_sha
+  UT_DEV_BOT_ID           Overrides the recorded dev_bot_id (default: 8678330610)
 
 The marker is written to:
   ${ATTESTATION_DIR}/integration-test-pass-VERSION.json
@@ -66,6 +79,7 @@ while [[ $# -gt 0 ]]; do
         --auto) MODE="auto"; shift ;;
         --tiers) TIERS="${2:?--tiers requires a value}"; shift 2 ;;
         --notes) NOTES="${2:?--notes requires a value}"; shift 2 ;;
+        --head-sha) HEAD_SHA="${2:?--head-sha requires a value}"; shift 2 ;;
         -*) echo "Unknown option: $1" >&2; usage 1 ;;
         *)
             if [[ -z "$VERSION" ]]; then VERSION="$1"; else echo "Unexpected: $1" >&2; usage 1; fi
@@ -97,6 +111,12 @@ fi
 mkdir -p "$ATTESTATION_DIR"
 MARKER="${ATTESTATION_DIR}/integration-test-pass-${VERSION}.json"
 
+# Derive head_sha from the script's own repo if not supplied. Never abort the
+# attestation just because git is unavailable — fall back to "unknown".
+if [[ -z "$HEAD_SHA" ]]; then
+    HEAD_SHA="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")"
+fi
+
 # Default tier list mirrors the release-discipline rule's per-bump-severity
 # requirements. Patch -> tier7+tier1-affected; minor -> wider; major -> all.
 # We don't know the bump severity from this script, so default empty and
@@ -108,12 +128,14 @@ import json
 marker = "${MARKER}"
 data = {
     "version": "${VERSION}",
+    "head_sha": "${HEAD_SHA}",
     "tester": "${TESTER}",
     "attested_at": "${TIMESTAMP}",
     "mode": "${MODE}",
     "tiers": "${TIERS}".split(",") if "${TIERS}" else [],
     "notes": """${NOTES}""",
     "dev_bot": "@untether_dev_bot",
+    "dev_bot_id": "${DEV_BOT_ID}",
     "playbook": "docs/reference/integration-testing.md",
 }
 with open(marker, "w") as f:
@@ -124,6 +146,7 @@ EOF
 cat <<EOF
 
 The fleet rollout gate is now satisfied for version ${VERSION}.
+Bound to head_sha ${HEAD_SHA} · dev_bot @untether_dev_bot (${DEV_BOT_ID}).
 
 Next steps:
   scripts/fleet-rollout.sh ${VERSION}              # roll to all 5 hosts in parallel

--- a/tests/test_attestation_marker.py
+++ b/tests/test_attestation_marker.py
@@ -1,0 +1,80 @@
+"""Tests for the integration-test attestation marker writer.
+
+Covers the #674 SHA-binding of ``scripts/run-integration-tests.sh``: the marker
+records ``head_sha`` + ``dev_bot_id`` so the fleet-rollout gate binds an exact
+commit + the real dev bot, not a reusable boolean.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "run-integration-tests.sh"
+FAKE_VERSION = "0.0.0test"
+
+
+def _run(
+    *args: str, home: Path, env_extra: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "HOME": str(home)}
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(SCRIPT), FAKE_VERSION, "--manual", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _marker(home: Path) -> dict:
+    path = home / ".untether-dev" / f"integration-test-pass-{FAKE_VERSION}.json"
+    assert path.exists(), f"marker not written: {path}"
+    return json.loads(path.read_text())
+
+
+def _git_head() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def test_marker_records_head_sha_and_dev_bot_id(tmp_path: Path) -> None:
+    _run(home=tmp_path)
+    m = _marker(tmp_path)
+    assert m["version"] == FAKE_VERSION
+    assert m["head_sha"] == _git_head()  # auto-derived from the script's repo
+    assert m["dev_bot_id"] == "8678330610"  # documented default
+    assert m["dev_bot"] == "@untether_dev_bot"
+
+
+def test_head_sha_flag_overrides(tmp_path: Path) -> None:
+    _run("--head-sha", "deadbeef", home=tmp_path)
+    assert _marker(tmp_path)["head_sha"] == "deadbeef"
+
+
+def test_head_sha_env_overrides(tmp_path: Path) -> None:
+    _run(home=tmp_path, env_extra={"UT_INTEGRATION_HEAD_SHA": "cafef00d"})
+    assert _marker(tmp_path)["head_sha"] == "cafef00d"
+
+
+def test_dev_bot_id_env_overrides(tmp_path: Path) -> None:
+    _run(home=tmp_path, env_extra={"UT_DEV_BOT_ID": "12345"})
+    assert _marker(tmp_path)["dev_bot_id"] == "12345"
+
+
+def test_tiers_and_notes_preserved(tmp_path: Path) -> None:
+    _run("--tiers", "tier7,tier1-claude", "--notes", "all green", home=tmp_path)
+    m = _marker(tmp_path)
+    assert m["tiers"] == ["tier7", "tier1-claude"]
+    assert m["notes"] == "all green"


### PR DESCRIPTION
Closes #674. Actions plan §9.2 (propose-to-Nathan → now implemented): the
attestation marker that gates `fleet-rollout.sh` was a reusable boolean — it
bound a version string but not the commit tested. Now it binds the exact
`head_sha` + a machine-readable dev-bot identity.

Operator tooling only (`scripts/` + a slash-command doc + a test) — **not
shipped in the wheel, no version bump, no changelog entry** (rc-skip territory).

| File | Change |
|------|--------|
| `scripts/run-integration-tests.sh` | record `head_sha` (auto-derived via `git rev-parse`, overridable `--head-sha` / `UT_INTEGRATION_HEAD_SHA`) + `dev_bot_id` (default `8678330610`, `UT_DEV_BOT_ID` override) in the marker JSON |
| `scripts/fleet-rollout.sh` | surface the bound `head_sha` + dev-bot at the gate (Guardrail 3, informational); warn on pre-#674 markers — no hard-gate change, backward compatible |
| `.claude/commands/qa.md` | `/qa` Q-6 passes `--head-sha` as a first-class field instead of embedding it in `--notes` |
| `tests/test_attestation_marker.py` | new — 5 tests |
| `CLAUDE.md` | `## Tests` list + count (3010 → 3015) |

## Tests
- `uv run pytest` — **3013 passed, 2 skipped, 83.03% coverage** (≥80% gate)
- `uv run ruff check` / `ruff format --check` — clean; both scripts pass `bash -n`
- Manual e2e: marker `head_sha` matches repo HEAD; `--head-sha` override works;
  `fleet-rollout --dry-run` surfaces the binding and warns on old markers.
- No integration-test gate: operator-tooling change, no shipped-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)