### PR TITLE
fix: dispatch release.yml explicitly from auto-tag-on-master (#376)

### DIFF
--- a/.github/workflows/auto-tag-on-master.yml
+++ b/.github/workflows/auto-tag-on-master.yml
@@ -1,20 +1,27 @@
 name: Auto-tag on master
 
 # When a push lands on master that bumps the version in pyproject.toml,
-# automatically create and push the matching `vX.Y.Z` tag. The tag push
-# triggers `release.yml`, which builds, validates, and publishes to PyPI.
+# automatically create and push the matching `vX.Y.Z` tag, then dispatch
+# `release.yml` against that tag to build, validate, and publish to PyPI.
 #
 # This collapses the previous two-gate release flow (PR merge + manual tag
 # creation + PyPI environment approval) into a single gate: the master PR
-# review. See docs/reference/release-process.md for the full rationale.
+# review.
 #
-# REQUIRES (one-time setup — see issue #376):
-#   1. A repo Actions secret `RELEASE_TAG_PAT` — a fine-scoped PAT with
-#      `contents: write` on this repo only. The tag push uses it (not the
-#      workflow GITHUB_TOKEN) so the resulting tag-push event actually fires
-#      release.yml. Without the secret this job fails loudly.
-#   2. The `pypi` GitHub Environment must NOT require a reviewer (the master PR
-#      review is the single gate; OIDC trusted publishing still protects PyPI).
+# WHY AN EXPLICIT DISPATCH (issue #376): a tag push does NOT cascade into
+# release.yml's `on: push: tags` trigger. GitHub suppresses downstream
+# workflow runs for GITHUB_TOKEN-triggered events, and a fine-grained-PAT
+# tag push does not trigger them either (empirically — every release from
+# v0.35.2 onward still required a manual `gh workflow run` even after the PAT
+# was provisioned). workflow_dispatch is the ONE event a GITHUB_TOKEN is
+# allowed to trigger, so this workflow pushes the tag and then dispatches
+# release.yml explicitly. Deterministic, exactly one release run, no PAT to
+# provision or rotate. The former `RELEASE_TAG_PAT` secret is no longer used.
+#
+# REQUIRES (one-time setup): the `pypi` GitHub Environment must NOT require a
+# reviewer (the master PR review is the single gate; OIDC trusted publishing
+# still protects PyPI). Already configured — the environment carries no
+# protection rules.
 #
 # Only fires when:
 #   1. The push is to master
@@ -39,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create + push tags
+      actions: write  # dispatch release.yml via workflow_dispatch (#376)
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -93,25 +101,32 @@ jobs:
         if: steps.version.outputs.stable == 'true' && steps.existing.outputs.exists == 'false'
         env:
           TAG: ${{ steps.version.outputs.tag }}
-          # #376: push the tag with a user-scoped PAT, NOT the workflow's
-          # GITHUB_TOKEN. GitHub deliberately suppresses downstream workflow
-          # runs for events triggered by GITHUB_TOKEN, so a GITHUB_TOKEN tag
-          # push never fires release.yml (`on: push: tags`). A PAT is treated
-          # as a normal actor and DOES trigger downstream workflows. There is
-          # NO GITHUB_TOKEN fallback on purpose — a fallback would silently
-          # reintroduce the "release didn't fire" bug.
-          RELEASE_TAG_PAT: ${{ secrets.RELEASE_TAG_PAT }}
-          REPO: ${{ github.repository }}
         run: |
-          if [ -z "$RELEASE_TAG_PAT" ]; then
-            echo "::error::RELEASE_TAG_PAT secret is not set. Create a fine-scoped PAT (contents:write on this repo only) and add it as the RELEASE_TAG_PAT Actions secret so the tag push triggers release.yml. See issue #376." >&2
-            exit 1
-          fi
           # Tag the merge commit (HEAD on master). Annotated tag so it
-          # carries the release version for audit purposes.
+          # carries the release version for audit purposes. The checkout step
+          # already persisted GITHUB_TOKEN as the origin credential, so this
+          # push needs no extra secret. It intentionally does NOT trigger
+          # release.yml (GITHUB_TOKEN pushes are suppressed) — the next step
+          # dispatches release.yml explicitly. See issue #376.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
-          git remote set-url origin "https://x-access-token:${RELEASE_TAG_PAT}@github.com/${REPO}.git"
           git push origin "$TAG"
-          echo "::notice::Created and pushed $TAG via RELEASE_TAG_PAT. release.yml will fire next."
+          echo "::notice::Created and pushed $TAG."
+
+      - name: Dispatch release workflow
+        if: steps.version.outputs.stable == 'true' && steps.existing.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # #376: dispatch release.yml against the freshly-pushed tag. This is
+          # the one path that reliably runs release.yml unattended — GITHUB_TOKEN
+          # is permitted to trigger workflow_dispatch (the documented exception
+          # to the downstream-suppression rule), and release.yml already exposes
+          # a workflow_dispatch trigger. Running it with --ref "$TAG" checks out
+          # the tag, so release.yml's "tag matches version" guard and the
+          # build/publish all operate on the release commit — identical to the
+          # manual `gh workflow run release.yml --ref vX.Y.Z` this replaces.
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"
+          echo "::notice::Dispatched release.yml against $TAG. Publishing will proceed unattended."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # changelog
 
+## v0.35.5 (unreleased)
+
+### fixes
+
+- **release:** dispatch `release.yml` explicitly from `auto-tag-on-master.yml` instead of relying on the tag push to trigger it. The `RELEASE_TAG_PAT` approach shipped in v0.35.4 did not work — a fine-grained-PAT tag push does not fire a downstream `on: push: tags` workflow any more than a `GITHUB_TOKEN` push does, so v0.35.4 still needed a manual `gh workflow run release.yml --ref v0.35.4` (verified: the v0.35.4 `release.yml` run was `workflow_dispatch`, 5.5 min after the auto-tag pushed the tag via the PAT). `auto-tag-on-master.yml` now pushes the tag with the workflow `GITHUB_TOKEN` and then runs `gh workflow run release.yml --ref "$TAG"` — `workflow_dispatch` is the one event a `GITHUB_TOKEN` is permitted to trigger, so the release proceeds unattended with exactly one run and no PAT to provision or rotate. Adds `actions: write` to the job; the now-unused `RELEASE_TAG_PAT` secret can be deleted. [#376](https://github.com/littlebearapps/untether/issues/376)
+
 ## v0.35.4 (2026-07-22)
 
 <!-- Covers rc1 through rc14 (the full v0.35.4 release-candidate cycle). Date is the


### PR DESCRIPTION
## Summary

- `auto-tag-on-master.yml` no longer relies on the tag push to cascade into `release.yml`. Option A (`RELEASE_TAG_PAT`, shipped in #576) **did not work** — a fine-grained-PAT tag push does not fire a downstream `on: push: tags` workflow any more than a `GITHUB_TOKEN` push does.
- Push the tag with `GITHUB_TOKEN` (reliably *creates* the tag; deliberately does not cascade), then dispatch `release.yml` explicitly with `gh workflow run release.yml --ref "$TAG"`. `workflow_dispatch` is the one event a `GITHUB_TOKEN` is permitted to trigger — this is the exact manual step every release since v0.35.2 required, now automated.
- Adds `actions: write` to the job. Removes the `RELEASE_TAG_PAT` dependency entirely (secret is now unused and can be deleted — no PAT to rotate). Exactly one release run, no double-fire.

## Evidence (v0.35.4, today)

| Fact | Value |
|---|---|
| `RELEASE_TAG_PAT` secret | present 17s before auto-tag ran |
| auto-tag run | success — log: "Created and pushed v0.35.4 via RELEASE_TAG_PAT. release.yml will fire next." |
| `release.yml` run for v0.35.4 | event = **`workflow_dispatch`** (manual), 5.5 min later |
| push-triggered `release.yml` run | **none** |
| `pypi` environment protection rules | `[]` (Option C already done) |

The manual v0.35.4 `workflow_dispatch` run (`--ref v0.35.4`, full build→publish→release, 2m34s) proves the dispatch path this PR automates works end-to-end.

## Issue

Fixes #376 (corrects the non-working approach shipped in #576).

## Test plan

- [x] YAML parse + invariants (no `secrets.RELEASE_TAG_PAT`, dispatch step present, `actions: write`, matched `if:` guards)
- [x] Full suite: `uv run pytest` — 3019 passed, 2 skipped, 83.07% (no Python touched)
- [x] Lint: `uv run ruff check src/` — clean
- [x] Format: `uv run ruff format --check src/ tests/` — clean
- [x] `python3 scripts/validate_release.py` — 3 passed
- [ ] **E2E (deferred, unavoidable):** the next stable `master` merge auto-fires `release.yml` with no manual `gh workflow run`. Falsification: next release again needs a hand-run dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)