### PR TITLE
feat(telegram): support native Codex image prompts

### DIFF
--- a/src/untether/runners/codex.py
+++ b/src/untether/runners/codex.py
@@ -510,12 +510,18 @@ class CodexRunner(ResumeTokenMixin, JsonlSubprocessRunner):
                 "--color=never",
             ]
         )
+        image_paths = run_options.image_paths if run_options is not None else ()
         if resume:
+            args.append("resume")
+            for image_path in image_paths:
+                args.extend(["--image", image_path])
             if resume.is_continue:
-                args.extend(["resume", "--last", "-"])
+                args.extend(["--last", "-"])
             else:
-                args.extend(["resume", resume.value, "-"])
+                args.extend([resume.value, "-"])
         else:
+            for image_path in image_paths:
+                args.extend(["--image", image_path])
             args.append("-")
         return args
 

--- a/src/untether/runners/run_options.py
+++ b/src/untether/runners/run_options.py
@@ -22,6 +22,9 @@ class EngineRunOptions:
     # means "follow global ``[loop] enabled``"; True/False is an explicit
     # per-chat override set via ``/config → 🔁 Loop mode``.
     loop_enabled: bool | None = None
+    # Native, runner-specific attachments. Telegram populates this only after
+    # resolving the effective engine to Codex; other runners ignore the field.
+    image_paths: tuple[str, ...] = ()
 
 
 # Canonical per-engine permission_mode value sets. Used by trigger config

--- a/src/untether/scheduler.py
+++ b/src/untether/scheduler.py
@@ -25,6 +25,7 @@ class ThreadJob:
     thread_id: ThreadId | None = None
     session_key: tuple[int, int | None] | None = None
     progress_ref: MessageRef | None = None
+    image_paths: tuple[str, ...] = ()
 
 
 RunJob = Callable[[ThreadJob], Awaitable[None]]
@@ -84,6 +85,7 @@ class ThreadScheduler:
         thread_id: ThreadId | None = None,
         session_key: tuple[int, int | None] | None = None,
         progress_ref: MessageRef | None = None,
+        image_paths: tuple[str, ...] = (),
     ) -> None:
         await self.enqueue(
             ThreadJob(
@@ -95,6 +97,7 @@ class ThreadScheduler:
                 thread_id=thread_id,
                 session_key=session_key,
                 progress_ref=progress_ref,
+                image_paths=image_paths,
             )
         )
 

--- a/src/untether/telegram/bridge.py
+++ b/src/untether/telegram/bridge.py
@@ -6,10 +6,8 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from pydantic import SecretStr
 
-from ..context import RunContext
 from ..logging import get_logger
 from ..markdown import MarkdownFormatter, MarkdownParts
-from ..model import ResumeToken
 from ..progress import ProgressState
 from ..runner_bridge import ExecBridgeConfig, RunningTask, RunningTasks
 from ..scheduler import ThreadScheduler
@@ -533,25 +531,14 @@ async def handle_callback_cancel(
 
 async def send_with_resume(
     cfg: TelegramBridgeConfig,
-    enqueue: Callable[
-        [
-            int,
-            int,
-            str,
-            ResumeToken,
-            RunContext | None,
-            int | None,
-            tuple[int, int | None] | None,
-            MessageRef | None,
-        ],
-        Awaitable[None],
-    ],
+    enqueue: Callable[..., Awaitable[None]],
     running_task: RunningTask,
     chat_id: int,
     user_msg_id: int,
     thread_id: int | None,
     session_key: tuple[int, int | None] | None,
     text: str,
+    image_paths: tuple[str, ...] = (),
 ) -> None:
     from .loop import send_with_resume as _send_with_resume
 
@@ -564,6 +551,7 @@ async def send_with_resume(
         thread_id,
         session_key,
         text,
+        image_paths,
     )
 
 

--- a/src/untether/telegram/commands/handlers.py
+++ b/src/untether/telegram/commands/handlers.py
@@ -9,6 +9,7 @@ from .executor import _should_show_resume_line as should_show_resume_line
 from .file_transfer import _handle_file_command as handle_file_command
 from .file_transfer import _handle_file_put_default as handle_file_put_default
 from .file_transfer import _save_file_put as save_file_put
+from .file_transfer import _save_file_put_group as save_file_put_group
 from .listen import _handle_listen_command as handle_listen_command
 from .media import _handle_media_group as handle_media_group
 from .menu import _reserved_commands as get_reserved_commands
@@ -47,6 +48,7 @@ __all__ = [
     "parse_slash_command",
     "run_engine",
     "save_file_put",
+    "save_file_put_group",
     "set_command_menu",
     "should_show_resume_line",
 ]

--- a/src/untether/telegram/commands/media.py
+++ b/src/untether/telegram/commands/media.py
@@ -39,6 +39,16 @@ async def _handle_media_group(
     ]
     | None = None,
     chat_prefs: ChatPrefsStore | None = None,
+    run_image_prompt: Callable[
+        [
+            TelegramIncomingMessage,
+            Sequence[TelegramIncomingMessage],
+            RunContext | None,
+            TopicStateStore | None,
+        ],
+        Awaitable[bool],
+    ]
+    | None = None,
 ) -> None:
     if not messages:
         return
@@ -84,6 +94,16 @@ async def _handle_media_group(
                 topic_store,
             )
             return
+    if (
+        run_image_prompt is not None
+        and all(
+            item.document is not None and item.document.is_image for item in ordered
+        )
+        and await run_image_prompt(command_msg, ordered, ambient_context, topic_store)
+    ):
+        return
+    if not cfg.files.enabled:
+        return
     if cfg.files.enabled and cfg.files.auto_put:
         caption_text = command_msg.text.strip()
         if cfg.files.auto_put_mode == "prompt" and caption_text:

--- a/src/untether/telegram/loop.py
+++ b/src/untether/telegram/loop.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
-from dataclasses import dataclass
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, replace
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -51,6 +51,7 @@ from .commands.handlers import (
     parse_slash_command,
     run_engine,
     save_file_put,
+    save_file_put_group,
     set_command_menu,
     should_show_resume_line,
 )
@@ -84,6 +85,9 @@ ForwardKey = tuple[int, int, int]
 MessageKey = tuple[int, int]
 _SEEN_MESSAGES_LIMIT = 2048
 _SEEN_UPDATES_LIMIT = 4096
+DEFAULT_IMAGE_ANALYSIS_PROMPT = (
+    "Analyse the attached image or images and respond to anything relevant in them."
+)
 
 _handle_file_put_default = handle_file_put_default
 
@@ -710,7 +714,9 @@ def _classify_message(
         and msg.media_group_id is None
     )
     is_media_group_document = (
-        files_enabled and msg.document is not None and msg.media_group_id is not None
+        msg.document is not None
+        and msg.media_group_id is not None
+        and (files_enabled or msg.document.is_image)
     )
     return MessageClassification(
         text=text,
@@ -965,19 +971,7 @@ class ResumeResolver:
         cfg: TelegramBridgeConfig,
         task_group: TaskGroup,
         running_tasks: Mapping[MessageRef, object],
-        enqueue_resume: Callable[
-            [
-                int,
-                int,
-                str,
-                ResumeToken,
-                RunContext | None,
-                int | None,
-                tuple[int, int | None] | None,
-                MessageRef | None,
-            ],
-            Awaitable[None],
-        ],
+        enqueue_resume: Callable[..., Awaitable[None]],
         topic_store: TopicStateStore | None,
         chat_session_store: ChatSessionStore | None,
     ) -> None:
@@ -1000,6 +994,7 @@ class ResumeResolver:
         topic_key: tuple[int, int] | None,
         engine_for_session: EngineId,
         prompt_text: str,
+        image_paths: tuple[str, ...] = (),
     ) -> ResumeDecision:
         if resume_token is not None:
             return ResumeDecision(
@@ -1020,6 +1015,7 @@ class ResumeResolver:
                     thread_id,
                     chat_session_key,
                     prompt_text,
+                    image_paths,
                 )
                 return ResumeDecision(resume_token=None, handled_by_running_task=True)
         if self._topic_store is not None and topic_key is not None:
@@ -1062,6 +1058,15 @@ class MediaGroupBuffer:
         run_prompt_from_upload: Callable[
             [TelegramIncomingMessage, str, ResolvedMessage], Awaitable[None]
         ],
+        run_image_prompt: Callable[
+            [
+                TelegramIncomingMessage,
+                Sequence[TelegramIncomingMessage],
+                RunContext | None,
+                TopicStateStore | None,
+            ],
+            Awaitable[bool],
+        ],
         resolve_prompt_message: Callable[
             [TelegramIncomingMessage, str, RunContext | None],
             Awaitable[ResolvedMessage | None],
@@ -1078,6 +1083,7 @@ class MediaGroupBuffer:
         self._reserved_chat_commands = reserved_chat_commands
         self._groups = groups
         self._run_prompt_from_upload = run_prompt_from_upload
+        self._run_image_prompt = run_image_prompt
         self._resolve_prompt_message = resolve_prompt_message
 
     def add(self, msg: TelegramIncomingMessage) -> None:
@@ -1134,6 +1140,7 @@ class MediaGroupBuffer:
                     self._run_prompt_from_upload,
                     self._resolve_prompt_message,
                     chat_prefs=self._chat_prefs,
+                    run_image_prompt=self._run_image_prompt,
                 )
                 logger.debug(
                     "media_group.flush.ok",
@@ -1267,25 +1274,14 @@ async def _send_queued_progress(
 
 async def send_with_resume(
     cfg: TelegramBridgeConfig,
-    enqueue: Callable[
-        [
-            int,
-            int,
-            str,
-            ResumeToken,
-            RunContext | None,
-            int | None,
-            tuple[int, int | None] | None,
-            MessageRef | None,
-        ],
-        Awaitable[None],
-    ],
+    enqueue: Callable[..., Awaitable[None]],
     running_task,
     chat_id: int,
     user_msg_id: int,
     thread_id: int | None,
     session_key: tuple[int, int | None] | None,
     text: str,
+    image_paths: tuple[str, ...] = (),
 ) -> None:
     reply = partial(
         send_plain,
@@ -1309,7 +1305,7 @@ async def send_with_resume(
         resume_token=resume,
         context=running_task.context,
     )
-    await enqueue(
+    args = (
         chat_id,
         user_msg_id,
         text,
@@ -1319,6 +1315,10 @@ async def send_with_resume(
         session_key,
         progress_ref,
     )
+    if image_paths:
+        await enqueue(*args, image_paths)
+    else:
+        await enqueue(*args)
 
 
 async def _notify_drain_start(
@@ -1863,6 +1863,7 @@ async def run_main_loop(
                 | None = None,
                 engine_override: EngineId | None = None,
                 progress_ref: MessageRef | None = None,
+                image_paths: tuple[str, ...] = (),
             ) -> None:
                 topic_key = (
                     (chat_id, thread_id)
@@ -1905,6 +1906,10 @@ async def run_main_loop(
                 run_options = _apply_trigger_permission_override(
                     run_options, context, engine=engine_for_overrides
                 )
+                if image_paths and engine_for_overrides == "codex":
+                    run_options = replace(
+                        run_options or EngineRunOptions(), image_paths=image_paths
+                    )
                 await run_engine(
                     exec_cfg=cfg.exec_cfg,
                     runtime=cfg.runtime,
@@ -1928,17 +1933,16 @@ async def run_main_loop(
 
             async def run_thread_job(job: ThreadJob) -> None:
                 await run_job(
-                    cast(int, job.chat_id),
-                    cast(int, job.user_msg_id),
-                    job.text,
-                    job.resume_token,
-                    job.context,
-                    cast(int | None, job.thread_id),
-                    job.session_key,
-                    None,
-                    scheduler.note_thread_known,
-                    None,
-                    job.progress_ref,
+                    chat_id=cast(int, job.chat_id),
+                    user_msg_id=cast(int, job.user_msg_id),
+                    text=job.text,
+                    resume_token=job.resume_token,
+                    context=job.context,
+                    thread_id=cast(int | None, job.thread_id),
+                    chat_session_key=job.session_key,
+                    on_thread_known=scheduler.note_thread_known,
+                    progress_ref=job.progress_ref,
+                    image_paths=job.image_paths,
                 )
 
             scheduler = ThreadScheduler(task_group=tg, run_job=run_thread_job)
@@ -2156,6 +2160,7 @@ async def run_main_loop(
                 chat_session_key: tuple[int, int | None] | None,
                 reply_ref: MessageRef | None,
                 reply_id: int | None,
+                image_paths: tuple[str, ...] = (),
             ) -> None:
                 chat_id = msg.chat_id
                 user_msg_id = msg.message_id
@@ -2177,6 +2182,7 @@ async def run_main_loop(
                     topic_key=topic_key,
                     engine_for_session=engine_resolution.engine,
                     prompt_text=prompt_text,
+                    image_paths=image_paths,
                 )
                 if resume_decision.handled_by_running_task:
                     return
@@ -2193,6 +2199,8 @@ async def run_main_loop(
                         reply_ref,
                         scheduler.note_thread_known,
                         engine_override,
+                        None,
+                        image_paths,
                     )
                     return
                 progress_ref = await _send_queued_progress(
@@ -2212,12 +2220,14 @@ async def run_main_loop(
                     msg.thread_id,
                     chat_session_key,
                     progress_ref,
+                    image_paths,
                 )
 
             async def run_prompt_from_upload(
                 msg: TelegramIncomingMessage,
                 prompt_text: str,
                 resolved: ResolvedMessage,
+                image_paths: tuple[str, ...] = (),
             ) -> None:
                 reply_id = msg.reply_to_message_id
                 reply_ref = (
@@ -2241,7 +2251,118 @@ async def run_main_loop(
                     chat_session_key=chat_session_key,
                     reply_ref=reply_ref,
                     reply_id=reply_id,
+                    image_paths=image_paths,
                 )
+
+            async def run_native_image_prompt(
+                msg: TelegramIncomingMessage,
+                messages: Sequence[TelegramIncomingMessage],
+                ambient_context: RunContext | None,
+                topic_store: TopicStateStore | None,
+            ) -> bool:
+                if not messages or any(
+                    item.document is None or not item.document.is_image
+                    for item in messages
+                ):
+                    return False
+                caption = msg.text.strip()
+                prompt_source = caption or DEFAULT_IMAGE_ANALYSIS_PROMPT
+                reply = make_reply(cfg, msg)
+                try:
+                    resolved = cfg.runtime.resolve_message(
+                        text=prompt_source,
+                        reply_text=msg.reply_to_text,
+                        ambient_context=ambient_context,
+                        chat_id=msg.chat_id,
+                    )
+                except DirectiveError as exc:
+                    await reply(text=f"error:\n{exc}")
+                    return True
+                topic_key = resolve_topic_key(msg)
+                engine_resolution = await resolve_engine_defaults(
+                    explicit_engine=resolved.engine_override,
+                    context=resolved.context,
+                    chat_id=msg.chat_id,
+                    topic_key=topic_key,
+                )
+                running_engine: EngineId | None = None
+                if msg.reply_to_message_id is not None:
+                    running_task = state.running_tasks.get(
+                        MessageRef(
+                            channel_id=msg.chat_id,
+                            message_id=msg.reply_to_message_id,
+                        )
+                    )
+                    if running_task is not None:
+                        if running_task.resume is not None:
+                            running_engine = running_task.resume.engine
+                        elif running_task.edits is not None:
+                            running_engine = running_task.edits.tracker.engine
+                effective_engine = running_engine or (
+                    resolved.resume_token.engine
+                    if resolved.resume_token is not None
+                    else engine_resolution.engine
+                )
+                if effective_engine != "codex":
+                    return False
+                if not resolved.prompt.strip():
+                    resolved = replace(
+                        resolved,
+                        prompt=DEFAULT_IMAGE_ANALYSIS_PROMPT,
+                    )
+                chat_project = (
+                    _topics_chat_project(cfg, msg.chat_id)
+                    if cfg.topics.enabled
+                    else None
+                )
+                _, ok = await ensure_topic_context(
+                    resolved=resolved,
+                    ambient_context=ambient_context,
+                    topic_key=topic_key,
+                    chat_project=chat_project,
+                    reply=reply,
+                )
+                if not ok:
+                    return True
+
+                ordered = sorted(messages, key=lambda item: item.message_id)
+                if len(ordered) == 1:
+                    saved = await save_file_put(
+                        cfg,
+                        msg,
+                        "",
+                        resolved.context,
+                        topic_store,
+                    )
+                    if saved is None:
+                        return True
+                    image_paths = (saved.rel_path.as_posix(),)
+                else:
+                    saved_group = await save_file_put_group(
+                        cfg,
+                        msg,
+                        "",
+                        ordered,
+                        resolved.context,
+                        topic_store,
+                    )
+                    if saved_group is None:
+                        return True
+                    if saved_group.failed or len(saved_group.saved) != len(ordered):
+                        await reply(text="failed to upload one or more images.")
+                        return True
+                    image_paths = tuple(
+                        item.rel_path.as_posix()
+                        for item in saved_group.saved
+                        if item.rel_path is not None
+                    )
+                await run_prompt_from_upload(
+                    msg,
+                    resolved.prompt,
+                    resolved,
+                    image_paths,
+                )
+                return True
 
             async def _dispatch_pending_prompt(pending: _PendingPrompt) -> None:
                 msg = pending.msg
@@ -2344,6 +2465,7 @@ async def run_main_loop(
                 reserved_chat_commands=state.reserved_chat_commands,
                 groups=state.media_groups,
                 run_prompt_from_upload=run_prompt_from_upload,
+                run_image_prompt=run_native_image_prompt,
                 resolve_prompt_message=resolve_prompt_message,
             )
 
@@ -2528,6 +2650,13 @@ async def run_main_loop(
                     if cfg.voice_show_transcription:
                         await reply(text=f"🎙 {text}")
                 if msg.document is not None:
+                    if msg.document.is_image and await run_native_image_prompt(
+                        msg,
+                        (msg,),
+                        ambient_context,
+                        state.topic_store,
+                    ):
+                        return
                     if cfg.files.enabled and cfg.files.auto_put:
                         caption_text = text.strip()
                         if cfg.files.auto_put_mode == "prompt" and caption_text:

--- a/src/untether/telegram/loop.py
+++ b/src/untether/telegram/loop.py
@@ -2567,6 +2567,27 @@ async def run_main_loop(
                         value="",
                         is_continue=True,
                     )
+                    image_paths: tuple[str, ...] = ()
+                    if (
+                        engine_resolution.engine == "codex"
+                        and msg.document is not None
+                        and msg.document.is_image
+                    ):
+                        saved = await save_file_put(
+                            cfg,
+                            msg,
+                            "",
+                            resolved.context,
+                            state.topic_store,
+                        )
+                        if saved is None:
+                            return
+                        image_paths = (saved.rel_path.as_posix(),)
+                        if not resolved.prompt.strip():
+                            resolved = replace(
+                                resolved,
+                                prompt=DEFAULT_IMAGE_ANALYSIS_PROMPT,
+                            )
                     resolved = ResolvedMessage(
                         prompt=resolved.prompt,
                         resume_token=continue_token,
@@ -2581,6 +2602,7 @@ async def run_main_loop(
                         chat_session_key=chat_session_key,
                         reply_ref=reply_ref,
                         reply_id=reply_id,
+                        image_paths=image_paths,
                     )
                     return
                 if command_id is not None and _dispatch_builtin_command(

--- a/src/untether/telegram/parsing.py
+++ b/src/untether/telegram/parsing.py
@@ -192,12 +192,18 @@ def _best_photo(photos: list[PhotoSize] | None) -> PhotoSize | None:
 
 
 def _document_from_media(media: Document | Video) -> TelegramDocument:
+    is_image = (
+        isinstance(media, Document)
+        and media.mime_type is not None
+        and media.mime_type.lower().startswith("image/")
+    )
     return TelegramDocument(
         file_id=media.file_id,
         file_name=media.file_name,
         mime_type=media.mime_type,
         file_size=media.file_size,
         raw=msgspec.to_builtins(media),
+        is_image=is_image,
     )
 
 
@@ -205,9 +211,10 @@ def _document_from_photo(photo: PhotoSize) -> TelegramDocument:
     return TelegramDocument(
         file_id=photo.file_id,
         file_name=None,
-        mime_type=None,
+        mime_type="image/jpeg",
         file_size=photo.file_size,
         raw=msgspec.to_builtins(photo),
+        is_image=True,
     )
 
 

--- a/src/untether/telegram/types.py
+++ b/src/untether/telegram/types.py
@@ -20,6 +20,7 @@ class TelegramDocument:
     mime_type: str | None
     file_size: int | None
     raw: dict[str, Any]
+    is_image: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_runner_run_options.py
+++ b/tests/test_runner_run_options.py
@@ -30,6 +30,74 @@ def test_codex_run_options_override_model_and_reasoning() -> None:
     ]
 
 
+def test_codex_run_options_place_images_for_new_and_resumed_sessions() -> None:
+    runner = CodexRunner(codex_cmd="codex", extra_args=[])
+    options = EngineRunOptions(image_paths=("incoming/one.jpg", "incoming/two.png"))
+
+    with apply_run_options(options):
+        new_args = runner.build_args("inspect", None, state=None)
+        resumed_args = runner.build_args(
+            "inspect",
+            ResumeToken(engine="codex", value="session-123"),
+            state=None,
+        )
+
+    assert new_args == [
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "--color=never",
+        "--image",
+        "incoming/one.jpg",
+        "--image",
+        "incoming/two.png",
+        "-",
+    ]
+    assert resumed_args == [
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "--color=never",
+        "resume",
+        "--image",
+        "incoming/one.jpg",
+        "--image",
+        "incoming/two.png",
+        "session-123",
+        "-",
+    ]
+
+
+def test_codex_run_options_place_images_for_continue_session() -> None:
+    runner = CodexRunner(codex_cmd="codex", extra_args=[])
+    options = EngineRunOptions(image_paths=("incoming/continued.png",))
+
+    with apply_run_options(options):
+        args = runner.build_args(
+            "inspect",
+            ResumeToken(engine="codex", value="", is_continue=True),
+            state=None,
+        )
+
+    assert args == [
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "--color=never",
+        "resume",
+        "--image",
+        "incoming/continued.png",
+        "--last",
+        "-",
+    ]
+
+
 def test_claude_run_options_override_model() -> None:
     runner = ClaudeRunner(claude_cmd="claude", model="claude-sonnet")
     with apply_run_options(EngineRunOptions(model="claude-opus")):

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -25,6 +25,7 @@ from untether.progress import ProgressTracker
 from untether.router import AutoRouter, RunnerEntry
 from untether.runner_bridge import ExecBridgeConfig, RunningTask
 from untether.runners.mock import Return, ScriptRunner, Sleep, Wait
+from untether.runners.run_options import EngineRunOptions
 from untether.scheduler import ThreadScheduler
 from untether.settings import TelegramFilesSettings, TelegramTopicsSettings
 from untether.telegram.api_models import Chat, File, ForumTopic, Message, Update, User
@@ -738,6 +739,27 @@ async def test_handle_cancel_cancels_queued_job() -> None:
     assert transport.edit_calls
     assert "cancelled" in transport.edit_calls[0]["message"].text.lower()
     assert await scheduler.cancel_queued(123, progress_ref.message_id) is None
+
+
+@pytest.mark.anyio
+async def test_scheduler_preserves_image_paths_for_queued_resume() -> None:
+    async def _noop_run_job(_) -> None:
+        return None
+
+    scheduler = ThreadScheduler(task_group=_NoopTaskGroup(), run_job=_noop_run_job)
+    progress_ref = MessageRef(channel_id=123, message_id=56)
+    await scheduler.enqueue_resume(
+        chat_id=123,
+        user_msg_id=11,
+        text="inspect",
+        resume_token=ResumeToken(engine=CODEX_ENGINE, value="sid"),
+        progress_ref=progress_ref,
+        image_paths=("incoming/queued.png",),
+    )
+
+    queued = scheduler.queued_for_chat(123)
+    assert len(queued) == 1
+    assert queued[0].image_paths == ("incoming/queued.png",)
 
 
 @pytest.mark.anyio
@@ -1623,31 +1645,21 @@ async def test_reasoning_command_show_reports_overrides(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
-async def test_send_with_resume_waits_for_token() -> None:
+async def test_send_with_resume_waits_for_token_and_preserves_images() -> None:
     transport = FakeTransport()
     cfg = make_cfg(transport)
-    sent: list[
-        tuple[
-            int,
-            int,
-            str,
-            ResumeToken,
-            RunContext | None,
-            int | None,
-            tuple[int, int | None] | None,
-            MessageRef | None,
-        ]
-    ] = []
+    sent: list[tuple[Any, ...]] = []
 
     async def enqueue(
         chat_id: int,
         user_msg_id: int,
         text: str,
-        resume: ResumeToken,
+        resume: Any,
         context: RunContext | None,
         thread_id: int | None,
         session_key: tuple[int, int | None] | None,
         progress_ref: MessageRef | None,
+        image_paths: tuple[str, ...] = (),
     ) -> None:
         sent.append(
             (
@@ -1659,6 +1671,7 @@ async def test_send_with_resume_waits_for_token() -> None:
                 thread_id,
                 session_key,
                 progress_ref,
+                image_paths,
             )
         )
 
@@ -1680,6 +1693,7 @@ async def test_send_with_resume_waits_for_token() -> None:
             None,
             None,
             "hello",
+            ("incoming/running.png",),
         )
 
     assert len(sent) == 1
@@ -1693,6 +1707,7 @@ async def test_send_with_resume_waits_for_token() -> None:
         None,
     )
     assert sent[0][7] == transport.send_calls[0]["ref"]
+    assert sent[0][8] == ("incoming/running.png",)
     assert transport.send_calls
     assert "queued" in transport.send_calls[0]["message"].text.lower()
 
@@ -2753,6 +2768,535 @@ async def test_run_main_loop_forwarded_document_still_uploads(
     prompt_text, _ = runner.calls[0]
     assert "do thing" in prompt_text
     assert "[uploaded file: incoming/hello.txt]" in prompt_text
+
+
+@pytest.mark.parametrize(
+    ("caption", "reply_text", "expected_prompt", "expected_resume"),
+    [
+        ("inspect this diagram", None, "inspect this diagram", None),
+        (
+            "",
+            "codex resume session-123",
+            telegram_loop.DEFAULT_IMAGE_ANALYSIS_PROMPT,
+            ResumeToken(engine=CODEX_ENGINE, value="session-123"),
+        ),
+    ],
+)
+@pytest.mark.anyio
+async def test_run_main_loop_routes_image_to_codex_out_of_band(
+    tmp_path: Path,
+    monkeypatch,
+    caption: str,
+    reply_text: str | None,
+    expected_prompt: str,
+    expected_resume: ResumeToken | None,
+) -> None:
+    payload = b"image bytes"
+
+    class _ImageBot(FakeBot):
+        async def get_file(self, file_id: str) -> File | None:
+            assert file_id == "image-1"
+            return File(file_path="photos/diagram.png")
+
+        async def download_file(self, file_path: str) -> bytes | None:
+            assert file_path == "photos/diagram.png"
+            return payload
+
+    runner = ScriptRunner([Return(answer="ok")], engine=CODEX_ENGINE)
+    projects = ProjectsConfig(
+        projects={
+            "proj": ProjectConfig(
+                alias="proj",
+                path=tmp_path,
+                worktrees_dir=Path(".worktrees"),
+            )
+        },
+        default_project="proj",
+    )
+    runtime = TransportRuntime(router=_make_router(runner), projects=projects)
+    transport = FakeTransport()
+    cfg = TelegramBridgeConfig(
+        bot=_ImageBot(),
+        runtime=runtime,
+        chat_id=123,
+        startup_msg="",
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=MarkdownPresenter(),
+            final_notify=True,
+        ),
+        forward_coalesce_s=FAST_FORWARD_COALESCE_S,
+        media_group_debounce_s=FAST_MEDIA_GROUP_DEBOUNCE_S,
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def _capture_run_engine(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(telegram_loop, "run_engine", _capture_run_engine)
+
+    async def poller(_cfg: TelegramBridgeConfig):
+        yield TelegramIncomingMessage(
+            transport="telegram",
+            chat_id=123,
+            message_id=1,
+            text=caption,
+            reply_to_message_id=99 if reply_text is not None else None,
+            reply_to_text=reply_text,
+            sender_id=123,
+            chat_type="private",
+            document=TelegramDocument(
+                file_id="image-1",
+                file_name="diagram.png",
+                mime_type="image/png",
+                file_size=len(payload),
+                raw={"file_id": "image-1"},
+                is_image=True,
+            ),
+        )
+
+    await run_main_loop(cfg, poller)
+
+    assert (tmp_path / "incoming" / "diagram.png").read_bytes() == payload
+    assert len(calls) == 1
+    assert calls[0]["text"] == expected_prompt
+    assert calls[0]["resume_token"] == expected_resume
+    options = calls[0]["run_options"]
+    assert isinstance(options, EngineRunOptions)
+    assert options.image_paths == ("incoming/diagram.png",)
+
+
+@pytest.mark.anyio
+async def test_uncaptioned_image_uses_persisted_chat_session_resume_after_restart(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    payload = b"chat image"
+    resume = ResumeToken(engine=CODEX_ENGINE, value="persisted-chat-session")
+    state_path = tmp_path / "untether.toml"
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    store = ChatSessionStore(resolve_sessions_path(state_path))
+    await store.set_session_resume(123, None, resume)
+
+    class _ImageBot(FakeBot):
+        async def get_file(self, file_id: str) -> File | None:
+            assert file_id == "chat-image"
+            return File(file_path="photos/chat.png")
+
+        async def download_file(self, file_path: str) -> bytes | None:
+            assert file_path == "photos/chat.png"
+            return payload
+
+    runner = ScriptRunner([Return(answer="ok")], engine=CODEX_ENGINE)
+    projects = ProjectsConfig(
+        projects={
+            "proj": ProjectConfig(
+                alias="proj",
+                path=project_dir,
+                worktrees_dir=Path(".worktrees"),
+            )
+        },
+        default_project="proj",
+    )
+    transport = FakeTransport()
+    cfg = TelegramBridgeConfig(
+        bot=_ImageBot(),
+        runtime=TransportRuntime(
+            router=_make_router(runner),
+            projects=projects,
+            config_path=state_path,
+        ),
+        chat_id=123,
+        startup_msg="",
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=MarkdownPresenter(),
+            final_notify=True,
+        ),
+        forward_coalesce_s=FAST_FORWARD_COALESCE_S,
+        media_group_debounce_s=FAST_MEDIA_GROUP_DEBOUNCE_S,
+        session_mode="chat",
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def _capture_run_engine(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(telegram_loop, "run_engine", _capture_run_engine)
+
+    async def poller(_cfg: TelegramBridgeConfig):
+        yield TelegramIncomingMessage(
+            transport="telegram",
+            chat_id=123,
+            message_id=1,
+            text="",
+            reply_to_message_id=None,
+            reply_to_text=None,
+            sender_id=123,
+            chat_type="private",
+            document=TelegramDocument(
+                file_id="chat-image",
+                file_name="chat.png",
+                mime_type="image/png",
+                file_size=len(payload),
+                raw={"file_id": "chat-image"},
+                is_image=True,
+            ),
+        )
+
+    await run_main_loop(cfg, poller)
+
+    assert (project_dir / "incoming" / "chat.png").read_bytes() == payload
+    assert len(calls) == 1
+    assert calls[0]["text"] == telegram_loop.DEFAULT_IMAGE_ANALYSIS_PROMPT
+    assert calls[0]["resume_token"] == resume
+    options = calls[0]["run_options"]
+    assert isinstance(options, EngineRunOptions)
+    assert options.image_paths == ("incoming/chat.png",)
+
+
+@pytest.mark.anyio
+async def test_uncaptioned_image_uses_persisted_topic_resume_after_restart(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    chat_id = -100
+    thread_id = 77
+    payload = b"topic image"
+    resume = ResumeToken(engine=CODEX_ENGINE, value="persisted-topic-session")
+    state_path = tmp_path / "untether.toml"
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    store = TopicStateStore(resolve_state_path(state_path))
+    await store.set_session_resume(chat_id, thread_id, resume)
+
+    class _ImageBot(FakeBot):
+        async def get_file(self, file_id: str) -> File | None:
+            assert file_id == "topic-image"
+            return File(file_path="photos/topic.png")
+
+        async def download_file(self, file_path: str) -> bytes | None:
+            assert file_path == "photos/topic.png"
+            return payload
+
+    runner = ScriptRunner([Return(answer="ok")], engine=CODEX_ENGINE)
+    projects = ProjectsConfig(
+        projects={
+            "proj": ProjectConfig(
+                alias="proj",
+                path=project_dir,
+                worktrees_dir=Path(".worktrees"),
+                chat_id=chat_id,
+            )
+        },
+        default_project=None,
+        chat_map={chat_id: "proj"},
+    )
+    transport = FakeTransport()
+    cfg = TelegramBridgeConfig(
+        bot=_ImageBot(),
+        runtime=TransportRuntime(
+            router=_make_router(runner),
+            projects=projects,
+            config_path=state_path,
+        ),
+        chat_id=chat_id,
+        startup_msg="",
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=MarkdownPresenter(),
+            final_notify=True,
+        ),
+        forward_coalesce_s=FAST_FORWARD_COALESCE_S,
+        media_group_debounce_s=FAST_MEDIA_GROUP_DEBOUNCE_S,
+        topics=TelegramTopicsSettings(enabled=True, scope="main"),
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def _capture_run_engine(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(telegram_loop, "run_engine", _capture_run_engine)
+
+    async def poller(_cfg: TelegramBridgeConfig):
+        yield TelegramIncomingMessage(
+            transport="telegram",
+            chat_id=chat_id,
+            message_id=1,
+            text="",
+            reply_to_message_id=None,
+            reply_to_text=None,
+            sender_id=123,
+            thread_id=thread_id,
+            is_topic_message=True,
+            chat_type="supergroup",
+            is_forum=True,
+            document=TelegramDocument(
+                file_id="topic-image",
+                file_name="topic.png",
+                mime_type="image/png",
+                file_size=len(payload),
+                raw={"file_id": "topic-image"},
+                is_image=True,
+            ),
+        )
+
+    await run_main_loop(cfg, poller)
+
+    assert (project_dir / "incoming" / "topic.png").read_bytes() == payload
+    assert len(calls) == 1
+    assert calls[0]["text"] == telegram_loop.DEFAULT_IMAGE_ANALYSIS_PROMPT
+    assert calls[0]["resume_token"] == resume
+    options = calls[0]["run_options"]
+    assert isinstance(options, EngineRunOptions)
+    assert options.image_paths == ("incoming/topic.png",)
+
+
+@pytest.mark.anyio
+async def test_run_main_loop_image_download_failure_does_not_start_codex(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    class _FailingImageBot(FakeBot):
+        async def get_file(self, file_id: str) -> File | None:
+            return File(file_path="photos/broken.png")
+
+        async def download_file(self, file_path: str) -> bytes | None:
+            return None
+
+    runner = ScriptRunner([Return(answer="unexpected")], engine=CODEX_ENGINE)
+    projects = ProjectsConfig(
+        projects={
+            "proj": ProjectConfig(
+                alias="proj", path=tmp_path, worktrees_dir=Path(".worktrees")
+            )
+        },
+        default_project="proj",
+    )
+    transport = FakeTransport()
+    cfg = TelegramBridgeConfig(
+        bot=_FailingImageBot(),
+        runtime=TransportRuntime(router=_make_router(runner), projects=projects),
+        chat_id=123,
+        startup_msg="",
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=MarkdownPresenter(),
+            final_notify=True,
+        ),
+        forward_coalesce_s=FAST_FORWARD_COALESCE_S,
+        media_group_debounce_s=FAST_MEDIA_GROUP_DEBOUNCE_S,
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def _capture_run_engine(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(telegram_loop, "run_engine", _capture_run_engine)
+
+    async def poller(_cfg: TelegramBridgeConfig):
+        yield TelegramIncomingMessage(
+            transport="telegram",
+            chat_id=123,
+            message_id=1,
+            text="",
+            reply_to_message_id=None,
+            reply_to_text=None,
+            sender_id=123,
+            chat_type="private",
+            document=TelegramDocument(
+                file_id="broken-image",
+                file_name="broken.png",
+                mime_type="image/png",
+                file_size=10,
+                raw={"file_id": "broken-image"},
+                is_image=True,
+            ),
+        )
+
+    await run_main_loop(cfg, poller)
+
+    assert calls == []
+    assert not (tmp_path / "incoming" / "broken.png").exists()
+    assert any(
+        "failed to download file" in call["message"].text.lower()
+        for call in transport.send_calls
+    )
+
+
+@pytest.mark.anyio
+async def test_run_main_loop_preserves_media_group_image_order(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    payloads = {
+        "photos/first.jpg": b"first",
+        "photos/second.jpg": b"second",
+    }
+    paths = {"image-1": "photos/first.jpg", "image-2": "photos/second.jpg"}
+
+    class _ImageBot(FakeBot):
+        async def get_file(self, file_id: str) -> File | None:
+            return File(file_path=paths[file_id])
+
+        async def download_file(self, file_path: str) -> bytes | None:
+            return payloads[file_path]
+
+    runner = ScriptRunner([Return(answer="ok")], engine=CODEX_ENGINE)
+    projects = ProjectsConfig(
+        projects={
+            "proj": ProjectConfig(
+                alias="proj",
+                path=tmp_path,
+                worktrees_dir=Path(".worktrees"),
+            )
+        },
+        default_project="proj",
+    )
+    transport = FakeTransport()
+    cfg = TelegramBridgeConfig(
+        bot=_ImageBot(),
+        runtime=TransportRuntime(router=_make_router(runner), projects=projects),
+        chat_id=123,
+        startup_msg="",
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=MarkdownPresenter(),
+            final_notify=True,
+        ),
+        forward_coalesce_s=FAST_FORWARD_COALESCE_S,
+        media_group_debounce_s=BATCH_MEDIA_GROUP_DEBOUNCE_S,
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def _capture_run_engine(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(telegram_loop, "run_engine", _capture_run_engine)
+    messages = [
+        TelegramIncomingMessage(
+            transport="telegram",
+            chat_id=123,
+            message_id=message_id,
+            text="",
+            reply_to_message_id=None,
+            reply_to_text=None,
+            sender_id=123,
+            chat_type="private",
+            media_group_id="album-1",
+            document=TelegramDocument(
+                file_id=file_id,
+                file_name=file_name,
+                mime_type="image/jpeg",
+                file_size=len(payloads[file_path]),
+                raw={"file_id": file_id},
+                is_image=True,
+            ),
+        )
+        for message_id, file_id, file_name, file_path in (
+            (2, "image-2", "second.jpg", "photos/second.jpg"),
+            (1, "image-1", "first.jpg", "photos/first.jpg"),
+        )
+    ]
+    stop_polling = anyio.Event()
+
+    async def poller(_cfg: TelegramBridgeConfig):
+        for message in messages:
+            yield message
+        await stop_polling.wait()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(run_main_loop, cfg, poller)
+        try:
+            with anyio.fail_after(5):
+                while not calls:
+                    await anyio.sleep(0.01)
+            options = calls[0]["run_options"]
+            assert isinstance(options, EngineRunOptions)
+            assert calls[0]["text"] == telegram_loop.DEFAULT_IMAGE_ANALYSIS_PROMPT
+            assert options.image_paths == (
+                "incoming/first.jpg",
+                "incoming/second.jpg",
+            )
+        finally:
+            stop_polling.set()
+            tg.cancel_scope.cancel()
+
+
+@pytest.mark.anyio
+async def test_run_main_loop_keeps_non_codex_image_upload_prompt_flow(
+    tmp_path: Path,
+) -> None:
+    payload = b"image bytes"
+
+    class _ImageBot(FakeBot):
+        async def get_file(self, file_id: str) -> File | None:
+            assert file_id == "image-1"
+            return File(file_path="photos/diagram.png")
+
+        async def download_file(self, file_path: str) -> bytes | None:
+            assert file_path == "photos/diagram.png"
+            return payload
+
+    runner = ScriptRunner([Return(answer="ok")], engine="claude")
+    projects = ProjectsConfig(
+        projects={
+            "proj": ProjectConfig(
+                alias="proj",
+                path=tmp_path,
+                worktrees_dir=Path(".worktrees"),
+            )
+        },
+        default_project="proj",
+    )
+    transport = FakeTransport()
+    cfg = TelegramBridgeConfig(
+        bot=_ImageBot(),
+        runtime=TransportRuntime(router=_make_router(runner), projects=projects),
+        chat_id=123,
+        startup_msg="",
+        exec_cfg=ExecBridgeConfig(
+            transport=transport,
+            presenter=MarkdownPresenter(),
+            final_notify=True,
+        ),
+        forward_coalesce_s=FAST_FORWARD_COALESCE_S,
+        media_group_debounce_s=FAST_MEDIA_GROUP_DEBOUNCE_S,
+        files=TelegramFilesSettings(
+            enabled=True,
+            auto_put=True,
+            auto_put_mode="prompt",
+        ),
+    )
+
+    async def poller(_cfg: TelegramBridgeConfig):
+        yield TelegramIncomingMessage(
+            transport="telegram",
+            chat_id=123,
+            message_id=1,
+            text="inspect this diagram",
+            reply_to_message_id=None,
+            reply_to_text=None,
+            sender_id=123,
+            chat_type="private",
+            document=TelegramDocument(
+                file_id="image-1",
+                file_name="diagram.png",
+                mime_type="image/png",
+                file_size=len(payload),
+                raw={"file_id": "image-1"},
+                is_image=True,
+            ),
+        )
+
+    await run_main_loop(cfg, poller)
+
+    assert len(runner.calls) == 1
+    prompt, _ = runner.calls[0]
+    assert prompt.endswith(
+        "inspect this diagram\n\n[uploaded file: incoming/diagram.png]"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -2867,6 +2867,80 @@ async def test_run_main_loop_routes_image_to_codex_out_of_band(
 
 
 @pytest.mark.anyio
+async def test_run_main_loop_continue_command_preserves_image(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    payload = b"continued image"
+
+    class _ImageBot(FakeBot):
+        async def get_file(self, file_id: str) -> File | None:
+            return File(file_path="photos/continued.png")
+
+        async def download_file(self, file_path: str) -> bytes | None:
+            return payload
+
+    runner = ScriptRunner([Return(answer="ok")], engine=CODEX_ENGINE)
+    projects = ProjectsConfig(
+        projects={
+            "proj": ProjectConfig(
+                alias="proj", path=tmp_path, worktrees_dir=Path(".worktrees")
+            )
+        },
+        default_project="proj",
+    )
+    cfg = TelegramBridgeConfig(
+        bot=_ImageBot(),
+        runtime=TransportRuntime(router=_make_router(runner), projects=projects),
+        chat_id=123,
+        startup_msg="",
+        exec_cfg=ExecBridgeConfig(
+            transport=FakeTransport(),
+            presenter=MarkdownPresenter(),
+            final_notify=True,
+        ),
+        forward_coalesce_s=FAST_FORWARD_COALESCE_S,
+        media_group_debounce_s=FAST_MEDIA_GROUP_DEBOUNCE_S,
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def _capture_run_engine(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(telegram_loop, "run_engine", _capture_run_engine)
+
+    async def poller(_cfg: TelegramBridgeConfig):
+        yield TelegramIncomingMessage(
+            transport="telegram",
+            chat_id=123,
+            message_id=1,
+            text="/continue inspect this",
+            reply_to_message_id=None,
+            reply_to_text=None,
+            sender_id=123,
+            chat_type="private",
+            document=TelegramDocument(
+                file_id="continued-image",
+                file_name="continued.png",
+                mime_type="image/png",
+                file_size=len(payload),
+                raw={"file_id": "continued-image"},
+                is_image=True,
+            ),
+        )
+
+    await run_main_loop(cfg, poller)
+
+    assert len(calls) == 1
+    assert calls[0]["text"] == "inspect this"
+    resume = calls[0]["resume_token"]
+    assert resume is not None and resume.is_continue
+    options = calls[0]["run_options"]
+    assert isinstance(options, EngineRunOptions)
+    assert options.image_paths == ("incoming/continued.png",)
+
+
+@pytest.mark.anyio
 async def test_uncaptioned_image_uses_persisted_chat_session_resume_after_restart(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_telegram_incoming.py
+++ b/tests/test_telegram_incoming.py
@@ -163,6 +163,30 @@ def test_parse_incoming_update_document_message() -> None:
     assert msg.document.file_name == "doc.txt"
     assert msg.document.mime_type == "text/plain"
     assert msg.document.file_size == 4321
+    assert msg.document.is_image is False
+
+
+def test_parse_incoming_update_image_document() -> None:
+    update = Update(
+        update_id=1,
+        message=Message(
+            message_id=10,
+            caption="inspect this",
+            chat=Chat(id=123, type="private"),
+            document=Document(
+                file_id="image-id",
+                file_name="diagram.png",
+                mime_type="image/png",
+                file_size=4321,
+            ),
+        ),
+    )
+
+    msg = parse_incoming_update(update, chat_id=123)
+
+    assert isinstance(msg, TelegramIncomingMessage)
+    assert msg.document is not None
+    assert msg.document.is_image is True
 
 
 def test_parse_incoming_update_photo_message() -> None:
@@ -196,7 +220,9 @@ def test_parse_incoming_update_photo_message() -> None:
     assert msg.document is not None
     assert msg.document.file_id == "large"
     assert msg.document.file_name is None
+    assert msg.document.mime_type == "image/jpeg"
     assert msg.document.file_size == 1000
+    assert msg.document.is_image is True
 
 
 def test_parse_incoming_update_media_group_id() -> None:
@@ -248,6 +274,7 @@ def test_parse_incoming_update_video_message() -> None:
     assert msg.document.file_name == "video.mp4"
     assert msg.document.mime_type == "video/mp4"
     assert msg.document.file_size == 4242
+    assert msg.document.is_image is False
 
 
 def test_parse_incoming_update_sticker_message() -> None:


### PR DESCRIPTION
## Summary

- accept Telegram photos and image documents as native Codex image inputs
- save images inside the resolved project and pass them out-of-band with `codex exec --image`
- preserve image paths across new, explicit, continue, active-run, queued, persisted chat, and persisted topic resume flows
- support ordered image albums while leaving non-Codex upload behavior unchanged
- fail closed when any image cannot be downloaded or saved

Closes #427.

## Testing

- `HOME=/tmp/untether-image-final-home UV_CACHE_DIR=/home/clawdiy/.cache/uv uv run pytest --ignore=tests/test_trigger_actions.py` — 3142 passed, 1 skipped; 82.95% coverage
- `uv run pytest --no-cov tests/test_trigger_actions.py -q` — 31 passed
- focused image/runner/Telegram suite — 117 passed
- reviewer edge suite covering active run, queued resume, `--last`, and download failure — 4 passed
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv lock --check`
- `git diff --check origin/dev`
- `uv build && uvx twine check dist/* && uvx check-wheel-contents dist/*.whl`
- `uv run bandit -r src/ -c pyproject.toml -q`
- docs prebuild and clean Zensical build

## Checklist

- [x] Tests added/updated
- [x] Docs updated (if needed)
- [x] No secrets committed
