### PR TITLE
chore: staging 0.35.5rc3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,14 +191,14 @@ Rules in `.claude/rules/` auto-load when editing matching files:
 
 ## Tests
 
-3021 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
+3092 unit tests, 80% coverage threshold. Integration testing against `@untether_dev_bot` is **mandatory before every release** — see `docs/reference/integration-testing.md` for the full playbook with per-release-type tier requirements (patch/minor/major). All integration test tiers are fully automated by Claude Code via Telegram MCP tools and Bash.
 
 Key test files:
 
 - `test_claude_control.py` — 100 tests: control requests, response routing, registry lifecycle, auto-approve/auto-deny, tool auto-approve, custom deny messages, discuss action, early toast, outline gate (#570 retired the progressive cooldown), auto permission mode, diff_preview plan bypass
 - `test_callback_dispatch.py` — 26 tests: callback parsing, dispatch toast/ephemeral behaviour, early answering
 - `test_exec_bridge.py` — 270 tests: ephemeral notification cleanup, approval push notifications, progressive stall warnings, stall diagnostics, stall auto-cancel with CPU-active suppression (sleeping-process aware), tool-active repeat suppression, approval-aware stall threshold, MCP tool stall threshold, frozen ring buffer hung escalation, session summary, PID/stream threading, auto-continue detection, signal death suppression, Type-A stream-idle auto-retry (#572), empty-resume quarantine-and-fresh recovery, resume divert/clear, empty-result diagnostics
-- `test_ask_user_question.py` — 35 tests: AskUserQuestion control request handling, question extraction, pending request registry, answer routing, option button rendering, multi-question flows, structured answer responses, ask mode toggle auto-deny
+- `test_ask_user_question.py` — 40 tests: AskUserQuestion control request handling, question extraction, pending request registry, answer routing, option button rendering, multi-question flows, structured answer responses, ask mode toggle auto-deny, late-tap already-answered memo (TTL + entry cap + channel scoping, #698)
 - `test_diff_preview.py` — 14 tests: Edit diff display, Write content preview, Bash command display, line/char truncation
 - `test_cost_tracker.py` — 17 tests: cost accumulation, per-run/daily budget thresholds, warning levels, daily reset, auto-cancel flag, one-shot `config.cost_visibility_gap` warning (#658)
 - `test_export_command.py` — 16 tests: session event recording, markdown/JSON export formatting, usage integration, session trimming
@@ -215,7 +215,7 @@ Key test files:
 - `test_config_command.py` — 240 tests: home page, plan mode/ask mode/verbose/engine/listen/model/reasoning sub-pages, toggle actions, callback vs command routing, button layout, engine-aware visibility, default resolution
 - `test_pi_compaction.py` — 6 tests: compaction start/end, aborted, no tokens, sequence
 - `test_proc_diag.py` — 56 tests: format_diag, is_cpu_active, collect_proc_diag (Linux /proc reads), ProcessDiag defaults, macOS ps backend (TIME parser, process table, tree CPU, dispatch — #689), read_cmdline_argv
-- `test_exec_runner.py` — 22 tests: event tracking (event_count, recent_events ring buffer, PID in StartedEvent meta), JsonlStreamState defaults
+- `test_exec_runner.py` — 50 tests: event tracking (event_count, recent_events ring buffer, PID in StartedEvent meta), JsonlStreamState defaults, watchdog approval-pending discriminator (registry probe first, non-positional ring scan fallback, same-tick `rate_limit_event`, #697)
 - `test_build_args.py` — 42 tests: CLI argument construction for all 6 engines, model/reasoning/permission flags
 - `test_telegram_files.py` — 17 tests: file helpers, deduplication, deny globs, default upload paths
 - `test_telegram_file_transfer_helpers.py` — 48 tests: `/file put` and `/file get` command handling, media groups, force overwrite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "untether"
 authors = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
 maintainers = [{name = "Little Bear Apps", email = "hello@littlebearapps.com"}]
-version = "0.35.5rc2"
+version = "0.35.5rc3"
 keywords = ["telegram", "claude-code", "codex", "opencode", "pi", "gemini-cli", "amp", "ai-agents", "coding-assistant", "remote-control", "cli-bridge"]
 description = "Run AI coding agents from your phone. Bridges Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp to Telegram with interactive permissions, voice input, cost tracking, and live progress."
 readme = {file = "README.md", content-type = "text/markdown"}

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ wheels = [
 
 [[package]]
 name = "untether"
-version = "0.35.5rc2"
+version = "0.35.5rc3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Cuts `0.35.5rc3` so the two fixes merged into `dev` today actually reach TestPyPI. A `dev` push **without** a version bump is a silent no-op there — `skip-existing` swallows the 400 and CI still reports success — so the rc bump is the publish.

| Issue | Fix on dev | Live verification |
|-------|-----------|-------------------|
| [#697](https://github.com/littlebearapps/untether/issues/697) | Watchdog approval-pending discriminator now consults the authoritative registry (`engine_state.awaiting_user_approval()` → `pending_control_requests_for_session()`); ring buffer kept as a non-positional True-only fallback (#707, `e8ea3d3`) | **Verified live** on `@untether_dev_bot`: the dev account's own rate limiting reproduced the issue's exact interleaving — `subprocess.approval_pending approval_pending=True source=watchdog last_event_type=rate_limit_event` with `control_request` at ring index -2. 0 `subprocess.liveness_stall` in the drive window; two approval waits of 6m22s / 4m53s finished `liveness_stalls=0` (stall canary unburnt) |
| [#698](https://github.com/littlebearapps/untether/issues/698) | Answered AskUserQuestion flows remembered briefly (300s TTL, 32-entry cap, channel-scoped); late tap → `ask_question.flow_already_answered` INFO + truthful "Already answered" toast; unknown flow still WARNs (#708, `ef30003`) | Happy path verified live twice (2-question and 1-question flows, both round-tripped, 0 `ask_question.flow_missing`). The late-tap branch rests on the pytest repro, **not** live evidence — `press_inline_button` re-reads the server-side keyboard before tapping, so once the #550 strip lands there is no button left to press. Stated as a limitation on the issue |

Docs reconciliation folded in: `CLAUDE.md`'s `## Tests` counts had drifted badly — 3021 → **3092** total, `test_exec_runner` 22 → **50**, `test_ask_user_question` 35 → **40**.

No CHANGELOG change needed — `v0.35.5 (unreleased)` already carries both issue-linked entries, and `validate_release.py` skips changelog validation for pre-releases (confirmed: *"Pre-release version — skipping changelog validation"*).

## Batching

The two fixes were deliberately **not** co-batched: #697 touches the watchdog/stall state machine, which `.claude/rules/workflow-commands.md` D-5 names as an independent high-risk surface requiring its own branch and PR. They landed as #707 and #708 separately, and this PR is a chore bump carrying neither. #708 needed a CHANGELOG conflict resolution against `dev` after #707 merged (both entries kept, `#697` first to match `dev`'s ordering).

## Tests
- Full suite: `uv run pytest` — **3092 passed, 2 skipped, 83.32% coverage**
- Lint: `uv run ruff check src/` — clean
- Format: `uv run ruff format --check src/ tests/` — 288 files already formatted
- Lockfile: `uv lock --check` — in sync
- Release validation: `python3 scripts/validate_release.py` — pre-release, changelog validation skipped as designed
- Integration: QA-3 already driven against `@untether_dev_bot` for both fixes (see the issue comments). Fleet rollout of this rc still needs the per-version attestation marker — `scripts/run-integration-tests.sh 0.35.5rc3 --manual` — which is deliberately **not** written here

## Follow-ups filed from the QA drive
- [#709](https://github.com/littlebearapps/untether/issues/709) — progress heartbeat re-renders over the in-place AskUserQuestion edit (Q2 shows Q1's labels); same one-message-two-writers root as #698
- [#710](https://github.com/littlebearapps/untether/issues/710) — concurrent taps on the final option raise `IndexError` at `ask_question.py:107`

🤖 Generated with [Claude Code](https://claude.com/claude-code)