### PR TITLE
feat(telegram): support local Bot API uploads

### DIFF
--- a/src/untether/settings.py
+++ b/src/untether/settings.py
@@ -5,6 +5,7 @@ import re
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Literal
+from urllib.parse import urlsplit
 
 from pydantic import (
     BaseModel,
@@ -53,7 +54,11 @@ class TelegramFilesSettings(BaseModel):
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
     max_upload_bytes: ClassVar[int] = 20 * 1024 * 1024
-    max_download_bytes: ClassVar[int] = 50 * 1024 * 1024
+    max_download_bytes: int = Field(
+        default=50 * 1024 * 1024,
+        ge=1,
+        le=2 * 1024 * 1024 * 1024,
+    )
 
     enabled: bool = False
     auto_put: bool = True
@@ -132,6 +137,7 @@ class TelegramTransportSettings(BaseModel):
     RESTART_REQUIRED_FIELDS: ClassVar[frozenset[str]] = frozenset(
         {
             "bot_token",
+            "bot_api_base_url",
             "chat_id",
             "session_mode",
             "topics",
@@ -144,6 +150,7 @@ class TelegramTransportSettings(BaseModel):
     # bot_token.get_secret_value() at the transport boundary.  The token is
     # additionally redacted from log URLs by _redact_event_dict (#190).
     bot_token: SecretStr
+    bot_api_base_url: NonEmptyStr = "https://api.telegram.org"
     chat_id: StrictInt
     allowed_user_ids: list[StrictInt] = Field(default_factory=list)
     # #377: opt-in escape hatch for demos/dev. When the allowlist is
@@ -202,6 +209,32 @@ class TelegramTransportSettings(BaseModel):
         if not token:
             raise ValueError("bot_token must not be empty")
         return SecretStr(token)
+
+    @field_validator("bot_api_base_url", mode="after")
+    @classmethod
+    def _validate_bot_api_base_url(cls, value: str) -> str:
+        """Allow HTTPS Bot API endpoints and loopback-only plain HTTP."""
+        base_url = value.rstrip("/")
+        parsed = urlsplit(base_url)
+        if (
+            not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("bot_api_base_url must be an absolute API base URL")
+        if parsed.scheme == "https":
+            return base_url
+        if parsed.scheme == "http" and parsed.hostname in {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+        }:
+            return base_url
+        raise ValueError(
+            "bot_api_base_url must use HTTPS, except for a loopback HTTP endpoint"
+        )
 
     @field_validator("voice_transcription_api_key", mode="after")
     @classmethod

--- a/src/untether/telegram/backend.py
+++ b/src/untether/telegram/backend.py
@@ -232,7 +232,11 @@ class TelegramBackend(TransportBackend):
             trigger_config=trigger_config,
         )
         progress_cfg = _load_progress_settings()
-        bot = TelegramClient(token, group_chat_rps=progress_cfg.group_chat_rps)
+        bot = TelegramClient(
+            token,
+            base_url=settings.bot_api_base_url,
+            group_chat_rps=progress_cfg.group_chat_rps,
+        )
         transport = TelegramTransport(bot)
         formatter = MarkdownFormatter(
             max_actions=progress_cfg.max_actions,

--- a/src/untether/telegram/client.py
+++ b/src/untether/telegram/client.py
@@ -44,6 +44,7 @@ class TelegramClient:
         token: str | None = None,
         *,
         client: BotClient | None = None,
+        base_url: str = "https://api.telegram.org",
         timeout_s: float = 120,
         http_client: httpx.AsyncClient | None = None,
         clock: Callable[[], float] = time.monotonic,
@@ -60,6 +61,7 @@ class TelegramClient:
                 raise ValueError("Telegram token is empty")
             self._client = HttpBotClient(
                 token,
+                base_url=base_url,
                 timeout_s=timeout_s,
                 http_client=http_client,
             )

--- a/src/untether/telegram/client_api.py
+++ b/src/untether/telegram/client_api.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any, Protocol, TypeVar
+from urllib.parse import urlsplit
 
+import anyio
 import httpx
 import msgspec
 
@@ -141,13 +144,20 @@ class HttpBotClient:
         self,
         token: str,
         *,
+        base_url: str = "https://api.telegram.org",
         timeout_s: float = 30,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
         if not token:
             raise ValueError("Telegram token is empty")
-        self._base = f"https://api.telegram.org/bot{token}"
-        self._file_base = f"https://api.telegram.org/file/bot{token}"
+        api_base = base_url.rstrip("/")
+        self._local_mode = urlsplit(api_base).hostname in {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+        }
+        self._base = f"{api_base}/bot{token}"
+        self._file_base = f"{api_base}/file/bot{token}"
         self._http_client = http_client or httpx.AsyncClient(timeout=timeout_s)
         self._owns_http_client = http_client is None
         # #598: last failure reason per (method, chat_id, message_id). The
@@ -395,6 +405,16 @@ class HttpBotClient:
         return self._decode_result(method="getFile", payload=result, model=File)
 
     async def download_file(self, file_path: str) -> bytes | None:
+        if self._local_mode and file_path.startswith("/"):
+            try:
+                return await anyio.to_thread.run_sync(Path(file_path).read_bytes)
+            except OSError as exc:
+                logger.error(
+                    "telegram.local_file_read_error",
+                    error=str(exc),
+                    error_type=exc.__class__.__name__,
+                )
+                return None
         # #204: reject file_path values that could redirect the request away
         # from api.telegram.org.  Telegram's documented shape is a relative
         # path ("documents/file_123.txt") — any scheme marker or parent-dir

--- a/tests/test_bridge_config_reload.py
+++ b/tests/test_bridge_config_reload.py
@@ -198,6 +198,7 @@ class TestRestartRequiredFields:
             frozenset(
                 {
                     "bot_token",
+                    "bot_api_base_url",
                     "chat_id",
                     "session_mode",
                     "topics",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -851,6 +851,49 @@ def test_files_outbox_defaults() -> None:
     assert cfg.outbox_dir == ".untether-outbox"
     assert cfg.outbox_max_files == 10
     assert cfg.outbox_cleanup is True
+    assert cfg.max_download_bytes == 50 * 1024 * 1024
+
+
+def test_files_max_download_bytes_accepts_two_gibibytes() -> None:
+    from untether.settings import TelegramFilesSettings
+
+    cfg = TelegramFilesSettings(max_download_bytes=2 * 1024 * 1024 * 1024)
+    assert cfg.max_download_bytes == 2 * 1024 * 1024 * 1024
+
+
+def test_files_max_download_bytes_rejects_more_than_two_gibibytes() -> None:
+    from pydantic import ValidationError
+
+    from untether.settings import TelegramFilesSettings
+
+    with pytest.raises(ValidationError):
+        TelegramFilesSettings(max_download_bytes=2 * 1024 * 1024 * 1024 + 1)
+
+
+def test_bot_api_base_url_accepts_loopback_http() -> None:
+    from untether.settings import TelegramTransportSettings
+
+    cfg = TelegramTransportSettings(
+        bot_token="token",
+        bot_api_base_url="http://127.0.0.1:8081/",
+        chat_id=1,
+        allow_any_user=True,
+    )
+    assert cfg.bot_api_base_url == "http://127.0.0.1:8081"
+
+
+def test_bot_api_base_url_rejects_remote_http() -> None:
+    from pydantic import ValidationError
+
+    from untether.settings import TelegramTransportSettings
+
+    with pytest.raises(ValidationError, match="loopback"):
+        TelegramTransportSettings(
+            bot_token="token",
+            bot_api_base_url="http://example.com",
+            chat_id=1,
+            allow_any_user=True,
+        )
 
 
 def test_files_outbox_dir_rejects_absolute() -> None:

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -37,6 +37,28 @@ async def test_telegram_429_no_retry() -> None:
 
 
 @pytest.mark.anyio
+async def test_custom_bot_api_base_url() -> None:
+    urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        urls.append(str(request.url))
+        return httpx.Response(200, json={"ok": True, "result": []}, request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        api = HttpBotClient(
+            "123:abcDEF_ghij",
+            base_url="http://127.0.0.1:8081/",
+            http_client=client,
+        )
+        await api.get_updates(None, timeout_s=0)
+    finally:
+        await client.aclose()
+
+    assert urls == ["http://127.0.0.1:8081/bot123:abcDEF_ghij/getUpdates"]
+
+
+@pytest.mark.anyio
 async def test_no_token_in_logs_on_http_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_telegram_client_api.py
+++ b/tests/test_telegram_client_api.py
@@ -277,6 +277,24 @@ async def test_download_file_rejects_path_with_scheme_or_traversal(
         await client.close()
 
 
+@pytest.mark.anyio
+async def test_download_file_reads_local_bot_api_absolute_path(tmp_path) -> None:
+    target = tmp_path / "document.bin"
+    target.write_bytes(b"local payload")
+    client = HttpBotClient(
+        "token",
+        base_url="http://127.0.0.1:8081",
+        http_client=httpx.AsyncClient(),
+    )
+
+    try:
+        result = await client.download_file(str(target))
+    finally:
+        await client.close()
+
+    assert result == b"local payload"
+
+
 # ---------------------------------------------------------------------------
 # #598 — failure reasons recorded for later correlation
 # ---------------------------------------------------------------------------

--- a/tests/test_telegram_file_transfer_helpers.py
+++ b/tests/test_telegram_file_transfer_helpers.py
@@ -1159,14 +1159,16 @@ async def test_handle_file_get_zip_too_large(tmp_path: Path, monkeypatch) -> Non
 
 
 @pytest.mark.anyio
-async def test_handle_file_get_file_too_large(tmp_path: Path, monkeypatch) -> None:
+async def test_handle_file_get_file_too_large(tmp_path: Path) -> None:
     transport = FakeTransport()
-    cfg = replace(make_cfg(transport), runtime=_runtime(tmp_path))
+    cfg = replace(
+        make_cfg(transport),
+        runtime=_runtime(tmp_path),
+        files=TelegramFilesSettings(max_download_bytes=1),
+    )
     target = tmp_path / "notes.txt"
     target.write_bytes(b"data")
     msg = _msg("/file get")
-
-    monkeypatch.setattr(TelegramFilesSettings, "max_download_bytes", 1)
 
     await transfer._handle_file_get(
         cfg,
@@ -1182,17 +1184,19 @@ async def test_handle_file_get_file_too_large(tmp_path: Path, monkeypatch) -> No
 
 @pytest.mark.anyio
 async def test_handle_file_get_oversize_detected_on_read(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path,
 ) -> None:
     """#211: streaming read caps at max+1 bytes — TOCTOU between stat() and
     read() can no longer slip an over-sized file through."""
     transport = FakeTransport()
-    cfg = replace(make_cfg(transport), runtime=_runtime(tmp_path))
+    cfg = replace(
+        make_cfg(transport),
+        runtime=_runtime(tmp_path),
+        files=TelegramFilesSettings(max_download_bytes=50),
+    )
     target = tmp_path / "notes.txt"
     target.write_bytes(b"x" * 100)
     msg = _msg("/file get")
-
-    monkeypatch.setattr(TelegramFilesSettings, "max_download_bytes", 50)
 
     await transfer._handle_file_get(
         cfg,
@@ -1209,16 +1213,18 @@ async def test_handle_file_get_oversize_detected_on_read(
 
 @pytest.mark.anyio
 async def test_handle_file_get_at_size_limit_succeeds(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path,
 ) -> None:
     """#211: file exactly at the cap is delivered (read returns max bytes)."""
     transport = FakeTransport()
-    cfg = replace(make_cfg(transport), runtime=_runtime(tmp_path))
+    cfg = replace(
+        make_cfg(transport),
+        runtime=_runtime(tmp_path),
+        files=TelegramFilesSettings(max_download_bytes=50),
+    )
     target = tmp_path / "notes.txt"
     target.write_bytes(b"x" * 50)
     msg = _msg("/file get")
-
-    monkeypatch.setattr(TelegramFilesSettings, "max_download_bytes", 50)
 
     await transfer._handle_file_get(
         cfg,


### PR DESCRIPTION
## Summary

- allow a configurable Telegram Bot API base URL, restricted to HTTPS or loopback HTTP
- support absolute local file paths returned by a local Bot API server
- make Telegram download limits configurable up to 2 GiB
- preserve the public Bot API and 50 MiB defaults

This keeps large local-Bot-API deployments reproducible instead of relying on uncommitted runtime patches.

## Testing

- focused settings/client/file-transfer/reload suite — 176 passed
- combined owner-stack integration suite — 289 passed
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv lock --check`
- `git diff --check origin/dev...HEAD`

## Manual testing

- [x] local Bot API daemon enabled and healthy on loopback
- [x] authenticated Bot API health check succeeds
- [x] Untether configured for the loopback API and a 2 GiB download ceiling
- [x] combined owner-stack rebuilt and published at `Dvredin/untether@252b714`
- [ ] send and receive a file larger than 50 MiB after Untether is restarted

## Checklist

- [x] Tests added/updated
- [x] No secrets committed
