### PR TITLE
docs: v0.35.4 release doc corrections (cooldown, Type-A auto-retry, voice SSRF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Full documentation is available in the [`docs/`](https://github.com/littlebearap
 ### How-To Guides
 
 - [Interactive approval](https://github.com/littlebearapps/untether/blob/master/docs/how-to/interactive-approval.md) — approve and deny tool calls from Telegram
-- [Plan mode](https://github.com/littlebearapps/untether/blob/master/docs/how-to/plan-mode.md) — control plan transitions and progressive cooldown
+- [Plan mode](https://github.com/littlebearapps/untether/blob/master/docs/how-to/plan-mode.md) — control plan transitions and the outline gate
 - [Cost budgets](https://github.com/littlebearapps/untether/blob/master/docs/how-to/cost-budgets.md) — per-run and daily budget limits
 - [Inline settings](https://github.com/littlebearapps/untether/blob/master/docs/how-to/inline-settings.md) — `/config` button menu
 - [Voice notes](https://github.com/littlebearapps/untether/blob/master/docs/how-to/voice-notes.md) — dictate tasks from your phone

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -204,7 +204,15 @@ The error message is classified inline ([#438](https://github.com/littlebearapps
   Shell-set `CLAUDE_STREAM_IDLE_TIMEOUT_MS` still wins.
 * **Type-B (cold-start zero-byte stall)** — `num_turns ≤ 1 && duration_api_ms == 0`. The connection opened and went silent before Anthropic produced any tokens. This is an upstream API outage, **not** a watchdog miscalibration — raising the timeout will not help. Wait it out, retry, or check the [Anthropic status page](https://status.anthropic.com).
 
-Auto-retry for Type-A is deferred to a future release pending upstream Anthropic stabilisation.
+**Auto-retry (opt-in, since v0.35.4):** a Type-A stall can now auto-resume the session instead of surfacing a terminal error ([#572](https://github.com/littlebearapps/untether/issues/572)). It's off by default:
+
+```toml
+[watchdog]
+stream_idle_auto_retry = true    # resume Type-A stalls automatically (🔁 notice)
+stream_idle_max_retries = 1      # attempt cap, 1–3
+```
+
+Type-B (cold-start zero-byte) is **never** retried — retrying just hammers a down API. Cost-budget caps and signal-death suppression still apply to a retried run, so it can't spiral under memory pressure or blow a daily budget.
 
 ## Claude session looks alive 30+ min after the final message
 
@@ -268,6 +276,12 @@ To change:
 2. Make sure you have an OpenAI API key set (voice transcription uses the OpenAI transcription API by default)
 3. Check the voice note size — default max is 10 MiB (`voice_max_bytes`)
 4. If using a custom transcription server, verify `voice_transcription_base_url` is reachable
+5. **Since v0.35.4**, a `voice_transcription_base_url` that resolves to a private/loopback address (e.g. a self-hosted Whisper on `localhost`, `10.x`, or `192.168.x`) is **rejected by the SSRF guard** ([#381](https://github.com/littlebearapps/untether/issues/381)). Opt the endpoint back in with its CIDR range:
+
+    ```toml
+    [transports.telegram]
+    voice_transcription_url_allowlist = ["127.0.0.0/8"]   # or your private range
+    ```
 
 Run `untether doctor` to validate voice configuration.
 

--- a/docs/tutorials/interactive-control.md
+++ b/docs/tutorials/interactive-control.md
@@ -139,8 +139,8 @@ After Claude Code writes the outline, **Approve Plan**, **Deny**, and **Let's di
 - Tap **Deny** to stop Claude Code and provide different direction
 - Tap **Let's discuss** to talk about the plan before deciding — Claude Code will ask what you'd like to change and wait for your reply
 
-!!! tip "Progressive cooldown"
-    After tapping "Pause & Outline Plan", a cooldown prevents Claude Code from immediately retrying. The cooldown starts at 30 seconds and escalates up to 120 seconds if Claude Code keeps retrying. This ensures the agent pauses long enough for you to read the outline.
+!!! tip "Outline gate"
+    After tapping "Pause & Outline Plan", Untether holds ExitPlanMode open until Claude Code provides a readable outline — the plan is posted to the chat and the agent stays alive while you read it. If Claude Code retries *without* an outline, that attempt is auto-denied with an instruction to write the outline first. *(Earlier versions also enforced a 30–120s escalating cooldown here — a workaround for a Claude Code v2.1.72–2.1.74 retry loop that was fixed upstream and retired in v0.35.4.)*
 
 ## 8. Answer a question
 
@@ -243,7 +243,7 @@ Check your internet connection. If the tap doesn't register, try again — Untet
 
 **Claude Code keeps retrying after I tap "Pause & Outline Plan"**
 
-This is the progressive cooldown at work. Claude Code may retry ExitPlanMode during the cooldown window, but each retry is auto-denied. Wait for Claude Code to write the outline, then use the Approve Plan / Let's discuss / Deny buttons that appear.
+Until Claude Code writes an outline, each ExitPlanMode retry is auto-denied with an instruction to provide the plan first — this is the outline gate. Wait for Claude Code to write the outline, then use the Approve Plan / Let's discuss / Deny buttons that appear. *(The 30–120s escalating cooldown earlier versions used here was retired in v0.35.4 — the upstream retry loop it worked around is fixed.)*
 
 **I don't get push notifications for approval requests**
 


### PR DESCRIPTION
Corrects three v0.35.4-relevant staleness bugs in user-facing docs, found during the release audit for **#680**. Docs-only; no behaviour change; version untouched; no CHANGELOG entry (these align docs with features already in the v0.35.4 release notes — #570, #572, #381).

## Changes
- **README.md** — "Plan mode … progressive cooldown" → "the outline gate". The 30–120s progressive cooldown was retired in v0.35.4 ([#570](https://github.com/littlebearapps/untether/issues/570)).
- **docs/how-to/troubleshooting.md** — the Type-A stall note said auto-retry was "deferred to a future release". It **shipped** in v0.35.4 ([#572](https://github.com/littlebearapps/untether/issues/572)); now documents the opt-in `[watchdog] stream_idle_auto_retry` / `stream_idle_max_retries`.
- **docs/how-to/troubleshooting.md** — voice section now notes the SSRF refusal of private/loopback `voice_transcription_base_url` + the `voice_transcription_url_allowlist` opt-in ([#381](https://github.com/littlebearapps/untether/issues/381)).
- **docs/tutorials/interactive-control.md** — two spots described the retired progressive cooldown as current behaviour → rewritten to the outline gate, matching `docs/how-to/plan-mode.md`.

## Why now
These land on `dev` so they flow into the open v0.35.4 release PR #680 (dev→master) — the release ships with docs that match its own behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)