### PR TITLE
fix(triggers): retry the announce send before aborting a trigger dispatch

### DIFF
--- a/src/untether/triggers/dispatcher.py
+++ b/src/untether/triggers/dispatcher.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
+import anyio
 from anyio.abc import TaskGroup
 
 from ..context import RunContext
@@ -17,6 +18,14 @@ logger = get_logger(__name__)
 
 # Type alias matching the run_job() closure signature in loop.py.
 RunJobFn = Callable[..., Awaitable[None]]
+
+# Bounded retry schedule (seconds) for the trigger announce send. A transient
+# resolver/network blip at cron-fire time must not cost the whole dispatch —
+# the session is the payload, the announce is decoration. One DNS hiccup in the
+# 06:45 second silently killed a whole scheduled run (auditor-toolkit#2535);
+# two retries ride out a blip while a real outage still fails loudly within
+# ~35s of the trigger firing.
+SEND_RETRY_DELAYS: tuple[float, ...] = (5.0, 30.0)
 
 
 @dataclass(slots=True)
@@ -119,11 +128,22 @@ class TriggerDispatcher:
         engine_override: str | None,
     ) -> None:
         # Send a notification message so run_job has a message_id to reply to.
+        # Retried on failure per SEND_RETRY_DELAYS before giving up.
         notify_ref = await self.transport.send(
             channel_id=chat_id,
             message=RenderedMessage(text=label),
             options=SendOptions(notify=False),
         )
+        for delay in SEND_RETRY_DELAYS:
+            if notify_ref is not None:
+                break
+            logger.warning("triggers.dispatch.send_retry", label=label, retry_in=delay)
+            await anyio.sleep(delay)
+            notify_ref = await self.transport.send(
+                channel_id=chat_id,
+                message=RenderedMessage(text=label),
+                options=SendOptions(notify=False),
+            )
         if notify_ref is None:
             logger.error("triggers.dispatch.send_failed", label=label)
             return

--- a/tests/test_trigger_dispatcher.py
+++ b/tests/test_trigger_dispatcher.py
@@ -413,3 +413,78 @@ async def test_dispatch_webhook_history_failure_does_not_raise(monkeypatch, tmp_
         assert len(run_job.calls) == 1
     finally:
         history.reset_history()
+
+
+@dataclass
+class FlakyTransport(FakeTransport):
+    """Transport whose first N sends fail (return None) before recovering.
+
+    Models the #2535 class: a transient resolver blip at cron-fire time makes
+    the Telegram announce send fail, which previously aborted the whole
+    dispatch — the session was never spawned.
+    """
+
+    fail_first: int = 0
+    attempts: int = 0
+
+    async def send(
+        self,
+        *,
+        channel_id: int | str,
+        message: RenderedMessage,
+        options: SendOptions | None = None,
+    ) -> MessageRef | None:
+        self.attempts += 1
+        if self.attempts <= self.fail_first:
+            return None
+        return await super().send(
+            channel_id=channel_id, message=message, options=options
+        )
+
+
+@pytest.mark.anyio
+async def test_cron_dispatch_retries_transient_send_failure(monkeypatch):
+    """A transient announce-send failure is retried, and the job still runs."""
+    from untether.triggers import dispatcher as dispatcher_mod
+
+    monkeypatch.setattr(dispatcher_mod, "SEND_RETRY_DELAYS", (0.0, 0.0))
+    transport = FlakyTransport(fail_first=2)
+    run_job = RunJobCapture()
+
+    async with anyio.create_task_group() as tg:
+        dispatcher = TriggerDispatcher(
+            run_job=run_job,
+            transport=transport,
+            default_chat_id=100,
+            task_group=tg,
+        )
+        await dispatcher.dispatch_cron(_make_cron())
+        await anyio.sleep(0.01)
+        tg.cancel_scope.cancel()
+
+    assert transport.attempts == 3  # 1 initial + 2 retries
+    assert len(run_job.calls) == 1  # the session is the payload — it spawned
+
+
+@pytest.mark.anyio
+async def test_cron_dispatch_aborts_after_retry_exhaustion(monkeypatch):
+    """A persistent send outage still fails loudly after the bounded retries."""
+    from untether.triggers import dispatcher as dispatcher_mod
+
+    monkeypatch.setattr(dispatcher_mod, "SEND_RETRY_DELAYS", (0.0, 0.0))
+    transport = FlakyTransport(fail_first=99)
+    run_job = RunJobCapture()
+
+    async with anyio.create_task_group() as tg:
+        dispatcher = TriggerDispatcher(
+            run_job=run_job,
+            transport=transport,
+            default_chat_id=100,
+            task_group=tg,
+        )
+        await dispatcher.dispatch_cron(_make_cron())
+        await anyio.sleep(0.01)
+        tg.cancel_scope.cancel()
+
+    assert transport.attempts == 3  # bounded: 1 initial + len(SEND_RETRY_DELAYS)
+    assert run_job.calls == []

--- a/uv.lock
+++ b/uv.lock
@@ -1290,11 +1290,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`TriggerDispatcher._dispatch` aborted the whole dispatch when the announce send returned `None` — the Claude session (the payload) was never spawned because a decorative Telegram message failed. A transient DNS failure in the exact cron-fire second killed a whole scheduled run and silenced its own alert (littlebearapps/auditor-toolkit#2535, 2026-08-29 06:45 `channelo-issue-triage`):

```
untether: telegram.network_error error='[Errno -3] Temporary failure in name resolution'
untether: transport.send.failed  chat_id=…
untether: triggers.dispatch.send_failed  label='⏰ Scheduled: cron:channelo-issue-triage'
(nothing follows — no session spawn)
```

## Fix

Bounded retry with backoff around the announce send (`SEND_RETRY_DELAYS = (5.0, 30.0)`), covering both cron and webhook dispatch paths. Each retry logs `triggers.dispatch.send_retry`; a persistent outage still fails loudly with `triggers.dispatch.send_failed` within ~35s. The spawn keeps its `message_id` invariant — no change to `run_job`.

Full decoupling (spawn without an announce message) was considered and deliberately not done: `run_job(user_msg_id: int)` threads the id into the progress machinery, and the retry alone covers the observed class (a one-second blip; even 3×30s would have covered it per the issue).

## Tests

- `test_cron_dispatch_retries_transient_send_failure` — first 2 sends fail, 3rd succeeds → job spawns (red before the fix).
- `test_cron_dispatch_aborts_after_retry_exhaustion` — persistent failure → bounded 3 attempts, loud abort, no spawn.
- Full suite: 3228 passed, 2 skipped. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCXwu52pTmFfj9PbcndHyM